### PR TITLE
Fix PType SimPanelValues semiz option extraction

### DIFF
--- a/SimulateTimeSeries/FHorz/PType/SimPanelValues_FHorz_Case1_PType.m
+++ b/SimulateTimeSeries/FHorz/PType/SimPanelValues_FHorz_Case1_PType.m
@@ -110,6 +110,7 @@ SimPanelValues=nan(length(FnsToEvaluate),simoptions.simperiods,simoptions.number
 for ii=1:N_i
     % First set up simoptions
     simoptions_temp=PType_Options(simoptions,Names_i,ii); % Note: already check for existence of simoptions and created it if it was not inputted
+    simoptions_temp=local_extract_ptype_semiexo_inputs(simoptions_temp,simoptions,Names_i,ii,N_i);
     
     if simoptions_temp.verbose==1
         fprintf('Permanent type: %i of %i \n',ii, N_i)
@@ -302,6 +303,33 @@ for ff=1:length(FnNames)
     SimPanelValues.(FnNames{ff})=shiftdim(SimPanelValues2(ff,:,:),1);
 end
 
+
+end
+
+function simoptions_temp=local_extract_ptype_semiexo_inputs(simoptions_temp,simoptions,Names_i,ii,N_i)
+
+if isfield(simoptions,'semiz_grid')
+    simoptions_temp.semiz_grid=local_extract_ptype_lastdim(simoptions.semiz_grid,Names_i,ii,N_i);
+end
+
+if isfield(simoptions,'pi_semiz')
+    simoptions_temp.pi_semiz=local_extract_ptype_lastdim(simoptions.pi_semiz,Names_i,ii,N_i);
+end
+
+end
+
+function value_ii=local_extract_ptype_lastdim(value,Names_i,ii,N_i)
+
+value_ii=value;
+if isstruct(value)
+    if isfield(value,Names_i{ii})
+        value_ii=value.(Names_i{ii});
+    end
+elseif ~isscalar(value) && ndims(value)>=2 && size(value,ndims(value))==N_i
+    index=repmat({':'},1,ndims(value));
+    index{end}=ii;
+    value_ii=value(index{:});
+end
 
 end
 


### PR DESCRIPTION
## Summary
This PR fixes a `PType` handling issue in `SimPanelValues_FHorz_Case1_PType` for models that use semi-exogenous states through `simoptions.semiz_grid` and `simoptions.pi_semiz`.

This PR is intentionally separate from the `LifeCycleProfiles_FHorz_Case1_PType` grouped-statistics fix so the two issues can be reviewed independently.

## Bug
`SimPanelValues_FHorz_Case1_PType` calls `PType_Options(simoptions, Names_i, ii)` and then passes the resulting `simoptions_temp` to the single-type simulator `SimPanelValues_FHorz_Case1`.

For per-type options, `PType_Options` only extracts type-specific values when the option is provided as a `struct` with fields such as `ptype001`, `ptype002`, etc.

That means if a user provides semi-exogenous simulation inputs in array form, for example:

- `simoptions.semiz_grid(..., i)`
- `simoptions.pi_semiz(..., i)`

then the current `PType` wrapper passes the full multi-type object through instead of selecting the current permanent type.

The downstream single-type semi-exogenous simulation code expects per-type objects, so this leads to shape mismatches. In the reproducer, the error appeared in `SemiExogShockSetup_FHorz` as:

```matlab
options.pi_semiz matrix is the wrong size
```

## Fix
The change is minimal and local to `SimPanelValues_FHorz_Case1_PType`:

- after `PType_Options`, extract the current permanent type from `simoptions.semiz_grid` and `simoptions.pi_semiz` when those objects are provided in array form with `ptype` in the last dimension
- preserve the existing behavior for the already-supported `struct` form

So after this patch, the wrapper accepts both:

- struct-valued per-type semi-exogenous options
- array-valued semi-exogenous options with permanent type in the last dimension

## Validation
I verified this in a finite-horizon life-cycle search model with:

- no ordinary exogenous state
- a semi-exogenous employment/skill state
- permanent types
- panel simulation through `SimPanelValues_FHorz_Case1_PType`

Before the patch, the simulation path required a local workaround that converted `simoptions.semiz_grid` and `simoptions.pi_semiz` into structs by permanent type.

After the patch:

- the workaround is no longer needed
- `SimPanelValues_FHorz_Case1_PType` works directly with the original array-valued inputs
- the full model runs successfully end to end
- deterministic comparisons with the manual MATLAB implementation remain exact for value functions, policies, distributions, values-on-grid outputs, and analytical life-cycle statistics

## Notes
This PR only changes the `SimPanelValues_FHorz_Case1_PType` wrapper and does not touch the lower-level simulation routines.
