### PR TITLE
Fix FHorz semi-exo grid interpolation indexing

### DIFF
--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw.m
@@ -47,7 +47,7 @@ StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(jequaloneDistKron); % use sparse matrix
 
 % Precompute; II2 used only for sparse matrix creation...best done on CPU
-II2=repelem((1:1:N_a*N_semiz*N_z*N_e)',1,N_semiz*N_probs); % Index for this period (a,semiz), note the N_probs-copies
+II2=repelem((1:1:N_a*N_semiz*N_z*N_e)',1,N_semizshort*N_probs); % Index for this period (a,semiz), note the N_semizshort*N_probs-copies
 
 for jj=1:(N_j-1)
     

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw.m
@@ -43,7 +43,7 @@ StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(jequaloneDistKron); % use sparse matrix
 
 % Precompute; II2 used only for sparse matrix creation...best done on CPU
-II2=repelem((1:1:N_a*N_semiz*N_e)',1,N_semiz*N_probs); % Index for this period (a,semiz), note the N_probs-copies
+II2=repelem((1:1:N_a*N_semiz*N_e)',1,N_semizshort*N_probs); % Index for this period (a,semiz), note the N_semizshort*N_probs-copies
 
 for jj=1:(N_j-1)
 

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw.m
@@ -40,7 +40,7 @@ StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(jequaloneDistKron); % use sparse matrix
 
 % Precompute; II2 used only for sparse matrix creation...best done on CPU
-II2=repelem((1:1:N_a*N_semiz)',1,N_semiz*N_probs); % Index for this period (a,semiz), note the N_semiz*N_probs-copies
+II2=repelem((1:1:N_a*N_semiz)',1,N_semizshort*N_probs); % Index for this period (a,semiz), note the N_semizshort*N_probs-copies
 
 for jj=1:(N_j-1)
         


### PR DESCRIPTION
## Summary
This PR fixes a finite-horizon stationary-distribution bug in the semi-exogenous `gridinterplayer = 1` path.

The issue is in the interpolated `nProbs` helpers used by the finite-horizon semi-exogenous distribution code. These routines compress the semi-exogenous transition matrix to its nonzero successors using `N_semizshort`, but the precomputed row-index array `II2` was still being built with `N_semiz * N_probs` entries instead of `N_semizshort * N_probs`.

That mismatch can cause the inputs to `sparse(...)` to have inconsistent lengths and raises an error during the distribution step.

## Root Cause
In the affected helpers:

- the semi-exogenous transition matrix is compressed to `N_semizshort`
- `Policy_aprime*` and `PolicyProbs` are expanded consistently with `N_semizshort * N_probs`
- but `II2` was still allocated with `N_semiz * N_probs`

When `N_semizshort < N_semiz`, the vectors passed to `sparse(...)` do not have matching lengths.

## Fix
Update `II2` to use `N_semizshort * N_probs` in the affected finite-horizon semi-exogenous interpolated distribution helpers:

- `StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw`
- `StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw`
- `StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw`

This matches the effective width of the compressed-policy objects and is also consistent with the corresponding `StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw` implementation.

## Validation
I validated the change with a local finite-horizon semi-exogenous reproducer:

- with `gridinterplayer = 0`, the run still completes end-to-end
- with `gridinterplayer = 1`, the run now gets past the finite-horizon stationary-distribution step that previously crashed

After this fix, the previous `sparse` length-mismatch error is removed. Any remaining differences after that point are separate from this indexing bug.
