### PR TITLE
Handle nonscalar gridinterplayer for ExpAsset

### DIFF
--- a/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAsset.m
+++ b/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAsset.m
@@ -114,7 +114,7 @@ if simoptions.gridinterplayer==0
     else % both z and e
         StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
     end
-elseif simoptions.gridinterplayer==1
+elseif (isscalar(simoptions.gridinterplayer) && simoptions.gridinterplayer==1) || (~isscalar(simoptions.gridinterplayer) && simoptions.gridinterplayer(1)==1 && all(simoptions.gridinterplayer(2:end)==0))
     % (a,z,2,j)
     Policy_aprime=repmat(Policy_aprime,1,1,2,1);
     PolicyProbs=repmat(PolicyProbs,1,1,2,1);

--- a/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAssetSemiExo.m
+++ b/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAssetSemiExo.m
@@ -145,7 +145,7 @@ if simoptions.gridinterplayer==0
     else % both z and e
         StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
     end
-elseif simoptions.gridinterplayer==1
+elseif (isscalar(simoptions.gridinterplayer) && simoptions.gridinterplayer==1) || (~isscalar(simoptions.gridinterplayer) && simoptions.gridinterplayer(1)==1 && all(simoptions.gridinterplayer(2:end)==0))
     % (a,z,2,j)
     Policy_aprime=repmat(Policy_aprime,1,1,2,1);
     PolicyProbs=repmat(PolicyProbs,1,1,2,1);

--- a/ValueFnIter/FHorz/GridInterpLayer/GI2B/ValueFnIter_FHorz_GI2B_nod_raw.m
+++ b/ValueFnIter/FHorz/GridInterpLayer/GI2B/ValueFnIter_FHorz_GI2B_nod_raw.m
@@ -15,7 +15,7 @@ a1_grid=a_grid(1:N_a1);
 a2_grid=a_grid(N_a1+1:end);
 
 % preallocate
-midpoints_jj=zeros(1,N_a2,N_a1,N_a2,N_z,'gpuArray');
+% midpoints_jj=zeros(1,N_a2,N_a1,N_a2,N_z,'gpuArray');
 
 % Grid interpolation
 % vfoptions.ngridinterp=9;


### PR DESCRIPTION
Simple changes to handle simplest case (grid interp on first asset only).