### PR TITLE
Precompute CumSumWeightedSortedValues in case of NaNs

### DIFF
--- a/EvaluateFnOnAgentDist/allstats/StatsFromWeightedGrid.m
+++ b/EvaluateFnOnAgentDist/allstats/StatsFromWeightedGrid.m
@@ -127,8 +127,9 @@ else
         AllStats.StdDeviation=sqrt(AllStats.Variance);
     end
 
-    if (whichstats(4)>=1 && npoints>0 && WeightedSortedValues(1)>=0) || whichstats(6)==2
-        % precompute so don't duplicate
+    if (whichstats(4)>=1 && npoints>0 && ~(WeightedSortedValues(1)<0)) || whichstats(6)==2
+        % precompute so don't duplicate; precompute needed if
+        % WeightedSortedValues contains NaNs
         CumSumSortedWeightedValues=cumsum(WeightedSortedValues);
     end
 


### PR DESCRIPTION
To run Chen2010 housing model to completion, we need to deal with the case that our WeightedSortedValues contains NaNs.  I don't know if the NaNs are a result of MATLAB or nVidia changing maths since Chen2010 was last run, so please adjust this patch as appropriate.