### PR TITLE
CPU/GPU balancing

### DIFF
--- a/StationaryDist/FHorz/StationaryDist_FHorz_Case1.m
+++ b/StationaryDist/FHorz/StationaryDist_FHorz_Case1.m
@@ -88,7 +88,7 @@ end
 %% Semi-exogenous shock gridvals and pi 
 if isfield(simoptions,'n_semiz')
     % Internally, only ever use age-dependent joint-grids (makes all the code much easier to write)
-    simoptions=SemiExogShockSetup_FHorz(n_d,N_j,simoptions.d_grid,Parameters,simoptions,1);
+    simoptions=SemiExogShockSetup_FHorz(n_d,N_j,simoptions.d_grid,Parameters,simoptions,simoptions.parallel);
     % output: simoptions.semiz_gridvals_J, simoptions.pi_semiz_J
     % size(semiz_gridvals_J)=[prod(n_z),length(n_z),N_j]
     % size(pi_semiz_J)=[prod(n_semiz),prod(n_semiz),prod(n_dsemiz),N_j]

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw.m
@@ -8,46 +8,45 @@ function StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequ
 % put a&semiz&z together into the 1st dim, semiz'&nprobs into the 2nd dim.
 
 % Policy_aprime is currently [N_a,N_semiz*N_z*N_e,N_probs,N_j]
-Policy_aprimesemizz=repelem(reshape(Policy_aprime,[N_a*N_semiz*N_z*N_e,N_probs,N_j]),1,N_semiz)+repmat(N_a*gpuArray(0:1:N_semiz-1),1,N_probs)+repmat(repelem(N_a*N_semiz*(0:1:N_z-1)',N_a*N_semiz,1),N_e,1); % Note: add semiz' index following the semiz' dimension, add z' index following the z dimension for Tan improvement
-Policy_aprimesemizz=gather(Policy_aprimesemizz); % [N_a*N_semiz*N_z*N_e,N_semiz*N_probs,N_j]
+Policy_aprimesemizz=repelem(reshape(gather(Policy_aprime),[N_a*N_semiz*N_z*N_e,N_probs,N_j]),1,N_semiz)+repmat(N_a*(0:1:N_semiz-1),1,N_probs)+repmat(repelem(N_a*N_semiz*(0:1:N_z-1)',N_a*N_semiz,1),N_e,1); % Note: add semiz' index following the semiz' dimension, add z' index following the z dimension for Tan improvement
 
 Policy_dsemiexo=reshape(Policy_dsemiexo,[N_a*N_semiz*N_z*N_e,1,N_j]);
-% precompute
-semizindex=repmat(repelem(gpuArray(1:1:N_semiz)',N_a,1),N_z*N_e,1)+N_semiz*gpuArray(0:1:N_semiz-1)+(N_semiz*N_semiz)*(Policy_dsemiexo-1); % index for semiz, plus that for semiz' (in the semiz' dim) and dsemiexo; their indexes in pi_semiz_J
+
+% precompute; Don't want `PolicyProbs` on GPU anyway, so leave these in CPU RAM
+semizindex=repmat(repelem((1:1:N_semiz)',N_a,1),N_z*N_e,1)+N_semiz*(0:1:N_semiz-1)+gather((N_semiz*N_semiz)*(Policy_dsemiexo-1)); % index for semiz, plus that for semiz' (in the semiz' dim) and dsemiexo; their indexes in pi_semiz_J
+pi_semiz_J=gather(pi_semiz_J);
 % semizindex is [N_a*N_semiz*N_z*N_e,N_semiz,N_j]
 
 PolicyProbs=reshape(PolicyProbs,[N_a*N_semiz*N_z*N_e,N_probs,N_j]);
-PolicyProbs=repelem(PolicyProbs,1,N_semiz).*repmat(pi_semiz_J(semizindex),1,N_probs);
-PolicyProbs=gather(PolicyProbs);
+PolicyProbs=repelem(gather(PolicyProbs),1,N_semiz).*repmat(pi_semiz_J(semizindex),1,N_probs);
+clear semizindex;
 
 N_bothz=N_semiz*N_z;
 
 %% Use Tan improvement
 
-StationaryDist=zeros(N_a*N_semiz*N_z*N_e,N_j,'gpuArray');
+StationaryDist=zeros(N_a*N_semiz*N_z*N_e,N_j,'gpuArray'); % StationaryDist cannot be sparse
 StationaryDist(:,1)=jequaloneDistKron;
-StationaryDist_jj=sparse(jequaloneDistKron); % sparse() creates a matrix of zeros
+StationaryDist_jj=sparse(jequaloneDistKron); % use sparse matrix
 
-% Precompute
+% Precompute; II2 used only for sparse matrix creation...best done on CPU
 II2=repelem((1:1:N_a*N_semiz*N_z*N_e)',1,N_semiz*N_probs); % Index for this period (a,semiz), note the N_probs-copies
 
 for jj=1:(N_j-1)
     
-    % First, get Gamma
     Gammatranspose=sparse(Policy_aprimesemizz(:,:,jj),II2,PolicyProbs(:,:,jj),N_a*N_bothz,N_a*N_bothz*N_e); % Note: sparse() will accumulate at repeated indices [only relevant at grid end points]
 
     % First step of Tan improvement
     StationaryDist_jj=reshape(Gammatranspose*StationaryDist_jj,[N_a*N_semiz,N_z]);
 
     % Second step of Tan improvement
-    pi_z=sparse(pi_z_J(:,:,jj));
-    StationaryDist_jj=reshape(StationaryDist_jj*pi_z,[N_a*N_bothz,1]);
+    StationaryDist_jj=reshape(StationaryDist_jj*pi_z_J(:,:,jj),[N_a*N_bothz,1]);
 
     % Now do e transitions
     pi_e=sparse(pi_e_J(:,jj));
     StationaryDist_jj=kron(pi_e,StationaryDist_jj);
 
-    StationaryDist(:,jj+1)=gpuArray(full(StationaryDist_jj));
+    StationaryDist(:,jj+1)=StationaryDist_jj;
 end
 
 % Reweight the different ages based on 'AgeWeightParamNames'. (it is assumed there is only one Age Weight Parameter (name))

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw.m
@@ -12,22 +12,24 @@ Policy_aprimesemiz=repelem(reshape(Policy_aprime,[N_a*N_semiz*N_e,N_probs,N_j]),
 Policy_aprimesemiz=gather(Policy_aprimesemiz); % [N_a*N_semiz*N_e,N_semiz*N_probs,N_j]
 
 Policy_dsemiexo=reshape(Policy_dsemiexo,[N_a*N_semiz*N_e,1,N_j]);
-% precompute
-semizindex=repmat(repelem(gpuArray(1:1:N_semiz)',N_a,1),N_e,1)+N_semiz*gpuArray(0:1:N_semiz-1)+(N_semiz*N_semiz)*(Policy_dsemiexo-1); % index for semiz, plus that for semiz' (in the semiz' dim) and dsemiexo; their indexes in pi_semiz_J
+
+% precompute; Don't want `PolicyProbs` on GPU anyway, so leave these in CPU RAM
+semizindex=repmat(repelem((1:1:N_semiz)',N_a,1),N_e,1)+N_semiz*(0:1:N_semiz-1)+gather((N_semiz*N_semiz)*(Policy_dsemiexo-1)); % index for semiz, plus that for semiz' (in the semiz' dim) and dsemiexo; their indexes in pi_semiz_J
+pi_semiz_J=gather(pi_semiz_J);
 % semizindex is [N_a*N_semiz*N_e,N_semiz,N_j]
 
 PolicyProbs=reshape(PolicyProbs,[N_a*N_semiz*N_e,N_probs,N_j]);
-PolicyProbs=repelem(PolicyProbs,1,N_semiz).*repmat(pi_semiz_J(semizindex),1,N_probs);
-PolicyProbs=gather(PolicyProbs);
+PolicyProbs=repelem(gather(PolicyProbs),1,N_semiz).*repmat(pi_semiz_J(semizindex),1,N_probs);
+clear semizindex;
 
 %% Use Tan improvement
 
-StationaryDist=zeros(N_a*N_semiz*N_e,N_j,'gpuArray');
+StationaryDist=zeros(N_a*N_semiz*N_e,N_j,'gpuArray'); % StationaryDist cannot be sparse
 StationaryDist(:,1)=jequaloneDistKron;
-StationaryDist_jj=sparse(jequaloneDistKron); % sparse() creates a matrix of zeros
+StationaryDist_jj=sparse(jequaloneDistKron); % use sparse matrix
 
-% Precompute
-II2=repelem(gpuArray(1:1:N_a*N_semiz*N_e)',1,N_semiz*N_probs); % Index for this period (a,semiz), note the N_probs-copies
+% Precompute; II2 used only for sparse matrix creation...best done on CPU
+II2=repelem((1:1:N_a*N_semiz*N_e)',1,N_semiz*N_probs); % Index for this period (a,semiz), note the N_probs-copies
 
 for jj=1:(N_j-1)
 
@@ -37,10 +39,9 @@ for jj=1:(N_j-1)
     StationaryDist_jj=Gammatranspose*StationaryDist_jj;
     
     % Put e back into dist
-    pi_e=sparse(gather(pi_e_J(:,jj)));
-    StationaryDist_jj=kron(pi_e,StationaryDist_jj);
+    StationaryDist_jj=kron(pi_e_J(:,jj),StationaryDist_jj);
 
-    StationaryDist(:,jj+1)=gpuArray(full(StationaryDist_jj));
+    StationaryDist(:,jj+1)=StationaryDist_jj;
 end
 
 % Reweight the different ages based on 'AgeWeightParamNames'. (it is assumed there is only one Age Weight Parameter (name))

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw.m
@@ -8,26 +8,27 @@ function StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(je
 % put a&semiz together into the 1st dim, semiz'&nprobs into the 2nd dim.
 
 % Policy_aprime is currently [N_a,N_semiz,N_probs,N_j]
-Policy_aprimesemiz=repelem(reshape(Policy_aprime,[N_a*N_semiz,N_probs,N_j]),1,N_semiz)+repmat(N_a*gpuArray(0:1:N_semiz-1),1,N_probs); % Note: add semiz' index following the semiz' dimension
-Policy_aprimesemiz=gather(Policy_aprimesemiz); % [N_a*N_semiz,N_semiz*N_probs,N_j]
+Policy_aprimesemiz=repelem(reshape(gather(Policy_aprime),[N_a*N_semiz,N_probs,N_j]),1,N_semiz)+repmat(N_a*(0:1:N_semiz-1),1,N_probs); % Note: add semiz' index following the semiz' dimension
 
 Policy_dsemiexo=reshape(Policy_dsemiexo,[N_a*N_semiz,1,N_j]);
-% precompute
-semizindex=repelem(gpuArray(1:1:N_semiz)',N_a,1)+N_semiz*gpuArray(0:1:N_semiz-1)+(N_semiz*N_semiz)*(Policy_dsemiexo-1); % index for semiz, plus that for semiz' (in the semiz' dim) and dsemiexo; their indexes in pi_semiz_J
+
+% precompute; Don't want `PolicyProbs` on GPU anyway, so leave these in CPU RAM
+semizindex=repelem((1:1:N_semiz)',N_a,1)+N_semiz*(0:1:N_semiz-1)+gather((N_semiz*N_semiz)*(Policy_dsemiexo-1)); % index for semiz, plus that for semiz' (in the semiz' dim) and dsemiexo; their indexes in pi_semiz_J
+pi_semiz_J=gather(pi_semiz_J);
 % semizindex is [N_a*N_semiz,N_semiz,N_j]
 
 PolicyProbs=reshape(PolicyProbs,[N_a*N_semiz,N_probs,N_j]);
-PolicyProbs=repelem(PolicyProbs,1,N_semiz).*repmat(pi_semiz_J(semizindex),1,N_probs);
-PolicyProbs=gather(PolicyProbs);
+PolicyProbs=repelem(gather(PolicyProbs),1,N_semiz).*repmat(pi_semiz_J(semizindex),1,N_probs);
+clear semizindex;
 
 %% Use Tan improvement
 
-StationaryDist=zeros(N_a*N_semiz,N_j,'gpuArray');
+StationaryDist=zeros(N_a*N_semiz,N_j,'gpuArray'); % StationaryDist cannot be sparse
 StationaryDist(:,1)=jequaloneDistKron;
-StationaryDist_jj=sparse(jequaloneDistKron); % sparse() creates a matrix of zeros
+StationaryDist_jj=sparse(jequaloneDistKron); % use sparse matrix
 
-% Precompute
-II2=repelem(gpuArray(1:1:N_a*N_semiz)',1,N_semiz*N_probs); % Index for this period (a,semiz), note the N_semiz*N_probs-copies
+% Precompute; II2 used only for sparse matrix creation...best done on CPU
+II2=repelem((1:1:N_a*N_semiz)',1,N_semiz*N_probs); % Index for this period (a,semiz), note the N_semiz*N_probs-copies
 
 for jj=1:(N_j-1)
         
@@ -36,7 +37,7 @@ for jj=1:(N_j-1)
     % No z, so just a single interation
     StationaryDist_jj=Gammatranspose*StationaryDist_jj;
     
-    StationaryDist(:,jj+1)=gpuArray(full(StationaryDist_jj));
+    StationaryDist(:,jj+1)=StationaryDist_jj;
 end
 
 

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw.m
@@ -12,25 +12,25 @@ Policy_aprimesemizz=repelem(reshape(gather(Policy_aprime),[N_a*N_semiz*N_z,N_pro
 
 Policy_dsemiexo=reshape(Policy_dsemiexo,[N_a*N_semiz*N_z,1,N_j]);
 
-% precompute
+% precompute; Don't want `PolicyProbs` on GPU anyway, so leave these in CPU RAM
 semizindex=repmat(repelem((1:1:N_semiz)',N_a,1),N_z,1)+N_semiz*(0:1:N_semiz-1)+gather((N_semiz*N_semiz)*(Policy_dsemiexo-1)); % index for semiz, plus that for semiz' (in the semiz' dim) and dsemiexo; their indexes in pi_semiz_J
+pi_semiz_J=gather(pi_semiz_J);
 % semizindex is [N_a*N_semiz*N_z,N_semiz,N_j]
 
-
 PolicyProbs=reshape(PolicyProbs,[N_a*N_semiz*N_z,N_probs,N_j]);
-% pi_semiz_J=gather(pi_semiz_J);
 PolicyProbs=repelem(gather(PolicyProbs),1,N_semiz).*repmat(pi_semiz_J(semizindex),1,N_probs);
+clear semizindex;
 
 N_bothz=N_semiz*N_z;
 
 %% Use Tan improvement
 
-StationaryDist=zeros(N_a*N_semiz*N_z,N_j,'gpuArray');
+StationaryDist=zeros(N_a*N_semiz*N_z,N_j,'gpuArray'); % StationaryDist cannot be sparse
 StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(jequaloneDistKron); % use sparse matrix
 
-% Precompute
-II2=repelem(gpuArray(1:1:N_a*N_semiz*N_z)',1,N_semiz*N_probs); % Index for this period (a,semiz), note the N_probs-copies
+% Precompute; II2 used only for sparse matrix creation...best done on CPU
+II2=repelem((1:1:N_a*N_semiz*N_z)',1,N_semiz*N_probs); % Index for this period (a,semiz), note the N_probs-copies
 
 for jj=1:(N_j-1)
 
@@ -40,10 +40,9 @@ for jj=1:(N_j-1)
     StationaryDist_jj=reshape(Gammatranspose*StationaryDist_jj,[N_a*N_semiz,N_z]);
 
     % Second step of Tan improvement
-    pi_z=sparse(gather(pi_z_J(:,:,jj)));
-    StationaryDist_jj=reshape(StationaryDist_jj*pi_z,[N_a*N_bothz,1]);
+    StationaryDist_jj=reshape(StationaryDist_jj*pi_z_J(:,:,jj),[N_a*N_bothz,1]);
 
-    StationaryDist(:,jj+1)=gpuArray(full(StationaryDist_jj));
+    StationaryDist(:,jj+1)=StationaryDist_jj;
 end
 
 


### PR DESCRIPTION
The slow step in these files is computing the sparse matrix for the Gamma transpose.  Strangely (and I measure it), the more of the inputs that start on the CPU rather than the GPU (e.g., `II2`, `PolicyProbs`, and `Policy_aprimesemizz` and the like), the faster MATLAB can construct the sparse matrix.

Based on this observation, uses of `gpuArray` that would only need to be `gather`ed immediately anyway, and which were themselves not in any computational loops, were also removed.

It was verified that StationaryDist_jj remains sparse within its loops, and that its contents become full when assigned to StationaryDist(:,jj+1).  Which enabled additional simplifications.

Finally, it should be noted that all these optimizations greatly relieve pressure on GPU memory, while actually improving specific sparse matrix creation performance by as much as 10x (based on tic/toc and timeit measurements).

As always, please check.  I was able to test the main case (z, but no e) using LifeCycle35semi, and I simply ported changes across to other files manually.