### PR TITLE
Fix handling of `FnsToEvaluate.(FnsToEvalNames{ff})`

### DIFF
--- a/EvaluateFnOnAgentDist/FHorz/PType/LifeCycleProfiles_FHorz_Case1_PType.m
+++ b/EvaluateFnOnAgentDist/FHorz/PType/LifeCycleProfiles_FHorz_Case1_PType.m
@@ -228,7 +228,7 @@ if isstruct(simoptions.agejshifter) % if using agejshifter
             end
         end
     end
-elseif length(simoptions.agejshifter)==1 % not using agejshifter
+elseif isscalar(simoptions.agejshifter) % not using agejshifter
     simoptions.agejshifter=zeros(N_i,1);
     N_j_max2=N_j_max;
 else % have inputed as a vector
@@ -563,7 +563,12 @@ if simoptions.lowmemory==0
             if FnsAndPTypeIndicator_ii(ff)==1 % If this function is relevant to this ptype
                 
                 % Get parameter names for current FnsToEvaluate functions
-                tempnames=getAnonymousFnInputNames(FnsToEvaluate.(FnsToEvalNames{ff}));
+                if isstruct(FnsToEvaluate.(FnsToEvalNames{ff}))
+                    tempfn=FnsToEvaluate.(FnsToEvalNames{ff}).(Names_i{ii});
+                else
+                    tempfn=FnsToEvaluate.(FnsToEvalNames{ff});
+                end
+                tempnames=getAnonymousFnInputNames(tempfn);
                 if length(tempnames)>(l_daprime_temp+l_a_temp+l_z_temp)
                     FnsToEvaluateParamNames={tempnames{l_daprime_temp+l_a_temp+l_z_temp+1:end}}; % the first inputs will always be (d,aprime,a,z)
                 else
@@ -577,7 +582,7 @@ if simoptions.lowmemory==0
                 
                 %% We have set up the current PType, now do some calculations for it.
                 simoptions_temp.keepoutputasmatrix=2;
-                ValuesOnGrid_ffii=EvalFnOnAgentDist_Grid_J(FnsToEvaluate.(FnsToEvalNames{ff}),CellOverAgeOfParamValues,PolicyValuesPermute_temp,l_daprime_temp,n_a_temp,n_z_temp,a_gridvals_temp,z_gridvals_J_temp);
+                ValuesOnGrid_ffii=EvalFnOnAgentDist_Grid_J(tempfn,CellOverAgeOfParamValues,PolicyValuesPermute_temp,l_daprime_temp,n_a_temp,n_z_temp,a_gridvals_temp,z_gridvals_J_temp);
                 
                 ValuesOnGrid_ffii=reshape(ValuesOnGrid_ffii,[N_a_temp*N_z_temp,N_j_temp]);
                 % StationaryDist_ii=reshape(StationaryDist.(Names_i{ii}),[N_a_temp*N_z_temp,N_j_temp]); % Note: does not impose *StationaryDist.ptweights(ii)
@@ -1193,37 +1198,37 @@ elseif simoptions.lowmemory==1
             % a structure is there a need to take just a specific part and send
             % only that to the 'non-PType' version of the command.
 
-            if isa(n_d,'struct')
+            if isstruct(n_d)
                 n_d_temp=n_d.(Names_i{ii});
             else
                 n_d_temp=n_d;
             end
-            if isa(n_a,'struct')
+            if isstruct(n_a)
                 n_a_temp=n_a.(Names_i{ii});
             else
                 n_a_temp=n_a;
             end
-            if isa(n_z,'struct')
+            if isstruct(n_z)
                 n_z_temp=n_z.(Names_i{ii});
             else
                 n_z_temp=n_z;
             end
-            if isa(N_j,'struct')
+            if isstruct(N_j)
                 N_j_temp=N_j.(Names_i{ii});
             else
                 N_j_temp=N_j;
             end
-            if isa(d_grid,'struct')
+            if isstruct(d_grid)
                 d_grid_temp=d_grid.(Names_i{ii});
             else
                 d_grid_temp=d_grid;
             end
-            if isa(a_grid,'struct')
+            if isstruct(a_grid)
                 a_grid_temp=a_grid.(Names_i{ii});
             else
                 a_grid_temp=a_grid;
             end
-            if isa(z_grid,'struct')
+            if isstruct(z_grid)
                 z_grid_temp=z_grid.(Names_i{ii});
             else
                 z_grid_temp=z_grid;
@@ -1236,7 +1241,7 @@ elseif simoptions.lowmemory==1
             FullParamNames=fieldnames(Parameters);
             nFields=length(FullParamNames);
             for kField=1:nFields
-                if isa(Parameters.(FullParamNames{kField}), 'struct') % Check for permanent type in structure form
+                if isstruct(Parameters.(FullParamNames{kField})) % Check for permanent type in structure form
                     names=fieldnames(Parameters.(FullParamNames{kField}));
                     for jj=1:length(names)
                         if strcmp(names{jj},Names_i{ii})


### PR DESCRIPTION
In OLGModel10, `FnsToEvaluate.(FnsToEvalNames{ff})` is not a structure.  In OLGModels 12&13, it is a structure.  Handle both cases.

Also, use MATLAB idioms isstruct and isscalar where appropriate.