### PR TITLE
Relocate error message concerning non-finite return values

### DIFF
--- a/ValueFnIter/InfHorz/ValueFnIter_nod_HowardGreedy_raw.m
+++ b/ValueFnIter/InfHorz/ValueFnIter_nod_HowardGreedy_raw.m
@@ -37,7 +37,9 @@ while currdist>Tolerance && tempcounter<=maxiter
     if isfinite(currdist) && currdist/Tolerance>10 && tempcounter<MaxHowards
         tempmaxindex=shiftdim(Policy,1)+addindexforaz; % aprime index, add the index for a and z
         Ftemp=reshape(ReturnMatrix(tempmaxindex),[N_a*N_z,1]); % keep return function of optimal policy for using in Howards
-
+        if any(~isfinite(Ftemp))
+            error("Howards-greedy doesn't work for non-finite return values; rerun with `vfoptions.howardsgreedy=0;`")
+        end
         T_E=sparse(greedyHind1,Policy(:)+greedyHind2,greedyHpi,N_a*N_z,N_a*N_z);
 
         VKron=(spI-DiscountFactorParamsVec*T_E)\Ftemp;
@@ -49,12 +51,6 @@ while currdist>Tolerance && tempcounter<=maxiter
 end
 
 Policy=reshape(Policy,[1,N_a,N_z]);
-
-
-%% Howards greedy cannot solve models where V contains values of -Inf. Can kind of test for this by looking for -Inf in Ftemp
-if any(~isfinite(Ftemp))
-    warning('Howards-greedy cannot be used for models where V contains values of -Inf. This model looks like it may be one where V takes a value of -Inf at some points in the state-space. Consider checking solution against that with vfoptions.howardsgreedy=0')
-end
 
 if tempcounter>=maxiter
     warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')


### PR DESCRIPTION
Howards-greedy does not work with non-finite return values.  Rather than testing whether we get any such and warning, we move the test inside the loop so that errors can be flagged closer to their initial appearance.  This makes understanding and fixing such errors easier when debugging.