### PR TITLE
Clean merge cruft in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-GNU GENERAL PUBLIC LICENSE
-=======
                     GNU GENERAL PUBLIC LICENSE
->>>>>>> 0b2509ef4981838d68e0f654e8699dea12f5674e
                        Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>


### PR DESCRIPTION
When the indented `GNU GENERAL PUBLIC LICENSE` text was merged, some git cruft remained.  This leaves the license in a clean state.