### PR TITLE
KronPolicyIndexes_FHorz_Case1_e has n_e before N_j

### DIFF
--- a/SubCodes/KronPolicyIndexes/KronPolicyIndexes_FHorz_Case1_e.m
+++ b/SubCodes/KronPolicyIndexes/KronPolicyIndexes_FHorz_Case1_e.m
@@ -8,7 +8,7 @@ N_a=prod(n_a);
 N_z=prod(n_z);
 
 % When using n_e, is instead:
-% Input: Policy (l_d+l_a,n_a,n_z,n_e,,N_j);
+% Input: Policy (l_d+l_a,n_a,n_z,n_e,N_j);
 %
 % Output: Policy=zeros(2,N_a,N_z,N_e,N_j); %first dim indexes the optimal choice for d and aprime rest of dimensions a,z 
 %                       (N_a,N_z,N_e,N_j) if there is no d

--- a/ValueFnFromPolicy/ValueFnFromPolicy_Case1_FHorz.m
+++ b/ValueFnFromPolicy/ValueFnFromPolicy_Case1_FHorz.m
@@ -1,5 +1,6 @@
 function V=ValueFnFromPolicy_Case1_FHorz(Policy,n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid, pi_z, ReturnFn, Parameters, DiscountFactorParamNames, vfoptions)
 % vfoptions is an optional input (not required)
+% we will fill in defaults if needed (e.g. `gridinterplayer`).
 
 N_d=prod(n_d);
 N_a=prod(n_a);
@@ -11,6 +12,12 @@ if exist('vfoptions','var')
             error('ValueFnFromPolicy_Case1_FHorz is only available on GPU')
         end
     end
+    if ~isfield(vfoptions,'gridinterplayer')
+        vfoptions.gridinterplayer=0;
+    end
+else
+    vfoptions=struct();
+    vfoptions.gridinterplayer=0;
 end
 
 
@@ -301,7 +308,7 @@ elseif N_z>0 && N_e==0
 elseif N_z>0 && N_e>0
     PolicyValues=PolicyInd2Val_FHorz(Policy,n_d,n_a,n_z,N_j,d_grid,a_grid,vfoptions,1);
     % The following will also be needed to calculate the expectation of next period value fn, evaluated based on the policy.
-    PolicyIndexesKron=KronPolicyIndexes_FHorz_Case1_e(Policy, n_d, n_a, n_z,N_j,n_e);
+    PolicyIndexesKron=KronPolicyIndexes_FHorz_Case1_e(Policy, n_d, n_a, n_z, n_e, N_j, vfoptions);
 
     
     %% Calculate the Value Fn by backward iteration


### PR DESCRIPTION
Fix caller that had `n_e` and` N_j` reversed when calling `KronPolicyIndexes_FHorz_Case1_e`.

Also fix setting of `gridinterplayer=0` if it's not in the inbound `vfoptions`.