### PR TITLE
Enable LifeCycleModel35semi to run

### DIFF
--- a/StationaryDist/FHorz/RiskyAsset/StationaryDist_FHorz_RiskyAssetSemiExo.m
+++ b/StationaryDist/FHorz/RiskyAsset/StationaryDist_FHorz_RiskyAssetSemiExo.m
@@ -16,7 +16,11 @@ end
 if ~isfield(simoptions,'refine_d')
     error('Cannot use riskyasset+semiz without setting simoptions.refine_d')
 end
-if (sum(simoptions.refine_d)+simoptions.l_dsemiz)~=length(n_d)
+if length(simoptions.refine_d)>=4 && simoptions.refine_d(end)==simoptions.l_dsemiz
+    if sum(simoptions.refine_d)~=length(n_d)
+        error('simoptions.refine_d (and agreeing simoptions.l_dsemiz) should sum together to length(n_d)')
+    end
+elseif (sum(simoptions.refine_d)+simoptions.l_dsemiz)~=length(n_d)
     error('simoptions.refine_d and simoptions.l_dsemiz should all sum together to length(n_d)')
     % Don't actually need simoptions.l_dsemiz here, because it is just what is left over after simoptions.refine_d. But do this check anyway.
     % Need simoptions.l_dsemiz in all other situations with semi-exo states, so easier to just insist on it here as well.
@@ -40,6 +44,11 @@ a2_grid=simoptions.a_grid(sum(n_a1)+1:end);
 
 
 %%
+if isfield(simoptions,'n_e')
+    N_e=prod(simoptions.n_e);
+else
+    N_e=0;
+end
 if ~isfield(simoptions,'n_u')
     error('To use an risky asset you must define simoptions.n_u')
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw.m
@@ -8,10 +8,10 @@ function StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequal
 % put a&semiz&z together into the 1st dim, semiz'&nprobs into the 2nd dim.
 
 % Policy_aprime is currently [N_a,N_semiz*N_z,N_probs,N_j]
-Policy_aprimesemizz=repelem(reshape(Policy_aprime,[N_a*N_semiz*N_z,N_probs,N_j]),1,N_semiz)+repmat(N_a*gpuArray(0:1:N_semiz-1),1,N_probs)+repelem(N_a*N_semiz*gpuArray(0:1:N_z-1)',N_a*N_semiz,1); % Note: add semiz' index following the semiz' dimension, add z' index following the z dimension for Tan improvement
-Policy_aprimesemizz=gather(Policy_aprimesemizz); % [N_a*N_semiz*N_z,N_semiz*N_probs,N_j]
+% Policy_aprimesemizz=repelem(reshape(Policy_aprime,[N_a*N_semiz*N_z,N_probs,N_j]),1,N_semiz)+repmat(N_a*gpuArray(0:1:N_semiz-1),1,N_probs)+repelem(N_a*N_semiz*gpuArray(0:1:N_z-1)',N_a*N_semiz,1); % Note: add semiz' index following the semiz' dimension, add z' index following the z dimension for Tan improvement
+% Policy_aprimesemizz=gather(Policy_aprimesemizz); % [N_a*N_semiz*N_z,N_semiz*N_probs,N_j]
 % % Previous two lines gave out of memory order, so the following line just does gather() earlier.
-% Policy_aprimesemizz=repelem(reshape(gather(Policy_aprime),[N_a*N_semiz*N_z,N_probs,N_j]),1,N_semiz)+repmat(N_a*(0:1:N_semiz-1),1,N_probs)+repelem(N_a*N_semiz*(0:1:N_z-1)',N_a*N_semiz,1); % Note: add semiz' index following the semiz' dimension, add z' index following the z dimension for Tan improvement
+Policy_aprimesemizz=repelem(reshape(gather(Policy_aprime),[N_a*N_semiz*N_z,N_probs,N_j]),1,N_semiz)+repmat(N_a*(0:1:N_semiz-1),1,N_probs)+repelem(N_a*N_semiz*(0:1:N_z-1)',N_a*N_semiz,1); % Note: add semiz' index following the semiz' dimension, add z' index following the z dimension for Tan improvement
 
 Policy_dsemiexo=reshape(Policy_dsemiexo,[N_a*N_semiz*N_z,1,N_j]);
 % precompute
@@ -22,11 +22,11 @@ semizindex=repmat(repelem(gpuArray(1:1:N_semiz)',N_a,1),N_z,1)+N_semiz*gpuArray(
 
 
 PolicyProbs=reshape(PolicyProbs,[N_a*N_semiz*N_z,N_probs,N_j]);
-PolicyProbs=repelem(PolicyProbs,1,N_semiz).*repmat(pi_semiz_J(semizindex),1,N_probs);
-PolicyProbs=gather(PolicyProbs);
+% PolicyProbs=repelem(PolicyProbs,1,N_semiz).*repmat(pi_semiz_J(semizindex),1,N_probs);
+% PolicyProbs=gather(PolicyProbs);
 % % Previous two lines gave out of memory order, so the following line just does gather() earlier.
 % pi_semiz_J=gather(pi_semiz_J);
-% PolicyProbs=repelem(gather(PolicyProbs),1,N_semiz).*repmat(pi_semiz_J(semizindex),1,N_probs);
+PolicyProbs=repelem(gather(PolicyProbs),1,N_semiz).*repmat(pi_semiz_J(semizindex),1,N_probs);
 
 N_bothz=N_semiz*N_z;
 


### PR DESCRIPTION
The principle change is to bring across the gridvals changes implemented in commit 347366ccd75ac2203ba4bd62dbb9f0de3c338972.

After implementing those changes in `ValueFnIter_FHorz_RiskyAsset_nod1_semiz_raw` and `ValueFnIter_FHorz_RiskyAsset_EpsteinZin_nod1_semiz_raw`, a few incongruities emerged from `StationaryDist_FHorz_RiskyAssetSemiExo` regarding the contents of `refine_d` and/or `l_dsemiz`.  Please check that the new test I've put in is sensible.

Finally, after running this lifecycle test, it reveals the Out-Of-Memory (OOM) errors mentioned in the comments.  Reverting to the commented-out code (which is less aggressive in the use of gpuArray) keeps things within the limits of a 32GB GPU.