### PR TITLE
Small changes for cpu-only LifeCycle demos

### DIFF
--- a/EvaluateFnOnAgentDist/FHorz/subcodes/LifeCycleProfiles_FHorz_Case1_cpu.m
+++ b/EvaluateFnOnAgentDist/FHorz/subcodes/LifeCycleProfiles_FHorz_Case1_cpu.m
@@ -100,7 +100,7 @@ a_grid=gather(a_grid);
 
 a_gridvals=CreateGridvals(n_a,a_grid,2);
 
-PolicyIndexes=reshape(Policy,[size(Policy,1),N_a,N_ze,N_j]);
+PolicyIndexes=reshape(Policy,[size(Policy,1),N_a,N_z,N_j]);
 for kk=1:length(simoptions.agegroupings)
     j1=simoptions.agegroupings(kk);
     if kk<length(simoptions.agegroupings)
@@ -108,12 +108,12 @@ for kk=1:length(simoptions.agegroupings)
     else
         jend=N_j;
     end
-    StationaryDistVec_kk=reshape(StationaryDistVec(:,j1:jend),[N_a*N_ze*(jend-j1+1),1]);
+    StationaryDistVec_kk=reshape(StationaryDistVec(:,j1:jend),[N_a*N_z*(jend-j1+1),1]);
     StationaryDistVec_kk=StationaryDistVec_kk./sum(StationaryDistVec_kk); % Normalize to sum to one for this 'agegrouping'
 
     clear gridvalsFull
     for jj=j1:jend
-        [d_gridvals, aprime_gridvals]=CreateGridvals_Policy(PolicyIndexes(:,:,:,jj),n_d,n_a,n_a,n_z,d_grid,a_grid,1, 2);
+        [d_gridvals, aprime_gridvals]=CreateGridvals_Policy(PolicyIndexes(:,:,:,jj),n_d,n_a,n_a,n_z,d_grid,a_grid,simoptions,1, 2);
         gridvalsFull(jj-j1+1).d_gridvals=d_gridvals;
         gridvalsFull(jj-j1+1).aprime_gridvals=aprime_gridvals;
 
@@ -142,7 +142,7 @@ for kk=1:length(simoptions.agegroupings)
     end
 
     for ii=1:length(FnsToEvaluate) % Each of the functions to be evaluated on the grid
-        Values=nan(N_a*N_ze,jend-j1+1); % Preallocate
+        Values=nan(N_a*N_z,jend-j1+1); % Preallocate
         if l_d>0
             for jj=j1:jend
                 d_gridvals=gridvalsFull(jj-j1+1).d_gridvals;
@@ -150,7 +150,7 @@ for kk=1:length(simoptions.agegroupings)
                 z_gridvals=gridvalsFull(jj-j1+1).z_gridvals;
                 % Includes check for cases in which no parameters are actually required
                 if isempty(FnsToEvaluateParamNames(ii).Names) % check for 'FnsToEvaluateParamNames={}'
-                    for ll=1:N_a*N_ze
+                    for ll=1:N_a*N_z
                         %        j1j2=ind2sub_homemade([N_a,N_z],ii); % Following two lines just do manual implementation of this.
                         l1=rem(ll-1,N_a)+1;
                         l2=ceil(ll/N_a);
@@ -158,7 +158,7 @@ for kk=1:length(simoptions.agegroupings)
                     end
                 else
                     FnToEvaluateParamsCell=num2cell(CreateVectorFromParams(Parameters,FnsToEvaluateParamNames(ii).Names,jj));
-                    for ll=1:N_a*N_ze
+                    for ll=1:N_a*N_z
                         %        j1j2=ind2sub_homemade([N_a,N_z],ii); % Following two lines just do manual implementation of this.
                         l1=rem(ll-1,N_a)+1;
                         l2=ceil(ll/N_a);
@@ -172,14 +172,14 @@ for kk=1:length(simoptions.agegroupings)
                 z_gridvals=gridvalsFull(jj-j1+1).z_gridvals;
                 % Includes check for cases in which no parameters are actually required
                 if isempty(FnsToEvaluateParamNames(ii).Names) % check for 'FnsToEvaluateParamNames={}'
-                    for ll=1:N_a*N_ze
+                    for ll=1:N_a*N_z
                         l1=rem(ll-1,N_a)+1;
                         l2=ceil(ll/N_a);
                         Values(ll,jj-j1+1)=FnsToEvaluate{ii}(aprime_gridvals{l1+(l2-1)*N_a,:},a_gridvals{l1,:},z_gridvals{l2,:});
                     end
                 else
                     FnToEvaluateParamsCell=num2cell(CreateVectorFromParams(Parameters,FnsToEvaluateParamNames(ii).Names,jj));
-                    for ll=1:N_a*N_ze
+                    for ll=1:N_a*N_z
                         l1=rem(ll-1,N_a)+1;
                         l2=ceil(ll/N_a);
                         Values(ll,jj-j1+1)=FnsToEvaluate{ii}(aprime_gridvals{l1+(l2-1)*N_a,:},a_gridvals{l1,:},z_gridvals{l2,:},FnToEvaluateParamsCell{:});
@@ -189,7 +189,7 @@ for kk=1:length(simoptions.agegroupings)
         end
 
         % From here on is essentially identical to the 'with gpu' case.
-        Values=reshape(Values,[N_a*N_ze*(jend-j1+1),1]);
+        Values=reshape(Values,[N_a*N_z*(jend-j1+1),1]);
 
         [SortedValues,SortedValues_index] = sort(Values);
 

--- a/EvaluateFnOnAgentDist/FHorz/subcodes/LifeCycleProfiles_FHorz_Case1_noz.m
+++ b/EvaluateFnOnAgentDist/FHorz/subcodes/LifeCycleProfiles_FHorz_Case1_noz.m
@@ -1,4 +1,4 @@
-function AgeConditionalStats=LifeCycleProfiles_FHorz_Case1_noz(StationaryDist,Policy,FnsToEvaluate,FnsToEvaluateParamNames,Parameters,n_d,n_a,N_j,d_grid,a_grid,simoptions)
+function AgeConditionalStats=LifeCycleProfiles_FHorz_Case1_noz(StationaryDist,Policy,FnsToEvaluate,Parameters,FnsToEvaluateParamNames,n_d,n_a,N_j,d_grid,a_grid,simoptions)
 % Similar to SimLifeCycleProfiles but works from StationaryDist rather than
 % simulating panel data. Where applicable it is faster and more accurate.
 % options.agegroupings can be used to do conditional on 'age bins' rather than age
@@ -17,6 +17,10 @@ function AgeConditionalStats=LifeCycleProfiles_FHorz_Case1_noz(StationaryDist,Po
 % AgeConditionalStats(length(FnsToEvaluate)).Gini=nan(1,ngroups);
 % AgeConditionalStats(length(FnsToEvaluate)).QuantileCutoffs=nan(options.nquantiles+1,ngroups); % Includes the min and max values
 % AgeConditionalStats(length(FnsToEvaluate)).QuantileMeans=nan(options.nquantiles,ngroups);
+
+if ~isfield(simoptions,'agegroupings')
+    simoptions.agegroupings=1:1:N_j; % by default does each period seperately, can be used to say, calculate gini for age bins
+end
 
 % N_d=prod(n_d);
 N_a=prod(n_a);
@@ -242,7 +246,7 @@ else % options.parallel~=2
         
         clear gridvalsFull
         for jj=j1:jend
-            [d_gridvals, aprime_gridvals]=CreateGridvals_Policy(PolicyIndexes(:,:,jj),n_d,n_a,n_a,0,d_grid,a_grid,1, 2);
+            [d_gridvals, aprime_gridvals]=CreateGridvals_Policy(PolicyIndexes(:,:,jj),n_d,n_a,n_a,0,d_grid,a_grid,simoptions,1, 2);
             gridvalsFull(jj-j1+1).d_gridvals=d_gridvals;
             gridvalsFull(jj-j1+1).aprime_gridvals=aprime_gridvals;
         end

--- a/PolicyInd2Val/PolicyInd2Val_FHorz.m
+++ b/PolicyInd2Val/PolicyInd2Val_FHorz.m
@@ -239,7 +239,7 @@ end
 
 % This CPU implementation could be vectorized to be much faster
 if Parallel~=2
-    Policy=KronPolicyIndexes_FHorz_Case1(Policy, n_d, n_a, n_z, N_j);
+    Policy=KronPolicyIndexes_FHorz_Case1(Policy, n_d, n_a, n_z, N_j,vfoptions);
     if n_d(1)==0
         PolicyValues=zeros(l_aprime,N_a,N_z,N_j);
         for jj=1:N_j

--- a/SubCodes/SetOptionsDefaults.m
+++ b/SubCodes/SetOptionsDefaults.m
@@ -1,0 +1,39 @@
+function [vfoptions, simoptions]=SetOptionsDefaults(vfoptions,simoptions)
+% A one-size-fits-most approach to setting options in the VFIToolkit.
+% Called without any parameters, this function will return newly created
+% structures with many (but by no means all) fields typically required
+% to be set in the VFOPTIONS and/or SIMOPTIONS variables used throughout
+% the toolkit.
+% When called with VFOPTIONS and possibly also SIMOPTIONS, set options
+% not yet set without overriding options that have been set.
+
+% heterogenous options and transpath options--you are on your own.
+
+if exist('vfoptions','var')==0
+    vfoptions=struct();
+end
+if ~isfield(vfoptions,'parallel')
+    vfoptions.parallel=1+(gpuDeviceCount>0);
+end
+
+if exist('simoptions','var')==0
+    simoptions=struct();
+end
+
+simdefaults=dictionary(...
+    'parallel', vfoptions.parallel,...
+    'tolerance', 10^(-12),...
+    'nquantiles', 20,... % by default gives ventiles
+    'npoints', 100,...
+    'gridinterplayer', 0,...
+    'experienceasset', 0,...
+    'experienceassetu', 0,...
+    nan, nan);
+
+my_keys=keys(simdefaults);
+for opt=1:numEntries(simdefaults)-1
+    if ~isfield(simoptions,my_keys(opt))
+        simoptions.(my_keys(opt))=lookup(simdefaults,my_keys(opt));
+    end
+end
+

--- a/ValueFnIter/FHorz/OnCPU/ValueFnIter_FHorz_Par1_raw.m
+++ b/ValueFnIter/FHorz/OnCPU/ValueFnIter_FHorz_Par1_raw.m
@@ -14,8 +14,8 @@ ReturnFnParamsVec=CreateVectorFromParams(Parameters, ReturnFnParamNames,N_j);
 
 if ~isfield(vfoptions,'V_Jplus1')
 
-    ReturnMatrix=CreateReturnFnMatrix_Case1_Disc(ReturnFn, n_d, n_a, n_z, d_grid, a_grid, z_grid, vfoptions.parallel,ReturnFnParamsVec);
-    %Calc the max and it's index
+    ReturnMatrix=CreateReturnFnMatrix_Case1_Disc(ReturnFn, n_d, n_a, n_z, d_grid, a_grid, z_grid, ReturnFnParamsVec);
+    % Calc the max and its index
     [Vtemp,maxindex]=max(ReturnMatrix,[],1);
     V(:,:,N_j)=Vtemp;
     Policy(:,:,N_j)=maxindex;
@@ -39,7 +39,7 @@ else
         entireEV_z=repelem(EV_z,N_d,1);
         entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*entireEV_z; % autoexpand a into 2nd-dim of entireEV_z
 
-        % Calc the max and it's index
+        % Calc the max and its index
         [Vtemp,maxindex]=max(entireRHS_z,[],1);
         V(:,z_c,N_j)=Vtemp;
         Policy(:,z_c,N_j)=maxindex;
@@ -62,7 +62,7 @@ for reverse_j=1:N_j-1
 
     EV=V(:,:,jj+1);
     
-    ReturnMatrix=CreateReturnFnMatrix_Case1_Disc(ReturnFn, n_d, n_a, n_z, d_grid, a_grid, z_grid, vfoptions.parallel, ReturnFnParamsVec);
+    ReturnMatrix=CreateReturnFnMatrix_Case1_Disc(ReturnFn, n_d, n_a, n_z, d_grid, a_grid, z_grid, ReturnFnParamsVec);
          
     parfor z_c=1:N_z
         ReturnMatrix_z=ReturnMatrix(:,:,z_c);
@@ -75,7 +75,7 @@ for reverse_j=1:N_j-1
         entireEV_z=repelem(EV_z,N_d,1);
         entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*entireEV_z; % autoexpand a into 2nd-dim of entireEV_z
 
-        %Calc the max and it's index
+        % Calc the max and its index
         [Vtemp,maxindex]=max(entireRHS_z,[],1);
         V(:,z_c,jj)=Vtemp;
         Policy(:,z_c,jj)=maxindex;


### PR DESCRIPTION
These changes help LifeCycleModels 4-7 work as well as models 1-3 in CPU-only environments.  The largest change is the addition of a new function `SetOptionsDefaults` which allows users to easily initialize `vfoptions` and `simoptions` to the very simple defaults that are nevertheless required for basic options.

It is highly likely that these defaults should be greatly expanded for more consistent use (not only supporting the simplest CPU-only cases).  I leave that for a future pull-request.

Some simple bugfixes (such as swapping parameters to match new interfaces) and typo corrections are also offered.

The addition of a check for `'agegroupings'` in LifeCycleProfiles_FHorz_Case1_noz.m is purely defensive programming. I changed the LifeCycleModels code to set it.  It might be better to further enhance `SetOptionsDefaults` to take an N_j parameter, but I didn't go that far.