### PR TITLE
MixedHorz changes only

### DIFF
--- a/EvaluateFnOnAgentDist/FHorz/PType/EvalFnOnAgentDist_AggVars_FHorz_Case1_PType.m
+++ b/EvaluateFnOnAgentDist/FHorz/PType/EvalFnOnAgentDist_AggVars_FHorz_Case1_PType.m
@@ -220,7 +220,7 @@ for ii=1:N_i
     if isfinite(N_j_temp)
         AggVars_ii=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist_temp, PolicyIndexes_temp, FnsToEvaluate_temp, Parameters_temp, FnsToEvaluateParamNames_temp, n_d_temp, n_a_temp, n_z_temp, N_j_temp, d_grid_temp, a_grid_temp, z_grid_temp, simoptions_temp);
     else % PType actually allows for infinite horizon as well
-        AggVars_ii=EvalFnOnAgentDist_AggVars_Case1(StationaryDist_temp, PolicyIndexes_temp, FnsToEvaluate_temp, Parameters_temp, FnsToEvaluateParamNames_temp, n_d_temp, n_a_temp, n_z_temp, d_grid_temp, a_grid_temp, z_grid_temp, simoptions_temp); % , EntryExitParamNames, PolicyWhenExiting
+        AggVars_ii=EvalFnOnAgentDist_AggVars_InfHorz(StationaryDist_temp, PolicyIndexes_temp, FnsToEvaluate_temp, Parameters_temp, FnsToEvaluateParamNames_temp, n_d_temp, n_a_temp, n_z_temp, d_grid_temp, a_grid_temp, z_grid_temp, simoptions_temp); % , EntryExitParamNames, PolicyWhenExiting
     end
 
     AggVarsFull(logical(FnsAndPTypeIndicator_ii),ii)=AggVars_ii;

--- a/EvaluateFnOnAgentDist/MixHorz/EvalFnOnAgentDist_AllStats_MixHorz_PType.m
+++ b/EvaluateFnOnAgentDist/MixHorz/EvalFnOnAgentDist_AllStats_MixHorz_PType.m
@@ -1,0 +1,627 @@
+function AllStats=EvalFnOnAgentDist_AllStats_MixHorz_PType(StationaryDist, Policy, FnsToEvaluate, Parameters,n_d,n_a,n_z,N_j,Names_i,d_grid, a_grid, z_grid, simoptions)
+% Reports a variety of stats, both grouped and by PType.
+%
+% Allows for different permanent (fixed) types of agent.
+% See ValueFnIter_PType for general idea.
+%
+%
+% simoptions.verbose=1 will give feedback
+% simoptions.verboseparams=1 will give further feedback on the param values of each permanent type
+%
+% Rest of this description describes how those inputs not already used for
+% ValueFnIter_PType or StationaryDist_PType should be set up.
+%
+% jequaloneDist can either be same for all permanent types, or must be passed as a structure.
+% AgeWeightParamNames is either same for all permanent types, or must be passed as a structure.
+%
+% The stationary distribution be a structure and will contain both the
+% weights/distribution across the permenant types, as well as a pdf for the
+% stationary distribution of each specific permanent type.
+%
+% How exactly to handle these differences between permanent (fixed) types
+% is to some extent left to the user. You can, for example, input
+% parameters that differ by permanent type as a vector with different rows f
+% for each type, or as a structure with different fields for each type.
+%
+% Any input that does not depend on the permanent type is just passed in
+% exactly the same form as normal.
+
+% Names_i can either be a cell containing the 'names' of the different
+% permanent types, or if there are no structures used (just parameters that
+% depend on permanent type and inputted as vectors or matrices as appropriate)
+% then Names_i can just be the number of permanent types (but does not have to be, can still be names).
+if iscell(Names_i)
+    N_i=length(Names_i);
+else
+    N_i=Names_i; % It is the number of PTypes (which have not been given names)
+    Names_i=cell(1,N_i);
+    for ii=1:N_i
+        if ii<10
+            Names_i{ii}=['ptype00',num2str(ii)];
+        elseif ii<100
+            Names_i{ii}=['ptype0',num2str(ii)];
+        elseif ii<1000
+            Names_i{ii}=['ptype',num2str(ii)];
+        end
+    end
+end
+
+if ~exist('simoptions','var')
+    simoptions.groupptypesforstats=1;
+    simoptions.ptypestorecpu=0; % GPU memory is limited, so switch solutions to the cpu (off by default)
+    simoptions.groupusingtdigest=0; % if you are ptypestorecpu=1 and groupptypesforstats=1, you might also need to use groupusingtdigest=1 if you get out of memory errors
+    simoptions.verbose=0;
+    simoptions.verboseparams=0;
+    simoptions.nquantiles=20; % by default gives ventiles
+    simoptions.npoints=100; % number of points for lorenz curve (note this lorenz curve is also used to calculate the gini coefficient
+    simoptions.tolerance=10^(-12); % Numerical tolerance used when calculating min and max values.
+    simoptions.whichstats=ones(7,1); % See StatsFromWeightedGrid(), zeros skip some stats and can be used to reduce runtimes
+    % simoptions.conditionalrestrictions  % Evaluate AllStats, but conditional on the restriction being equal to one (not zero).
+    simoptions.gridinterplayer=0;
+    % When calling as a subcommand, the following is used internally
+    simoptions.alreadygridvals=0;
+    simoptions.alreadygridvals_semiexo=0;
+else
+    if ~isfield(simoptions,'groupptypesforstats')
+        simoptions.groupptypesforstats=1;
+    end
+    if ~isfield(simoptions,'ptypestorecpu')
+        simoptions.ptypestorecpu=0; % GPU memory is limited, so switch solutions to the cpu (off by default)
+    end
+    if ~isfield(simoptions,'groupusingtdigest')
+        simoptions.groupusingtdigest=0; % if you are ptypestorecpu=1 and groupptypesforstats=1, you might also need to use groupusingtdigest=1 if you get out of memory errors
+    end
+    if ~isfield(simoptions,'verboseparams')
+        simoptions.verboseparams=0;
+    end
+    if ~isfield(simoptions,'verbose')
+        simoptions.verbose=100;
+    end
+    if isfield(simoptions,'nquantiles')==0
+        simoptions.nquantiles=20; % by default gives ventiles
+    end
+    if isfield(simoptions,'npoints')==0
+        simoptions.npoints=100; % number of points for lorenz curve (note this lorenz curve is also used to calculate the gini coefficient
+    elseif simoptions.npoints==0
+        error('simoptions.npoints must be a positive (non-zero) integer')
+    end
+    if isfield(simoptions,'tolerance')==0    
+        simoptions.tolerance=10^(-12); % Numerical tolerance used when calculating min and max values.
+    end
+    if ~isfield(simoptions,'whichstats')
+        simoptions.whichstats=ones(7,1); % See StatsFromWeightedGrid(), zeros skip some stats and can be used to reduce runtimes
+    end
+    % simoptions.conditionalrestrictions  % Evaluate AllStats, but conditional on the restriction being equal to one (not zero).
+    if ~isfield(simoptions,'gridinterplayer')
+        simoptions.gridinterplayer=0;
+    end
+    % When calling as a subcommand, the following is used internally
+    if ~isfield(simoptions,'alreadygridvals')
+        simoptions.alreadygridvals=0;
+    end
+    if ~isfield(simoptions,'alreadygridvals_semiexo')
+        simoptions.alreadygridvals_semiexo=0;
+    end
+end
+
+if isstruct(FnsToEvaluate)
+    FnsToEvalNames=fieldnames(FnsToEvaluate);
+    numFnsToEvaluate=length(FnsToEvalNames);
+else
+    error('You can only use PType when FnsToEvaluate is a structure')
+end
+
+% Set default of grouping all the PTypes together when reporting statistics
+% AllStats reports both
+% simoptions.groupptypesforstats=0;
+% and
+% simoptions.groupptypesforstats=1;
+
+
+% Preallocate a few things
+MeanVec=nan(numFnsToEvaluate,N_i); % Note, these need to be nan so we can omitnan to ignore ptypes for who that FnToEvaluate is not relevant
+StdDevVec=zeros(numFnsToEvaluate,N_i);
+minvaluevec=nan(numFnsToEvaluate,N_i);
+maxvaluevec=nan(numFnsToEvaluate,N_i);
+AllStats=struct();
+
+
+% Preallocate
+if simoptions.groupusingtdigest==1 % Things are being stored on cpu but solved on gpu
+    % Following few lines relate to the digest
+    delta=10000;
+    merge_nsofar=zeros(1,numFnsToEvaluate); % Keep count
+    merge_nsofar2=zeros(1,numFnsToEvaluate); % Keep count
+
+    AllCMerge=struct();
+    Alldigestweightsmerge=struct();
+    for ff=1:numFnsToEvaluate % Each of the functions to be evaluated on the grid
+        AllCMerge.(FnsToEvalNames{ff})=zeros(5000*N_i,1); % This is intended to be an upper limit on number of points that might be use
+        Alldigestweightsmerge.(FnsToEvalNames{ff})=zeros(5000*N_i,1); % This is intended to be an upper limit on number of points that might be use
+    end
+else
+    AllValues=struct();
+    AllWeights=struct();
+    for ff=1:numFnsToEvaluate % Each of the functions to be evaluated on the grid
+        AllValues.(FnsToEvalNames{ff})=[];
+        AllWeights.(FnsToEvalNames{ff})=[];
+    end
+end
+
+FnsAndPTypeIndicator=zeros(numFnsToEvaluate,N_i,'gpuArray');
+
+
+%% If there are any conditional restrictions, set up for these
+% Evaluate AllStats, but conditional on the restriction being non-zero.
+
+useCondlRest=0;
+% Code works by evaluating the the restriction and imposing this on the distribution (and renormalizing it).
+if isfield(simoptions,'conditionalrestrictions')
+    useCondlRest=1;
+    CondlRestnFnNames=fieldnames(simoptions.conditionalrestrictions);
+
+    restrictedsamplemass=nan(N_i,length(CondlRestnFnNames));
+    % RestrictionStruct_ii=struct();
+
+    if simoptions.groupusingtdigest==1 % Things are being stored on cpu but solved on gpu
+        error('Have not implemented simoptions.groupusingtdigest==1 together with simoptions.conditionalrestrictions')
+    else
+        AllRestrictedWeights=struct(); % Only used if useCondlRest==1
+        for ff=1:numFnsToEvaluate % Each of the functions to be evaluated on the grid
+            for rr=1:length(CondlRestnFnNames)
+                AllRestrictedWeights.(CondlRestnFnNames{rr}).(FnsToEvalNames{ff})=[];
+            end
+        end
+    end
+end
+
+
+%% NOTE GROUPING ONLY WORKS IF THE GRIDS ARE THE SAME SIZES FOR EACH AGENT (for whom a given FnsToEvaluate is being calculated)
+% (mainly because otherwise would have to deal with simoptions.agegroupings being different for each agent and this requires more complex code)
+% Will throw an error if this is not the case
+
+% If grouping, we have ValuesOnDist and StationaryDist that contain
+% everything we will need. Now we just have to compute them.
+% Note that I do not currently allow the following simoptions to differ by PType
+
+
+for ii=1:N_i
+
+    tic;
+
+    % First set up simoptions
+    simoptions_temp=PType_Options(simoptions,Names_i,ii); % Note: already check for existence of simoptions and created it if it was not inputted
+
+    if simoptions_temp.verbose==1
+        fprintf('Permanent type: %i of %i \n',ii, N_i)
+    end
+
+    if simoptions_temp.ptypestorecpu==1 % Things are being stored on cpu but solved on gpu
+        PolicyIndexes_temp=gpuArray(Policy.(Names_i{ii}));
+        % StationaryDist_temp=gpuArray(StationaryDist.(Names_i{ii}));
+    else
+        PolicyIndexes_temp=Policy.(Names_i{ii});
+        % StationaryDist_temp=StationaryDist.(Names_i{ii});
+    end
+
+    % Go through everything which might be dependent on permanent type (PType)
+    % Notice that the way this is coded the grids (etc.) could be either
+    % fixed, or a function (that depends on age, and possibly on permanent
+    % type), or they could be a structure. Only in the case where they are
+    % a structure is there a need to take just a specific part and send
+    % only that to the 'non-PType' version of the command.
+
+    % Start with those that determine whether the current permanent type is finite or
+    % infinite horizon, and whether it is Case 1 or Case 2
+    % Figure out which case is relevant to the current PType. This is done
+    % using N_j which for the current type will evaluate to 'Inf' if it is
+    % infinite horizon and a finite number for any other finite horizon.
+    % First, check if it is a structure, and otherwise just get the
+    % relevant value.
+
+    % Horizon is determined via N_j
+    if isstruct(N_j)
+        N_j_temp=N_j.(Names_i{ii});
+    elseif isscalar(N_j)
+        N_j_temp=N_j;
+    else % is a vector
+        N_j_temp=N_j(ii);
+    end
+
+    if isstruct(n_d)
+        n_d_temp=n_d.(Names_i{ii});
+    else
+        n_d_temp=n_d;
+    end
+    if isstruct(n_a)
+        n_a_temp=n_a.(Names_i{ii});
+    else
+        n_a_temp=n_a;
+    end
+    if isstruct(n_z)
+        n_z_temp=n_z.(Names_i{ii});
+    else
+        n_z_temp=n_z;
+    end
+
+    if isstruct(d_grid)
+        d_grid_temp=d_grid.(Names_i{ii});
+    else
+        d_grid_temp=d_grid;
+    end
+    if isstruct(a_grid)
+        a_grid_temp=a_grid.(Names_i{ii});
+    else
+        a_grid_temp=a_grid;
+    end
+
+    %% Exogenous shocks
+    if isstruct(z_grid)
+        z_grid_temp=z_grid.(Names_i{ii});
+    else
+        nn=size(z_grid,ndims(z_grid));
+        if nn==N_i
+            otherdims = repmat({':'},1,ndims(z_grid)-1);
+            z_grid_temp=z_grid(otherdims{:},ii);
+        else
+            z_grid_temp=z_grid;
+        end
+    end
+
+    % e
+    if isfield(simoptions_temp,'n_e')
+        % If simoptions_temp.e_grid is a structure that was already dealt with by PType_Options() command
+        if ~isstruct(simoptions.e_grid)
+            % So just need to check if last dimension is of length N_i
+            nn=size(simoptions_temp.e_grid,ndims(simoptions_temp.e_grid));
+            if nn==N_i
+                otherdims = repmat({':'},1,ndims(simoptions_temp.e_grid)-1);
+                simoptions_temp.e_grid=simoptions_temp.e_grid(otherdims{:},ii);
+            end
+        end
+    end
+
+    % semiz
+    if isfield(simoptions_temp,'n_semiz')
+        % If simoptions_temp.semiz_grid is a structure that was already dealt with by PType_Options() command
+        if ~isstruct(simoptions.semiz_grid)
+            % So just need to check if last dimension is of length N_i
+            nn=size(simoptions_temp.semiz_grid,ndims(simoptions_temp.semiz_grid));
+            if nn==N_i
+                otherdims = repmat({':'},1,ndims(simoptions_temp.semiz_grid)-1);
+                simoptions_temp.semiz_grid=simoptions_temp.semiz_grid(otherdims{:},ii);
+            end
+        end
+    end
+    
+    %% Parameters
+    % Parameters are allowed to be given as structure, or as vector/matrix
+    % (in terms of their dependence on permanent type). So go through each of
+    % these in term.
+    % ie. Parameters.alpha=[0;1]; or Parameters.alpha.ptype1=0; Parameters.alpha.ptype2=1;
+    Parameters_temp=Parameters;
+    FullParamNames=fieldnames(Parameters); % all the different parameters
+    nFields=length(FullParamNames);
+    for kField=1:nFields
+        if isa(Parameters.(FullParamNames{kField}), 'struct') % Check the current parameter for permanent type in structure form
+            % Check if this parameter is used for the current permanent type (it may or may not be, some parameters are only used be a subset of permanent types)
+            if isfield(Parameters.(FullParamNames{kField}),Names_i{ii})
+                Parameters_temp.(FullParamNames{kField})=Parameters.(FullParamNames{kField}).(Names_i{ii});
+            end
+        elseif sum(size(Parameters.(FullParamNames{kField}))==N_i)>=1 % Check for permanent type in vector/matrix form.
+            temp=Parameters.(FullParamNames{kField});
+            [~,ptypedim]=max(size(Parameters.(FullParamNames{kField}))==N_i); % Parameters as vector/matrix can be at most two dimensional, figure out which relates to PType.
+            if ptypedim==1
+                Parameters_temp.(FullParamNames{kField})=temp(ii,:);
+            elseif ptypedim==2
+                Parameters_temp.(FullParamNames{kField})=temp(:,ii);
+            end
+        end
+    end
+    % THIS TREATMENT OF PARAMETERS COULD BE IMPROVED TO BETTER DETECT INPUT SHAPE ERRORS.
+
+    if simoptions_temp.verboseparams==1
+        fprintf('Parameter values for the current permanent type \n')
+        Parameters_temp
+    end
+    
+    % A few other things we can do in outer loop
+    if n_d_temp(1)==0
+        l_d_temp=0;
+    else
+        l_d_temp=1;
+    end
+    l_a_temp=length(n_a_temp);
+    N_a_temp=prod(n_a_temp);
+    
+    a_gridvals_temp=CreateGridvals(n_a_temp,a_grid_temp,1);
+    if isfinite(N_j_temp)
+        % Turn (semiz,z,e) into z_gridvals_J_temp as FnsToEvalute do not distinguish them
+        [n_z_temp,z_gridvals_J_temp,N_z_temp,l_z_temp,simoptions_temp]=CreateGridvals_FnsToEvaluate_FHorz(n_z_temp,z_grid_temp,N_j_temp,simoptions_temp,Parameters_temp);
+    else
+        l_z_temp=length(n_z_temp);
+        N_z_temp=prod(n_z_temp);
+        z_gridvals_temp=CreateGridvals(n_z_temp,z_grid_temp,1);
+    end
+    if N_z_temp==0
+        N_z_temp=1; % Just makes things easier below
+    end
+    
+    % Switch to PolicyVals
+    if isfinite(N_j_temp)
+        PolicyValues_temp=PolicyInd2Val_FHorz(PolicyIndexes_temp,n_d_temp,n_a_temp,n_z_temp,N_j_temp,d_grid_temp,a_grid_temp,simoptions_temp,1);
+        if l_z_temp==0
+            PolicyValuesPermute_temp=permute(PolicyValues_temp,[2,3,1]); % (N_a,N_j,l_daprime)
+        else
+            PolicyValuesPermute_temp=permute(PolicyValues_temp,[2,3,4,1]); % (N_a,N_z,N_j,l_daprime)
+        end
+        StationaryDist_ii=reshape(StationaryDist.(Names_i{ii}),[N_a_temp*N_z_temp*N_j_temp,1]); % Note: does not impose *StationaryDist.ptweights(ii)
+    else
+        PolicyValues_temp=PolicyInd2Val_InfHorz(PolicyIndexes_temp,n_d_temp,n_a_temp,n_z_temp,d_grid_temp,a_grid_temp,simoptions_temp,1);
+        if l_z_temp==0
+            PolicyValuesPermute_temp=permute(PolicyValues_temp,[2,1]); % (N_a,l_daprime)
+        else
+            PolicyValuesPermute_temp=permute(PolicyValues_temp,[2,3,1]); % (N_a,N_z,l_daprime)
+        end
+        StationaryDist_ii=reshape(StationaryDist.(Names_i{ii}),[N_a_temp*N_z_temp,1]); % Note: does not impose *StationaryDist.ptweights(ii)
+    end
+    l_daprime_temp=size(PolicyValues_temp,1);
+
+    [~,~,~,FnsAndPTypeIndicator_ii]=PType_FnsToEvaluate(FnsToEvaluate,Names_i,ii,l_d_temp,l_a_temp,l_z_temp,0);
+    FnsAndPTypeIndicator(:,ii)=FnsAndPTypeIndicator_ii;
+
+    %% Some things that don't need to go in the loop over FnsToEvalaute
+    % Eliminate all the zero-weighted points (this doesn't really save runtime for the exact calculation and often can increase it, but
+    % for the createDigest it slashes the runtime. So since we want it then we may as well do it now.)    
+    temp=logical(StationaryDist_ii~=0);
+    % StationaryDist_ii=StationaryDist_ii(temp); % This has to happen after the conditional restriction dist is calculated
+    
+    %% Evaluate conditional restrictions for this PType (note: these use simoptions not simoptions_temp)
+    if useCondlRest==1
+        RestrictionStruct_ii=struct();
+        
+        % For each conditional restriction, create a 'restricted stationary distribution'
+        for rr=1:length(CondlRestnFnNames)
+            % The current conditional restriction function
+            CondlRestnFn=simoptions.conditionalrestrictions.(CondlRestnFnNames{rr});
+            % Get parameter names for Conditional Restriction functions
+            temp2=getAnonymousFnInputNames(CondlRestnFn);
+            if length(temp2)>(l_daprime_temp+l_a_temp+l_z_temp)
+                CondlRestnFnParamNames={temp2{l_daprime_temp+l_a_temp+l_z_temp+1:end}}; % the first inputs will always be (d,aprime,a,z)
+            else
+                CondlRestnFnParamNames={};
+            end
+
+            if isfinite(N_j_temp)
+                if l_z_temp==0
+                    CellOverAgeOfParamValues=CreateCellOverAgeFromParams(Parameters_temp,CondlRestnFnParamNames,N_j_temp,2); % j in 2nd dimension: (a,j,l_d+l_a), so we want j to be after N_a
+                    RestrictionValues=logical(EvalFnOnAgentDist_Grid_J(CondlRestnFn,CellOverAgeOfParamValues,PolicyValuesPermute_temp,l_daprime_temp,n_a_temp,0,a_gridvals_temp,[]));
+                else
+                    CellOverAgeOfParamValues=CreateCellOverAgeFromParams(Parameters_temp,CondlRestnFnParamNames,N_j_temp,3); % j in 3rd dimension: (a,z,j,l_d+l_a), so we want j to be after N_a and N_z
+                    RestrictionValues=logical(EvalFnOnAgentDist_Grid_J(CondlRestnFn,CellOverAgeOfParamValues,PolicyValuesPermute_temp,l_daprime_temp,n_a_temp,n_z_temp,a_gridvals_temp,z_gridvals_J_temp));
+                end
+                RestrictionValues=reshape(RestrictionValues,[N_a_temp*N_z_temp*N_j_temp,1]);
+            else
+                CondlRestnFnParamsCell=CreateCellFromParams(Parameters_temp,CondlRestnFnParamNames);
+
+                RestrictionValues=logical(EvalFnOnAgentDist_Grid(CondlRestnFn, CondlRestnFnParamsCell,PolicyValuesPermute_temp,l_daprime_temp,n_a_temp,n_z_temp,a_gridvals_temp,z_gridvals_temp));
+                RestrictionValues=reshape(RestrictionValues,[N_a_temp*N_z_temp,1]);
+            end
+
+            RestrictedStationaryDistVec=StationaryDist_ii;
+            RestrictedStationaryDistVec(~RestrictionValues)=0; % zero mass on all points that do not meet the restriction
+            RestrictedStationaryDistVec=RestrictedStationaryDistVec(temp); % This has already been done to StationaryDist_ii, so have to do it to Restricted Agent Dist
+
+            % Need to keep two things, the restrictedsamplemass and the RestrictedStationaryDistVec (normalized to have mass of 1)
+            restrictedsamplemass(ii,rr)=sum(RestrictedStationaryDistVec);
+            RestrictedStationaryDistVec=RestrictedStationaryDistVec./restrictedsamplemass(ii,rr); % Normalize to mass of 1
+            % Store for later
+            RestrictionStruct_ii(rr).RestrictedStationaryDistVec=RestrictedStationaryDistVec;
+            
+            AllStats.(CondlRestnFnNames{rr}).RestrictedSampleMass.(Names_i{ii})=restrictedsamplemass(ii,rr); % Seems likely this would be something user might want
+            if restrictedsamplemass(ii,rr)==0
+                warning('One of the conditional restrictions evaluates to a zero mass')
+                fprintf(['Specifically, the restriction called ',CondlRestnFnNames{rr},' has a restricted sample that is of zero mass \n'])
+            end
+        end
+    end
+    
+    %%
+    StationaryDist_ii=StationaryDist_ii(temp);
+    
+    %%
+    for ff=1:numFnsToEvaluate % Each of the functions to be evaluated on the grid
+        if FnsAndPTypeIndicator_ii(ff)==1 % If this function is relevant to this ptype
+
+            % Get parameter names for current FnsToEvaluate functions
+            % Get parameter names for current FnsToEvaluate functions
+            if isstruct(FnsToEvaluate.(FnsToEvalNames{ff}))
+                tempfn=FnsToEvaluate.(FnsToEvalNames{ff}).(Names_i{ii});
+            else
+                tempfn=FnsToEvaluate.(FnsToEvalNames{ff});
+            end
+            tempnames=getAnonymousFnInputNames(tempfn);
+            if length(tempnames)>(l_daprime_temp+l_a_temp+l_z_temp)
+                FnsToEvaluateParamNames={tempnames{l_daprime_temp+l_a_temp+l_z_temp+1:end}}; % the first inputs will always be (d,aprime,a,z)
+            else
+                FnsToEvaluateParamNames={};
+            end
+            if isfinite(N_j_temp)
+                if l_z_temp==0
+                    CellOverAgeOfParamValues=CreateCellOverAgeFromParams(Parameters_temp,FnsToEvaluateParamNames,N_j_temp,2);
+                else
+                    CellOverAgeOfParamValues=CreateCellOverAgeFromParams(Parameters_temp,FnsToEvaluateParamNames,N_j_temp,3);
+                end
+                
+                %% We have set up the current PType, now do some calculations for it.
+                simoptions_temp.keepoutputasmatrix=1;
+                ValuesOnGrid_ii=EvalFnOnAgentDist_Grid_J(tempfn,CellOverAgeOfParamValues,PolicyValuesPermute_temp,l_daprime_temp,n_a_temp,n_z_temp,a_gridvals_temp,z_gridvals_J_temp);
+                ValuesOnGrid_ii=reshape(ValuesOnGrid_ii,[N_a_temp*N_z_temp*N_j_temp,1]);
+    
+                % StationaryDist_ii=reshape(StationaryDist.(Names_i{ii}),[N_a_temp*N_z_temp*N_j_temp,1]); % Note: does not impose *StationaryDist.ptweights(ii)
+            else
+                FnToEvaluateParamsCell=CreateCellFromParams(Parameters_temp,FnsToEvaluateParamNames);
+                ValuesOnGrid_ii=EvalFnOnAgentDist_Grid(tempfn, FnToEvaluateParamsCell,PolicyValuesPermute_temp,l_daprime_temp,n_a_temp,n_z_temp,a_gridvals_temp,z_gridvals_temp);
+                ValuesOnGrid_ii=reshape(ValuesOnGrid_ii,[N_a_temp*N_z_temp,1]);
+            end
+
+            % Eliminate all the zero-weighted points (this doesn't really save runtime for the exact calculation and often can increase it, but
+            % for the createDigest it slashes the runtime. So since we want it then we may as well do it now.)
+            % temp=logical(StationaryDist_ii~=0);
+            % StationaryDist_ii=StationaryDist_ii(temp);
+            ValuesOnGrid_ii=ValuesOnGrid_ii(temp);
+
+            % I want to use unique to make it easier to put the different agent
+            % ptypes together (as all the matrices are typically smaller).
+            % May as well do it before doing the StatsFromWeightedGrid
+            [SortedValues,~,sortindex]=unique(ValuesOnGrid_ii);
+            SortedWeights=accumarray(sortindex,StationaryDist_ii,[],@sum);
+            
+            %% Use the full ValuesOnGrid_ii and StationaryDist_ii to calculate various statistics for the current PType-FnsToEvaluate (current ii and kk)
+            AllStats.(FnsToEvalNames{ff}).(Names_i{ii})=StatsFromWeightedGrid(SortedValues,SortedWeights,simoptions.npoints,simoptions.nquantiles,simoptions.tolerance,1,simoptions.whichstats); % 1 is presorted
+
+            %% If using conditional restrictions, do those
+            if useCondlRest==1
+                for rr=1:length(CondlRestnFnNames)
+                    RestrictedSortedWeights=accumarray(sortindex,RestrictionStruct_ii(rr).RestrictedStationaryDistVec,[],@sum); % This has already been done to SortedValues, so have to do it to Restricted Agent Dist
+                    AllStats.(CondlRestnFnNames{rr}).(FnsToEvalNames{ff}).(Names_i{ii})=StatsFromWeightedGrid(SortedValues,RestrictedSortedWeights,simoptions.npoints,simoptions.nquantiles,simoptions.tolerance,1,simoptions.whichstats); % 1 is presorted
+                    
+                    % If doing grouped stats, store RestrictedSortedWeights
+                    if simoptions_temp.groupusingtdigest==1
+                        error('Code should never get here (should have thrown an error earlier')
+                    else
+                        if simoptions.ptypestorecpu==1
+                            AllRestrictedWeights.(CondlRestnFnNames{rr}).(FnsToEvalNames{ff})=[AllRestrictedWeights.(CondlRestnFnNames{rr}).(FnsToEvalNames{ff}); gather(RestrictedSortedWeights*restrictedsamplemass(ii,rr))]; %*gather(StationaryDist.ptweights(ii))];
+                        else
+                            AllRestrictedWeights.(CondlRestnFnNames{rr}).(FnsToEvalNames{ff})=[AllRestrictedWeights.(CondlRestnFnNames{rr}).(FnsToEvalNames{ff}); RestrictedSortedWeights*restrictedsamplemass(ii,rr)]; %*StationaryDist.ptweights(ii)];
+                        end
+                        % Note: later once we have all the ii do AllRestrictedWeights.(CondlRestnFnNames{rr}).(FnsToEvalNames{ff}) renormalized by sum(restrictedsamplemass(:,rr))
+                    end
+                end
+            end
+            
+            %% For later, put the mean and std dev in a convenient place
+            if simoptions.whichstats(1)==1
+                MeanVec(ff,ii)=AllStats.(FnsToEvalNames{ff}).(Names_i{ii}).Mean;
+            end
+            if simoptions.whichstats(3)==1
+                StdDevVec(ff,ii)=AllStats.(FnsToEvalNames{ff}).(Names_i{ii}).StdDeviation;
+            end
+            % Do the same with the minimum and maximum
+            if simoptions.whichstats(5)==1
+                minvaluevec(ff,ii)=AllStats.(FnsToEvalNames{ff}).(Names_i{ii}).Minimum;
+                maxvaluevec(ff,ii)=AllStats.(FnsToEvalNames{ff}).(Names_i{ii}).Maximum;
+            end
+            
+            if simoptions_temp.groupusingtdigest==1
+                Cmerge=AllCMerge.(FnsToEvalNames{ff});
+                digestweightsmerge=Alldigestweightsmerge.(FnsToEvalNames{ff});
+
+                %% Create digest (if unique() was not enough to make them small)
+                [C_ii,digestweights_ii,~]=createDigest(SortedValues, SortedWeights,delta,1); % 1 is presorted
+                
+                merge_nsofar2(ff)=merge_nsofar(ff)+length(C_ii);
+                Cmerge(merge_nsofar(ff)+1:merge_nsofar2(ff))=C_ii;
+                digestweightsmerge(merge_nsofar(ff)+1:merge_nsofar2(ff))=digestweights_ii*StationaryDist.ptweights(ii);
+                merge_nsofar(ff)=merge_nsofar2(ff);
+                
+                AllCMerge.(FnsToEvalNames{ff})=Cmerge;
+                Alldigestweightsmerge.(FnsToEvalNames{ff})=digestweightsmerge;
+            else
+                if simoptions.ptypestorecpu==1
+                    AllValues.(FnsToEvalNames{ff})=[AllValues.(FnsToEvalNames{ff}); gather(SortedValues)];
+                    AllWeights.(FnsToEvalNames{ff})=[AllWeights.(FnsToEvalNames{ff}); gather(SortedWeights)*gather(StationaryDist.ptweights(ii))];
+                else
+                    AllValues.(FnsToEvalNames{ff})=[AllValues.(FnsToEvalNames{ff}); SortedValues];
+                    AllWeights.(FnsToEvalNames{ff})=[AllWeights.(FnsToEvalNames{ff}); SortedWeights*StationaryDist.ptweights(ii)];
+                end
+            end
+        end
+    end
+end
+
+
+
+%% Now for the grouped stats, putting the ptypes together
+for ff=1:numFnsToEvaluate % Each of the functions to be evaluated on the grid    
+
+    if simoptions_temp.groupusingtdigest==1
+        Cmerge=AllCMerge.(FnsToEvalNames{ff});
+        digestweightsmerge=Alldigestweightsmerge.(FnsToEvalNames{ff});
+        % Clean off the zeros at the end of Cmerge (that exist because of how we preallocate 'too much' for Cmerge); same for digestweightsmerge.
+        Cmerge=Cmerge(1:merge_nsofar(ff));
+        digestweightsmerge=digestweightsmerge(1:merge_nsofar(ff));
+
+        % Merge the digests
+        [C_kk,digestweights_kk,~]=mergeDigest(Cmerge, digestweightsmerge, delta);
+
+        tempStats=StatsFromWeightedGrid(C_kk,digestweights_kk,simoptions.npoints,simoptions.nquantiles,simoptions.tolerance,1,simoptions.whichstats);
+
+        allstatnames=fieldnames(tempStats);
+    else
+        % Do unique() before we calculate stats
+        [AllValues.(FnsToEvalNames{ff}),~,sortindex]=unique(AllValues.(FnsToEvalNames{ff}));
+        AllWeights.(FnsToEvalNames{ff})=accumarray(sortindex,AllWeights.(FnsToEvalNames{ff}),[],@sum);
+
+        tempStats=StatsFromWeightedGrid(AllValues.(FnsToEvalNames{ff}),AllWeights.(FnsToEvalNames{ff}),simoptions.npoints,simoptions.nquantiles,simoptions.tolerance,1,simoptions.whichstats);
+
+        allstatnames=fieldnames(tempStats);
+        if useCondlRest==1
+            for rr=1:length(CondlRestnFnNames)
+                AllRestrictedWeights.(CondlRestnFnNames{rr}).(FnsToEvalNames{ff})=accumarray(sortindex,AllRestrictedWeights.(CondlRestnFnNames{rr}).(FnsToEvalNames{ff})/sum(restrictedsamplemass(:,rr)),[],@sum);
+                tempStatsRestricted=StatsFromWeightedGrid(AllValues.(FnsToEvalNames{ff}),AllRestrictedWeights.(CondlRestnFnNames{rr}).(FnsToEvalNames{ff}),simoptions.npoints,simoptions.nquantiles,simoptions.tolerance,1,simoptions.whichstats);
+                % Following is necessary as just AllStats=StatsFromWeightedGrid() overwrote the existing subfields
+                rallstatnames=fieldnames(tempStatsRestricted);
+                for aa=1:length(rallstatnames)
+                    AllStats.(CondlRestnFnNames{rr}).(FnsToEvalNames{ff}).(rallstatnames{aa})=tempStatsRestricted.(rallstatnames{aa});
+                end
+                if ff==1
+                    AllStats.(CondlRestnFnNames{rr}).RestrictedSampleMass.TotalAllPTypes=sum(restrictedsamplemass(:,rr));
+                end
+            end
+        end
+    end
+    % Following is necessary as just AllStats=StatsFromWeightedGrid() overwrote the existing subfields
+    % allstatnames=fieldnames(tempStats);
+    for aa=1:length(allstatnames)
+        AllStats.(FnsToEvalNames{ff}).(allstatnames{aa})=tempStats.(allstatnames{aa});
+    end
+    
+
+    % Grouped mean and standard deviation are overwritten on a more direct calculation that does not involve the digests
+    SigmaNxi=sum(FnsAndPTypeIndicator(ff,:).*(StationaryDist.ptweights)'); % The sum of the masses of the relevant types
+    
+    % Mean
+    if simoptions.whichstats(1)==1
+        AllStats.(FnsToEvalNames{ff}).Mean=sum(FnsAndPTypeIndicator(ff,:).*(StationaryDist.ptweights').*MeanVec(ff,:))/SigmaNxi;
+    end
+
+    % Standard Deviation
+    if simoptions.whichstats(3)==1
+        if N_i==1
+            AllStats.(FnsToEvalNames{ff}).StdDeviation=StdDevVec(ff,:);
+        else
+            temp2=zeros(N_i,1);
+            for ii=2:N_i
+                if FnsAndPTypeIndicator(ff,ii)==1
+                    temp=MeanVec(ff,1:(ii-1))-MeanVec(ff,ii); % This bit with temp is just to handle numerical rounding errors where temp evalaulated to negative with order -15
+                    if any(temp<0) && all(temp>10^(-12))
+                        temp=max(temp,0);
+                    end
+                    temp2(ii)=StationaryDist.ptweights(ii)*sum(FnsAndPTypeIndicator(ff,1:(ii-1)).*(StationaryDist.ptweights(1:(ii-1))').*(temp.^2));
+                end
+            end
+            AllStats.(FnsToEvalNames{ff}).StdDeviation=sqrt(sum(FnsAndPTypeIndicator(ff,:).*(StationaryDist.ptweights').*StdDevVec(ff,:))/SigmaNxi + sum(temp2)/(SigmaNxi^2));
+        end
+        AllStats.(FnsToEvalNames{ff}).Variance=(AllStats.(FnsToEvalNames{ff}).StdDeviation)^2;
+    end
+
+    % Similarly, directly calculate the minimum and maximum as this is cleaner (and overwrite these)
+    if simoptions.whichstats(5)==1
+        AllStats.(FnsToEvalNames{ff}).Maximum=max(maxvaluevec(ff,:));
+        AllStats.(FnsToEvalNames{ff}).Minimum=min(minvaluevec(ff,:));
+    end
+end
+
+
+end

--- a/EvaluateFnOnAgentDist/TransPathMixHorz/EvalFnOnTransPath_AggVars_Case1_MixHorz_PType.m
+++ b/EvaluateFnOnAgentDist/TransPathMixHorz/EvalFnOnTransPath_AggVars_Case1_MixHorz_PType.m
@@ -1,0 +1,203 @@
+function AggVarsPath=EvalFnOnTransPath_AggVars_Case1_MixHorz_PType(FnsToEvaluate, AgentDistPath, PolicyPath, PricePath, ParamPath, Parameters, T, n_d, n_a, n_z, N_j, Names_i, d_grid, a_grid,z_grid, transpathoptions, simoptions)
+% AggVars is simple in the sense we can just solve to get AggVars for each ptype and then take the weigthed sum over them
+% This only works because we are just after the mean
+
+AggVarsPath=struct();
+
+%%
+if iscell(Names_i)
+    N_i=length(Names_i);
+else
+    N_i=Names_i; % It is the number of PTypes (which have not been given names)
+    Names_i={'ptype001'};
+    for ii=2:N_i
+        if ii<10
+            Names_i{ii}=['ptype00',num2str(ii)];
+        elseif ii<100
+            Names_i{ii}=['ptype0',num2str(ii)];
+        elseif ii<1000
+            Names_i{ii}=['ptype',num2str(ii)];
+        end
+    end
+end
+
+% Need to initialize the aggregates as zeros, these will then be updated adding on each ptype
+FnNames=fieldnames(FnsToEvaluate);
+for ff=1:length(FnNames)
+    AggVarsPath.(FnNames{ff}).Mean=zeros(1,T);
+end
+
+
+
+
+%% Loop over permanent types
+for ii=1:N_i
+
+    % First set up transpathoptions
+    if exist('transpathoptions','var')
+        transpathoptions_temp=PType_Options(transpathoptions,Names_i,ii);
+        if ~isfield(transpathoptions_temp,'verbose')
+            transpathoptions_temp.verbose=0;
+        end
+        if ~isfield(transpathoptions_temp,'verboseparams')
+            transpathoptions_temp.verboseparams=0;
+        end
+    else
+        transpathoptions_temp.verbose=0;
+        transpathoptions_temp.verboseparams=0;
+    end
+
+    % First set up simoptions
+    if exist('simoptions','var')
+        simoptions_temp=PType_Options(simoptions,Names_i,ii);
+        if ~isfield(simoptions_temp,'verbose')
+            simoptions_temp.verbose=0;
+        end
+        if ~isfield(simoptions_temp,'verboseparams')
+            simoptions_temp.verboseparams=0;
+        end
+        if ~isfield(simoptions_temp,'ptypestorecpu')
+            simoptions_temp.ptypestorecpu=1; % GPU memory is limited, so switch solutions to the cpu
+        end
+    else
+        simoptions_temp.verbose=0;
+        simoptions_temp.verboseparams=0;
+        simoptions_temp.ptypestorecpu=1; % GPU memory is limited, so switch solutions to the cpu
+    end 
+    
+    if simoptions_temp.verbose==1
+        fprintf('Permanent type: %i of %i \n',ii, N_i)
+    end
+           
+    PolicyPath_temp=PolicyPath.(Names_i{ii});
+    AgentDistPath_temp=AgentDistPath.(Names_i{ii});
+
+    
+    % Go through everything which might be dependent on permanent type (PType)
+    % Notice that the way this is coded the grids (etc.) could be either
+    % fixed, or a function (that depends on age, and possibly on permanent
+    % type), or they could be a structure. Only in the case where they are
+    % a structure is there a need to take just a specific part and send
+    % only that to the 'non-PType' version of the command.
+    if isa(n_d,'struct')
+        n_d_temp=n_d.(Names_i{ii});
+    else
+        n_d_temp=n_d;
+    end
+    l_d_temp=length(n_d_temp);
+    if isa(n_a,'struct')
+        n_a_temp=n_a.(Names_i{ii});
+    else
+        n_a_temp=n_a;
+    end
+    l_a_temp=length(n_a_temp);
+    if isa(n_z,'struct')
+        n_z_temp=n_z.(Names_i{ii});
+    else
+        n_z_temp=n_z;
+    end
+    l_z_temp=length(n_z_temp);
+    if isa(N_j,'struct')
+        N_j_temp=N_j.(Names_i{ii});
+    else
+        N_j_temp=N_j;
+    end
+    if isa(d_grid,'struct')
+        d_grid_temp=d_grid.(Names_i{ii});
+    else
+        d_grid_temp=d_grid;
+    end
+    if isa(a_grid,'struct')
+        a_grid_temp=a_grid.(Names_i{ii});
+    else
+        a_grid_temp=a_grid;
+    end
+    if isa(z_grid,'struct')
+        z_grid_temp=z_grid.(Names_i{ii});
+    else
+        z_grid_temp=z_grid;
+    end
+    
+    % Parameters are allowed to be given as structure, or as vector/matrix
+    % (in terms of their dependence on fixed type). So go through each of
+    % these in term.
+    Parameters_temp=Parameters;
+    FullParamNames=fieldnames(Parameters);
+    nFields=length(FullParamNames);
+    for kField=1:nFields
+        if isa(Parameters.(FullParamNames{kField}), 'struct') % Check for permanent type in structure form
+            names=fieldnames(Parameters.(FullParamNames{kField}));
+            for jj=1:length(names)
+                if strcmp(names{jj},Names_i{ii})
+                    Parameters_temp.(FullParamNames{kField})=Parameters.(FullParamNames{kField}).(names{jj});
+                end
+            end
+        elseif any(size(Parameters.(FullParamNames{kField}))==N_i) % Check for permanent type in vector/matrix form.
+            temp=Parameters.(FullParamNames{kField});
+            [~,ptypedim]=max(size(Parameters.(FullParamNames{kField}))==N_i); % Parameters as vector/matrix can be at most two dimensional, figure out which relates to PType.
+            if ptypedim==1
+                Parameters_temp.(FullParamNames{kField})=temp(ii,:);
+            elseif ptypedim==2
+                Parameters_temp.(FullParamNames{kField})=temp(:,ii);
+            end
+        end
+    end
+    
+    if simoptions_temp.verboseparams==1
+        sprintf('Parameter values for the current permanent type')
+        Parameters_temp
+    end
+    
+    % PricePath can include parameters that differ by ptype
+    PricePath_temp=PricePath;
+    PricePathNames=fieldnames(PricePath);
+    for nn=1:length(PricePathNames)
+        if isstruct(PricePath_temp.(PricePathNames{nn}))
+            PricePath_temp.(PricePathNames{nn})=PricePath.(PricePathNames{nn}).(Names_i{ii});
+        elseif any(size(PricePath_temp.(PricePathNames{nn}))==N_i)
+            if size(PricePath_temp.(PricePathNames{nn}),1)==N_i
+                temp=PricePath_temp.(PricePathNames{nn});
+                PricePath_temp.(PricePathNames{nn})=temp(ii,:);
+            elseif size(PricePath_temp.(PricePathNames{nn}),2)==N_i
+                temp=PricePath_temp.(PricePathNames{nn});
+                PricePath_temp.(PricePathNames{nn})=temp(:,ii);
+            end
+        end
+    end
+
+    % ParamPath can include parameters that differ by ptype
+    ParamPath_temp=ParamPath;
+    ParamPathNames=fieldnames(ParamPath);
+    for nn=1:length(ParamPathNames)
+        if isstruct(ParamPath_temp.(ParamPathNames{nn}))
+            ParamPath_temp.(ParamPathNames{nn})=ParamPath.(ParamPathNames{nn}).(Names_i{ii});
+        elseif any(size(ParamPath_temp.(ParamPathNames{nn}))==N_i)
+            if size(ParamPath_temp.(ParamPathNames{nn}),1)==N_i
+                temp=ParamPath_temp.(ParamPathNames{nn});
+                ParamPath_temp.(ParamPathNames{nn})=temp(ii,:);
+            elseif size(ParamPath_temp.(ParamPathNames{nn}),2)==N_i
+                temp=ParamPath_temp.(ParamPathNames{nn});
+                ParamPath_temp.(ParamPathNames{nn})=temp(:,ii);
+            end
+        end
+    end
+
+    [FnsToEvaluate_temp,~, ~,~]=PType_FnsToEvaluate(FnsToEvaluate,Names_i,ii,l_d_temp,l_a_temp,l_z_temp,0);
+
+    if isfinite(N_j_temp)
+        AggVarsPath_ii=EvalFnOnTransPath_AggVars_Case1_FHorz(FnsToEvaluate_temp, AgentDistPath_temp, PolicyPath_temp, PricePath_temp, ParamPath_temp, Parameters_temp, T, n_d_temp, n_a_temp, n_z_temp, N_j_temp, d_grid_temp, a_grid_temp,z_grid_temp, transpathoptions_temp, simoptions_temp);
+    else
+        AggVarsPath_ii=EvalFnOnTransPath_AggVars_InfHorz(FnsToEvaluate_temp, AgentDistPath_temp, PolicyPath_temp, PricePath_temp, ParamPath_temp, Parameters_temp, T, n_d_temp, n_a_temp, n_z_temp, d_grid_temp, a_grid_temp,z_grid_temp, simoptions_temp);
+    end
+
+    FnNames_temp=fieldnames(FnsToEvaluate_temp);
+    for ff=1:length(FnNames_temp)
+        % Keep the ptype-conditional values
+        AggVarsPath.(FnNames_temp{ff}).(Names_i{ii}).Mean=AggVarsPath_ii.(FnNames_temp{ff}).Mean;
+        % And also create the actual aggregate values
+        AggVarsPath.(FnNames_temp{ff}).Mean=AggVarsPath.(FnNames_temp{ff}).Mean+AgentDistPath.ptweights(ii)*AggVarsPath_ii.(FnNames_temp{ff}).Mean;
+    end
+end
+
+
+end

--- a/HeterogeneousAgent/MixHorz/HeteroAgentStationaryEqm_Case1_MixHorz_PType.m
+++ b/HeterogeneousAgent/MixHorz/HeteroAgentStationaryEqm_Case1_MixHorz_PType.m
@@ -1,0 +1,1091 @@
+function varargout=HeteroAgentStationaryEqm_Case1_MixHorz_PType(n_d, n_a, n_z, N_j, Names_i, n_p, pi_z, d_grid, a_grid, z_grid,jequaloneDist, ReturnFn, FnsToEvaluate, GeneralEqmEqns, Parameters, DiscountFactorParamNames, AgeWeightParamNames, PTypeDistParamNames, GEPriceParamNames,heteroagentoptions, simoptions, vfoptions)
+% Outputs: [p_eqm, GeneralEqmConditions]
+% Unless you use n_p and p_grid, in which case [p_eq, p_eqm_index, GeneralEqmConditions]
+%
+% Allows for different permanent (fixed) types of agent. 
+% See ValueFnIter_Case1_MixHorz_PType for general idea.
+%
+% Rest of this description describes how those inputs not used for
+% ValueFnIter_Case1_MixHorz_PType should be set up.
+%
+% jequaloneDist can either be same for all permanent types, or must be passed as a structure.
+% AgeWeightParamNames is either same for all permanent types, or must be passed as a structure.
+%
+%
+%
+% How exactly to handle these differences between permanent (fixed) types
+% is to some extent left to the user. You can, for example, input
+% parameters that differ by permanent type as a vector with different rows f
+% for each type, or as a structure with different fields for each type.
+%
+% Any input that does not depend on the permanent type is just passed in
+% exactly the same form as normal.
+%
+% Names_i can either be a cell containing the 'names' of the different
+% permanent types, or if there are no structures used (just parameters that
+% depend on permanent type and inputted as vectors or matrices as appropriate) 
+% then Names_i can just be the number of permanent types (but does not have to be, can still be names).
+
+
+%% Check 'double fminalgo'
+if exist('heteroagentoptions','var')
+    if isfield(heteroagentoptions,'fminalgo')
+        if length(heteroagentoptions.fminalgo)>1
+            if isfield(heteroagentoptions,'toleranceGEcondns')
+                heteroagentoptions.toleranceGEcondns=heteroagentoptions.toleranceGEcondns.*ones(1,length(heteroagentoptions.fminalgo));
+            else
+                heteroagentoptions.toleranceGEcondns=10^(-4).*ones(1,length(heteroagentoptions.fminalgo)); % Accuracy of general eqm prices
+            end
+            if isfield(heteroagentoptions,'toleranceGEprices')
+                heteroagentoptions.toleranceGEprices=heteroagentoptions.toleranceGEprices.*ones(1,length(heteroagentoptions.fminalgo));
+            else
+                heteroagentoptions.toleranceGEprices=10^(-4).*ones(1,length(heteroagentoptions.fminalgo)); % Accuracy of general eqm prices
+            end
+            temp=heteroagentoptions.fminalgo;
+            temp2=heteroagentoptions.toleranceGEcondns;
+            temp3=heteroagentoptions.toleranceGEprices;
+            heteroagentoptions.fminalgo=heteroagentoptions.fminalgo(1:end-1);
+            heteroagentoptions.toleranceGEcondns=heteroagentoptions.toleranceGEcondns(1:end-1);
+            heteroagentoptions.toleranceGEprices=heteroagentoptions.toleranceGEprices(1:end-1);
+            p_eqm_previous=HeteroAgentStationaryEqm_Case1_MixHorz_PType(n_d, n_a, n_z, N_j, Names_i, n_p, pi_z, d_grid, a_grid, z_grid,jequaloneDist, ReturnFn, FnsToEvaluate, GeneralEqmEqns, Parameters, DiscountFactorParamNames, AgeWeightParamNames, PTypeDistParamNames, GEPriceParamNames,heteroagentoptions, simoptions, vfoptions);
+            for pp=1:length(GEPriceParamNames)
+                Parameters.(GEPriceParamNames{pp})=p_eqm_previous.(GEPriceParamNames{pp});
+            end
+            heteroagentoptions.fminalgo=temp(end);
+            heteroagentoptions.toleranceGEcondns=temp2(end);
+            heteroagentoptions.toleranceGEprices=temp3(end);
+        end
+    end
+end
+
+
+%% Check which options have been used, set all others to defaults 
+N_p=prod(n_p);
+if isempty(n_p)
+    N_p=0;
+end
+
+if exist('heteroagentoptions','var')==0
+    heteroagentoptions.fminalgo=1; % =1 use fminsearch. Main alternatives: =4 is CMA-ES (robust but slow), =5 is shooting (you set update rules), =8 is lsqnonlin() fast but requires Matlab Optimization Toolbox (and often not quite high accuracy of results)
+    heteroagentoptions.multiGEcriterion=1; % How to combine multiple GE condns (default is sum-of-squares)
+    heteroagentoptions.multiGEweights=ones(1,length(fieldnames(GeneralEqmEqns))); % Weights on GECondns, when being combined
+    heteroagentoptions.toleranceGEprices=10^(-4); % Accuracy of general eqm prices
+    heteroagentoptions.toleranceGEcondns=10^(-4); % Accuracy of general eqm eqns
+    heteroagentoptions.maxiter=1000; % maximum iterations of optimization routine
+    heteroagentoptions.GEptype={}; % zeros(1,length(fieldnames(GeneralEqmEqns))); % 1 indicates that this general eqm condition is 'conditional on permanent type' [input should be a cell of names; it gets reformatted internally to be this form]
+    % heteroagentoptions.GEusenames=0; % =1, can use '_name' for Params and AggVars in the general eqm eqns
+    % Constrain parameters
+    heteroagentoptions.constrainpositive={}; % names of parameters to constrained to be positive (gets converted to binary-valued vector below)
+    heteroagentoptions.constrain0to1={}; % names of parameters to constrained to be positive (gets converted to binary-valued vector below)
+    heteroagentoptions.constrainAtoB={}; % names of parameters to constrained to be positive (gets converted to binary-valued vector below)
+    % Verbose settings (feedback)
+    heteroagentoptions.verbose=0; % =1, give feedback
+    heteroagentoptions.verboseaccuracy1=4; % number of decimal places for GEPrices (among others)
+    heteroagentoptions.verboseaccuracy2=6; % number of decimal places for GECondns
+    heteroagentoptions.pricehistory=0; % =1, saves the history of the GEPrices during the convergence
+    % For internal use only
+    % heteroagentoptions.outputGEform=0;
+    heteroagentoptions.outputGEstruct=1; % output GE conditions as a structure (=2 will output as a vector)
+    heteroagentoptions.outputgather=1; % output GE conditions on CPU [some optimization routines only work on CPU, some can handle GPU]
+else
+    if ~isfield(heteroagentoptions,'fminalgo')
+        heteroagentoptions.fminalgo=1; % use fminsearch
+    end
+    if ~isfield(heteroagentoptions,'multiGEcriterion')
+        heteroagentoptions.multiGEcriterion=1;
+    end
+    if ~isfield(heteroagentoptions,'multiGEweights')
+        heteroagentoptions.multiGEweights=ones(1,length(fieldnames(GeneralEqmEqns)));
+    end
+    if ~isfield(heteroagentoptions,'toleranceGEprices')
+        heteroagentoptions.toleranceGEprices=10^(-4); % Accuracy of general eqm prices
+    end
+    if ~isfield(heteroagentoptions,'toleranceGEcondns')
+        heteroagentoptions.toleranceGEcondns=10^(-4); % Accuracy of general eqm prices
+    end
+    if ~isfield(heteroagentoptions,'maxiter')
+        heteroagentoptions.maxiter=200*length(GEPriceParamNames); % =0 just evaluate (rather than solves for) GE condns
+    end
+    if N_p~=0
+        if ~isfield(heteroagentoptions,'p_grid')
+            error('You have set n_p to a non-zero value, but not declared heteroagentoptions.p_grid')
+        end
+    end
+    if ~isfield(heteroagentoptions,'GEptype')
+        heteroagentoptions.GEptype={}; % zeros(1,length(fieldnames(GeneralEqmEqns))); % 1 indicates that this general eqm condition is 'conditional on permanent type' [input should be a cell of names; it gets reformatted internally to be this form]
+    end
+    % if ~isfield(heteroagentoptions,'GEusenames')
+    %     heteroagentoptions.GEusenames=0; % =1, can use '_name' for Params and AggVars in the general eqm eqns
+    % end
+    % Constrain parameters
+    if ~isfield(heteroagentoptions,'constrainpositive')
+        heteroagentoptions.constrainpositive={}; % names of parameters to constrained to be positive (gets converted to binary-valued vector below)
+        % Convert constrained positive p into x=log(p) which is unconstrained.
+        % Then use p=exp(x) in the model.
+    end
+    if ~isfield(heteroagentoptions,'constrain0to1')
+        heteroagentoptions.constrain0to1={}; % names of parameters to constrained to be positive (gets converted to binary-valued vector below)
+        % Handle 0 to 1 constraints by using log-odds function to switch parameter p into unconstrained x, so x=log(p/(1-p))
+        % Then use the logistic-sigmoid p=1/(1+exp(-x)) when evaluating model.
+    end
+    if ~isfield(heteroagentoptions,'constrainAtoB')
+        heteroagentoptions.constrainAtoB={}; % names of parameters to constrained to be positive (gets converted to binary-valued vector below)
+        % Handle A to B constraints by converting y=(p-A)/(B-A) which is 0 to 1, and then treating as constrained 0 to 1 y (so convert to unconstrained x using log-odds function)
+        % Once we have the 0 to 1 y (by converting unconstrained x with the logistic sigmoid function), we convert to p=A+(B-a)*y
+    elseif ~isempty(heteroagentoptions.constrainAtoB)
+        if prod(heteroagentoptions.constrainAtoB)>0
+            if ~isfield(heteroagentoptions,'constrainAtoBlimits')
+                error('You have used heteroagentoptions.constrainAtoB, but are missing heteroagentoptions.constrainAtoBlimits')
+            end
+        end
+    end
+    % Verbose settings (feedback)
+    if ~isfield(heteroagentoptions,'verbose')
+        heteroagentoptions.verbose=0;
+    end
+    if ~isfield(heteroagentoptions,'verboseaccuracy1')
+        heteroagentoptions.verboseaccuracy1=4; % number of decimal places for GEPrices (among others)
+    end
+    if ~isfield(heteroagentoptions,'verboseaccuracy2')
+        heteroagentoptions.verboseaccuracy2=6; % number of decimal places for GECondns
+    end
+    if ~isfield(heteroagentoptions,'pricehistory')
+        heteroagentoptions.pricehistory=0; % =1, saves the history of the GEPrices during the convergence
+    end
+    % For internal use only
+    % heteroagentoptions.outputGEform=0;
+    if ~isfield(heteroagentoptions,'outputGEstruct')
+        heteroagentoptions.outputGEstruct=1; % output GE conditions as a structure (=2 will output as a vector)
+    end
+    if ~isfield(heteroagentoptions,'outputgather')
+        heteroagentoptions.outputgather=1; % output GE conditions on CPU [some optimization routines only work on CPU, some can handle GPU]
+    end
+end
+
+heteroagentoptions.useCustomModelStats=0;
+if isfield(heteroagentoptions,'CustomModelStats')
+    heteroagentoptions.useCustomModelStats=1;
+    % Stash some of the inputs so they can be passed to CustomModelStats later (only things we otherwise overwrite).
+    % So that user gets exactly what they input, not any internally reworked things
+    % In this (PType) context, these assignments are typically structs that each have all the PType fields within them
+    heteroagentoptions.CustomModelStatsInputs.FnsToEvaluate=FnsToEvaluate;
+    heteroagentoptions.CustomModelStatsInputs.n_d=n_d;
+    heteroagentoptions.CustomModelStatsInputs.n_a=n_a;
+    heteroagentoptions.CustomModelStatsInputs.n_z=n_z;
+    heteroagentoptions.CustomModelStatsInputs.N_j=N_j;
+    heteroagentoptions.CustomModelStatsInputs.d_grid=d_grid;
+    heteroagentoptions.CustomModelStatsInputs.a_grid=a_grid;
+    heteroagentoptions.CustomModelStatsInputs.z_grid=z_grid;
+    heteroagentoptions.CustomModelStatsInputs.pi_z=pi_z;
+    heteroagentoptions.CustomModelStatsInputs.vfoptions=vfoptions;
+    heteroagentoptions.CustomModelStatsInputs.simoptions=simoptions;
+end
+
+if heteroagentoptions.fminalgo==0
+    heteroagentoptions.outputGEform=1;
+elseif heteroagentoptions.fminalgo==5
+    heteroagentoptions.outputGEform=1; % Need to output GE condns as a vector when using fminalgo=5
+    heteroagentoptions.outputgather=0; % leave GE condns vector on GPU
+elseif heteroagentoptions.fminalgo==7
+    heteroagentoptions.outputGEform=1; % Need to output GE condns as a vector when using fminalgo=7
+else
+    heteroagentoptions.outputGEform=0;
+end
+
+temp=size(heteroagentoptions.multiGEweights);
+if temp(2)==1 % probably column vector
+    heteroagentoptions.multiGEweights=heteroagentoptions.multiGEweights'; % make row vector
+end
+if length(heteroagentoptions.multiGEweights)~=length(fieldnames(GeneralEqmEqns))
+    error('length(heteroagentoptions.multiGEweights)~=length(fieldnames(GeneralEqmEqns)) (the length of the GE weights is not equal to the number of general eqm equations')
+end
+
+heteroagentoptions.verboseaccuracy1=['	%s: %8.',num2str(heteroagentoptions.verboseaccuracy1),'f \n']; % set up a string
+heteroagentoptions.verboseaccuracy2=['	%s: %8.',num2str(heteroagentoptions.verboseaccuracy2),'f \n']; % set up a string
+
+AggVarNames=fieldnames(FnsToEvaluate);
+nGEprices=length(GEPriceParamNames);
+
+PTypeStructure.numFnsToEvaluate=length(fieldnames(FnsToEvaluate)); % Total number of functions to evaluate
+
+%%
+if iscell(Names_i)
+    N_i=length(Names_i);
+else
+    N_i=Names_i;
+    Names_i={'ptype001'};
+    for ii=2:N_i
+        if ii<10
+            Names_i{ii}=['ptype00',num2str(ii)];
+        elseif ii<100
+            Names_i{ii}=['ptype0',num2str(ii)];
+        elseif ii<1000
+            Names_i{ii}=['ptype',num2str(ii)];
+        end
+    end
+end
+
+%% Reformat heteroagentoptions.GEptype from cell of names into vector of 1s and 0s
+if isempty(heteroagentoptions.GEptype)
+    heteroagentoptions.GEptype=zeros(1,length(fieldnames(GeneralEqmEqns))); % 1 indicates that this general eqm condition is 'conditional on permanent type'
+else
+    temp=heteroagentoptions.GEptype;
+    heteroagentoptions.GEptype=zeros(1,length(fieldnames(GeneralEqmEqns))); % 1 indicates that this general eqm condition is 'conditional on permanent type'
+    GEeqnNames=fieldnames(GeneralEqmEqns);
+    for gg1=1:length(temp)
+        for gg2=1:length(GEeqnNames)
+            if strcmp(temp{gg1},GEeqnNames{gg2})
+                heteroagentoptions.GEptype(gg2)=1;
+            end
+        end
+    end
+end
+if any(heteroagentoptions.GEptype==1)
+    % heteroagentoptions.GEusenames=1; % Use the '_name' as part of handling this (keeps internal code simpler)
+    % Adjust the size of weights for the dependence on ptype
+    temp=heteroagentoptions.multiGEweights;
+    heteroagentoptions.multiGEweights=zeros(1,sum(heteroagentoptions.GEptype==0)+N_i*sum(heteroagentoptions.GEptype==1));
+    gg_c=0;
+    for gg=1:length(fieldnames(GeneralEqmEqns))
+        if heteroagentoptions.GEptype(gg)==0
+            gg_c=gg_c+1;
+            heteroagentoptions.multiGEweights(gg_c)=temp(gg);
+        elseif heteroagentoptions.GEptype(gg)==1
+            for ii=1:N_i
+                gg_c=gg_c+1;
+                heteroagentoptions.multiGEweights(gg_c)=temp(gg);
+            end
+        end
+    end
+    if ~isfield(heteroagentoptions,'GEptype_vectoroutput')
+        heteroagentoptions.GEptype_vectoroutput=0;
+    end
+else
+    heteroagentoptions.GEptype_vectoroutput=0;
+end
+
+%% If using _names, set up the parameters for this
+% Note: I do this before PTypeStructure, which is maybe not the cleanest, but works fine.
+paramnames=fieldnames(Parameters);
+paramnamesptype={};
+paramthatdependsonptype=zeros(1,length(paramnames));
+N_i=length(Names_i);
+for pp=1:length(paramnames)
+    try
+        if isstruct(Parameters.(paramnames{pp})) % parameter depends on ptype as a structure
+            for ii=1:N_i
+                Parameters.([paramnames{pp},'_',Names_i{ii}])=Parameters.(paramnames{pp}).(Names_i{ii});
+            end
+            paramthatdependsonptype(pp)=1;
+            paramnamesptype{sum(paramthatdependsonptype)}=paramnames{pp};
+        elseif any(size(Parameters.(paramnames{pp}))==N_i) % parameter depends on ptype as a vector
+            temp=Parameters.(paramnames{pp});
+            for ii=1:N_i
+                Parameters.([paramnames{pp},'_',Names_i{ii}])=temp(ii);
+            end
+            paramthatdependsonptype(pp)=1;
+            paramnamesptype{sum(paramthatdependsonptype)}=paramnames{pp};
+        end
+        % if not dependent on ptype, nothing to do
+    catch ME
+        % In OLGModels13.m, married couples have kappa_j1 and kappa_j2
+        % parameters, but no kappa_j parameter. kappa_j leads to male and
+        % female vectors, but no married vectors, so nothing to do.
+    end
+end
+
+
+%%
+% PTypeStructure contains everything for the different permanent types.
+% There are two fields, PTypeStructure.Names_i, and PTypeStructure.N_i.
+% Then everything else is stored in, eg., PTypeStructure.ptype004, for the
+% 4th permanent type.
+%
+% Code implicitly assumes that simoptions.agedependentgrids contains the same as
+% vfoptions.agedependentgrids. Seems likely that you would always want this
+% to be the case anyway.
+
+% PTypeStructure.Names_i never really gets used. Just makes things easier
+% to read when you are looking at PTypeStructure (which only ever exists
+% internally to the VFI Toolkit)
+PTypeStructure.Names_i=Names_i;
+PTypeStructure.N_i=N_i;
+
+% If jequaloneDist is not a structure, then we deal with it here (as it may be dependent on PType, and we will turn it into a structure if it is)
+if ~isstruct(jequaloneDist)
+    if ~exist("simoptions","var")
+        error('You must input simoptions to HeteroAgentStationaryEqm_Case1_MixHorz_PType when using jequaloneDist as a structure')
+    end
+    [jequaloneDist,~,Parameters]=jequaloneDist_PType(jequaloneDist,Parameters,simoptions,n_a,n_z,PTypeStructure.N_i,PTypeStructure.Names_i,PTypeDistParamNames,1);
+end
+
+%%
+for ii=1:PTypeStructure.N_i
+
+    iistr=PTypeStructure.Names_i{ii};
+    PTypeStructure.iistr{ii}=iistr;
+    
+    if exist('vfoptions','var') % vfoptions.verbose (allowed to depend on permanent type)
+        if ~isempty(vfoptions)
+            PTypeStructure.(iistr).vfoptions=PType_Options(vfoptions,Names_i,ii); % some vfoptions will differ by permanent type, will clean these up as we go before they are passed
+        else
+            PTypeStructure.(iistr).simoptions.verbose=0;
+        end
+    else
+        PTypeStructure.(iistr).vfoptions.verbose=0;
+    end
+    
+    if exist('simoptions','var') % simoptions.verbose (allowed to depend on permanent type)
+        if ~isempty(simoptions)
+            PTypeStructure.(iistr).simoptions=PType_Options(simoptions,Names_i,ii); % some simoptions will differ by permanent type, will clean these up as we go before they are passed
+        else
+            PTypeStructure.(iistr).simoptions.verbose=0;
+        end
+    else
+        PTypeStructure.(iistr).simoptions.verbose=0;
+    end
+    
+    PTypeStructure.(iistr).simoptions.outputasstructure=0; % Used by AggVars (in heteroagent subfn)
+
+    if heteroagentoptions.verbose==1
+        fprintf('Setting up, Permanent type: %i of %i \n',ii, PTypeStructure.N_i)
+    end
+
+    % Go through everything which might be dependent on permanent type (PType)
+    % Notice that the way this is coded the grids (etc.) could be either
+    % fixed, or a function (that depends on age, and possibly on permanent
+    % type), or they could be a structure. Only in the case where they are
+    % a structure is there a need to take just a specific part and send
+    % only that to the 'non-PType' version of the command.
+    
+    % Start with those that determine whether the current permanent type is finite or
+    % infinite horizon, and whether it is Case 1 or Case 2
+    % Figure out which case is relevant to the current PType. This is done
+    % using N_j which for the current type will evaluate to 'Inf' if it is
+    % infinite horizon and a finite number for any other finite horizon.
+    % First, check if it is a structure, and otherwise just get the
+    % relevant value.
+    
+    % Horizon is determined via N_j
+    if isstruct(N_j)
+        PTypeStructure.(iistr).N_j=N_j.(Names_i{ii});
+    elseif isscalar(N_j)
+        PTypeStructure.(iistr).N_j=N_j;
+    else
+        PTypeStructure.(iistr).N_j=N_j(ii);
+    end
+    
+    if isstruct(n_d)
+        PTypeStructure.(iistr).n_d=n_d.(Names_i{ii});
+    else
+        PTypeStructure.(iistr).n_d=n_d;
+    end
+    if isstruct(n_a)
+        PTypeStructure.(iistr).n_a=n_a.(Names_i{ii});
+    else
+        PTypeStructure.(iistr).n_a=n_a;
+    end
+    if isstruct(n_z)
+        PTypeStructure.(iistr).n_z=n_z.(Names_i{ii});
+    else
+        PTypeStructure.(iistr).n_z=n_z;
+    end
+    
+    if PTypeStructure.(iistr).n_d(1)==0
+        PTypeStructure.(iistr).l_d=0;
+    else
+        PTypeStructure.(iistr).l_d=length(PTypeStructure.(iistr).n_d);
+    end
+    PTypeStructure.(iistr).l_a=length(PTypeStructure.(iistr).n_a);
+    if PTypeStructure.(iistr).n_z(1)==0
+        PTypeStructure.(iistr).l_z=0;
+    else
+        PTypeStructure.(iistr).l_z=length(PTypeStructure.(iistr).n_z);
+    end
+    if isfield(PTypeStructure.(iistr).simoptions,'n_e')
+        PTypeStructure.(iistr).l_e=length(PTypeStructure.(iistr).simoptions.n_e);
+    else
+        PTypeStructure.(iistr).l_e=0;
+    end
+    
+    if isstruct(d_grid)
+        PTypeStructure.(iistr).d_grid=d_grid.(Names_i{ii});
+    else
+        PTypeStructure.(iistr).d_grid=d_grid;
+    end
+    if isstruct(a_grid)
+        PTypeStructure.(iistr).a_grid=a_grid.(Names_i{ii});
+    else
+        PTypeStructure.(iistr).a_grid=a_grid;
+    end
+    
+    %% Parameter Structure
+    % Parameters are allowed to be given as structure, or as vector/matrix
+    % (in terms of their dependence on permanent type). So go through each of
+    % these in term.
+    % ie. Parameters.alpha=[0;1]; or Parameters.alpha.ptype1=0; Parameters.alpha.ptype2=1;
+    PTypeStructure.(iistr).Parameters=Parameters;
+    FullParamNames=fieldnames(Parameters); % all the different parameters
+    nFields=length(FullParamNames);
+    for kField=1:nFields
+        if isa(Parameters.(FullParamNames{kField}), 'struct') % Check the current parameter for permanent type in structure form
+            % Check if this parameter is used for the current permanent type (it may or may not be, some parameters are only used be a subset of permanent types)
+            if isfield(Parameters.(FullParamNames{kField}),Names_i{ii})
+                PTypeStructure.(iistr).Parameters.(FullParamNames{kField})=Parameters.(FullParamNames{kField}).(Names_i{ii});
+            end
+        elseif sum(size(Parameters.(FullParamNames{kField}))==PTypeStructure.N_i)>=1 % Check for permanent type in vector/matrix form.
+            temp=Parameters.(FullParamNames{kField});
+            [~,ptypedim]=max(size(Parameters.(FullParamNames{kField}))==PTypeStructure.N_i); % Parameters as vector/matrix can be at most two dimensional, figure out which relates to PType, it should be the row dimension, if it is not then give a warning.
+            if ptypedim==1
+                PTypeStructure.(iistr).Parameters.(FullParamNames{kField})=temp(ii,:);
+            elseif ptypedim==2
+                PTypeStructure.(iistr).Parameters.(FullParamNames{kField})=temp(:,ii);
+            end
+        end
+    end
+
+    %% Set up exogenous shock grids now (so they can then just be reused every time)
+
+    if isstruct(z_grid)
+        PTypeStructure.(iistr).z_grid=z_grid.(Names_i{ii});
+    else
+        % If the last dimension is of length N_i, this indicates dependence on ptype
+        nn=size(z_grid,ndims(z_grid));
+        if nn==N_i
+            otherdims = repmat({':'},1,ndims(z_grid)-1);
+            PTypeStructure.(iistr).z_grid=z_grid(otherdims{:},ii);
+        else
+            PTypeStructure.(iistr).z_grid=z_grid;
+        end
+    end
+    if isstruct(pi_z)
+        PTypeStructure.(iistr).pi_z=pi_z.(Names_i{ii});
+    else
+        % If the last dimension is of length N_i, this indicates dependence on ptype
+        nn=size(pi_z,ndims(pi_z));
+        if nn==N_i
+            otherdims = repmat({':'},1,ndims(pi_z)-1);
+            PTypeStructure.(iistr).pi_z=pi_z(otherdims{:},ii);
+        else
+            PTypeStructure.(iistr).pi_z=pi_z;
+        end
+    end
+
+    %% Parameter Structure
+    % Parameters are allowed to be given as structure, or as vector/matrix
+    % (in terms of their dependence on permanent type). So go through each of
+    % these in term.
+    % ie. Parameters.alpha=[0;1]; or Parameters.alpha.ptype1=0; Parameters.alpha.ptype2=1;
+    % Need to establish this in PTypeStructure before we use it below.
+    PTypeStructure.(iistr).Parameters=Parameters;
+    FullParamNames=fieldnames(Parameters); % all the different parameters
+    nFields=length(FullParamNames);
+    for kField=1:nFields
+        if isa(Parameters.(FullParamNames{kField}), 'struct') % Check the current parameter for permanent type in structure form
+            % Check if this parameter is used for the current permanent type (it may or may not be, some parameters are only used be a subset of permanent types)
+            if isfield(Parameters.(FullParamNames{kField}),Names_i{ii})
+                PTypeStructure.(iistr).Parameters.(FullParamNames{kField})=Parameters.(FullParamNames{kField}).(Names_i{ii});
+            end
+        elseif sum(size(Parameters.(FullParamNames{kField}))==PTypeStructure.N_i)>=1 % Check for permanent type in vector/matrix form.
+            temp=Parameters.(FullParamNames{kField});
+            [~,ptypedim]=max(size(Parameters.(FullParamNames{kField}))==PTypeStructure.N_i); % Parameters as vector/matrix can be at most two dimensional, figure out which relates to PType, it should be the row dimension, if it is not then give a warning.
+            if ptypedim==1
+                PTypeStructure.(iistr).Parameters.(FullParamNames{kField})=temp(ii,:);
+            elseif ptypedim==2
+                PTypeStructure.(iistr).Parameters.(FullParamNames{kField})=temp(:,ii);
+            end
+        end
+    end
+
+    % Check if using ExogShockFn or EiidShockFn, and if so, do these use a parameter that is being determined in general eqm
+    heteroagentoptions.gridsinGE(ii)=0;
+    if isfield(PTypeStructure.(iistr).vfoptions,'ExogShockFn')
+        tempExogShockFnParamNames=getAnonymousFnInputNames(PTypeStructure.(iistr).vfoptions.ExogShockFn);
+        % can just leave action space in here as we only use it to see if GEPriceParamNames is part of it
+        if ~isempty(intersect(tempExogShockFnParamNames,GEPriceParamNames))
+            heteroagentoptions.gridsinGE(ii)=1;
+        end
+    end
+    if isfield(PTypeStructure.(iistr).vfoptions,'EiidShockFn')
+        tempEiidShockFnParamNames=getAnonymousFnInputNames(PTypeStructure.(iistr).vfoptions.EiidShockFn);
+        % can just leave action space in here as we only use it to see if GEPriceParamNames is part of it
+        if ~isempty(intersect(tempEiidShockFnParamNames,GEPriceParamNames))
+            heteroagentoptions.gridsinGE(ii)=1;
+        end
+    end
+
+    % Switch over to joint-grids
+    if isfinite(PTypeStructure.(iistr).N_j) % FHorz
+        % If z (and e) are not determined in GE, then compute z_gridvals_J and pi_z_J now (and e_gridvals_J and pi_e_J)
+        if heteroagentoptions.gridsinGE(ii)==0
+            [PTypeStructure.(iistr).z_gridvals_J, PTypeStructure.(iistr).pi_z_J, PTypeStructure.(iistr).vfoptions]=ExogShockSetup_FHorz(PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).z_grid,PTypeStructure.(iistr).pi_z,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).Parameters,PTypeStructure.(iistr).vfoptions,3);
+            % Note: these are actually z_gridvals_J and pi_z_J
+            PTypeStructure.(iistr).simoptions.e_gridvals_J=PTypeStructure.(iistr).vfoptions.e_gridvals_J; % Note, will be [] if no e
+            PTypeStructure.(iistr).simoptions.pi_e_J=PTypeStructure.(iistr).vfoptions.pi_e_J; % Note, will be [] if no e
+        else
+            % % Create placeholders, as these will need to be created in general eqm since they depend on General eqm parameters
+            % PTypeStructure.(iistr).z_gridvals_J=[];
+            % PTypeStructure.(iistr).pi_z_J=[];
+        end
+        PTypeStructure.(iistr)=rmfield(PTypeStructure.(iistr),'z_grid'); % Should not be used, as now have z_gridvals_J
+        PTypeStructure.(iistr)=rmfield(PTypeStructure.(iistr),'pi_z'); % Should not be used, as now have pi_z_J
+    else % InfHorz
+        if heteroagentoptions.gridsinGE(ii)==0
+            [PTypeStructure.(iistr).z_gridvals, PTypeStructure.(iistr).pi_z, PTypeStructure.(iistr).vfoptions]=ExogShockSetup_InfHorz(PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).z_grid,PTypeStructure.(iistr).pi_z,PTypeStructure.(iistr).Parameters,PTypeStructure.(iistr).vfoptions,3);
+            PTypeStructure.(iistr).simoptions.e_gridvals=PTypeStructure.(iistr).vfoptions.e_gridvals; % Note, will be [] if no e
+            PTypeStructure.(iistr).simoptions.pi_e=PTypeStructure.(iistr).vfoptions.pi_e; % Note, will be [] if no e
+        else
+            % % Create placeholders, as these will need to be created in general eqm since they depend on General eqm parameters
+            % PTypeStructure.(iistr).z_gridvals=[];
+            % PTypeStructure.(iistr).pi_z=[];
+        end
+    end
+    % Regardless of whether they are done here of in _subfn, they will be precomputed by the time we get to the value fn, staty dist, etc. So
+    PTypeStructure.(iistr).vfoptions.alreadygridvals=1;
+    PTypeStructure.(iistr).simoptions.alreadygridvals=1;
+
+    % Now do same for semi-exogenous state if that is being used
+    heteroagentoptions.gridsinGE_semiexo(ii)=0;
+    if isfield(PTypeStructure.(iistr).vfoptions,'n_semiz')
+        heteroagentoptions.gridsinGE_semiexo(ii)=0;
+        if isfield(PTypeStructure.(iistr).vfoptions,'SemiExoShockFn')
+            tempExogShockFnParamNames=getAnonymousFnInputNames(PTypeStructure.(iistr).vfoptions.SemiExoShockFn);
+            % can just leave action space in here as we only use it to see if GEPriceParamNames is part of it
+            if ~isempty(intersect(tempExogShockFnParamNames,GEPriceParamNames))
+                heteroagentoptions.gridsinGE_semiexo(ii)=1;
+            end
+        end
+
+        % Check if using semi_grid and pi_semiz with last dimension being ptype
+        if size(PTypeStructure.(iistr).vfoptions.semiz_grid,ndims(PTypeStructure.(iistr).vfoptions.semiz_grid))==N_i
+            otherdims = repmat({':'},1,ndims(PTypeStructure.(iistr).vfoptions.semiz_grid)-1);
+            PTypeStructure.(iistr).vfoptions.semiz_grid=PTypeStructure.(iistr).vfoptions.semiz_grid(otherdims{:},ii);
+        end
+        if isfield(PTypeStructure.(iistr).vfoptions,'pi_semiz')
+            if size(PTypeStructure.(iistr).vfoptions.pi_semiz,ndims(PTypeStructure.(iistr).vfoptions.pi_semiz))==N_i
+                otherdims = repmat({':'},1,ndims(PTypeStructure.(iistr).vfoptions.pi_semiz)-1);
+                PTypeStructure.(iistr).vfoptions.pi_semiz=PTypeStructure.(iistr).vfoptions.pi_semiz(otherdims{:},ii);
+            end
+        end
+        
+        if isfinite(PTypeStructure.(iistr).N_j) % FHorz
+            PTypeStructure.(iistr).vfoptions=SemiExogShockSetup_FHorz(PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).d_grid,PTypeStructure.(iistr).Parameters,PTypeStructure.(iistr).vfoptions,2,3);
+            PTypeStructure.(iistr).simoptions.semiz_gridvals_J=PTypeStructure.(iistr).vfoptions.semiz_gridvals_J;
+            PTypeStructure.(iistr).simoptions.pi_semiz_J=PTypeStructure.(iistr).vfoptions.pi_semiz_J;
+        else
+            error('Semi-exogenous state not yet implemented for InfHorz')
+        end
+        % Regardless of whether they are done here of in _subfn, they will be precomputed by the time we get to the value fn, staty dist, etc. So
+        PTypeStructure.(iistr).vfoptions.alreadygridvals_semiexo=1;
+        PTypeStructure.(iistr).simoptions.alreadygridvals_semiexo=1;        
+    end
+        
+
+    %% DiscountFactor and ReturnFn
+    % The parameter names can be made to depend on the permanent-type
+    if isstruct(DiscountFactorParamNames)
+        PTypeStructure.(iistr).DiscountFactorParamNames=DiscountFactorParamNames.(Names_i{ii});
+    else
+        PTypeStructure.(iistr).DiscountFactorParamNames=DiscountFactorParamNames;
+    end
+
+    PTypeStructure.(iistr).ReturnFn=ReturnFn;
+    if isa(ReturnFn,'struct')
+        PTypeStructure.(iistr).ReturnFn=ReturnFn.(Names_i{ii});
+    end
+    PTypeStructure.(iistr).ReturnFnParamNames=ReturnFnParamNamesFn(PTypeStructure.(iistr).ReturnFn,PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).vfoptions,PTypeStructure.(iistr).Parameters);
+    
+    %% jequaloneDist and AgeWeightsParamNames
+    if isfinite(PTypeStructure.(iistr).N_j) % FHorz
+        if isstruct(jequaloneDist)
+            if isfield(jequaloneDist,PTypeStructure.Names_i{ii})
+                if isa(jequaloneDist, 'function_handle')
+                    [PTypeStructure.(iistr).jequaloneDist,~,PTypeStructure.(iistr).Parameters]=jequaloneDist_PType(jequaloneDist.(iistr),PTypeStructure.(iistr).Parameters,PTypeStructure.(iistr).simoptions,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).N_i,PTypeStructure.(iistr).PTypeDistParamNames,0);
+                else
+                    PTypeStructure.(iistr).jequaloneDist=jequaloneDist.(PTypeStructure.Names_i{ii});
+                end
+            else
+                error(['You must input jequaloneDist for permanent type ', PTypeStructure.Names_i{ii}, ' \n'])
+            end
+        else
+            PTypeStructure.(iistr).jequaloneDist=jequaloneDist;
+        end
+
+        PTypeStructure.(iistr).AgeWeightParamNames=AgeWeightParamNames;
+        if isstruct(AgeWeightParamNames)
+            if isfield(AgeWeightParamNames,Names_i{ii})
+                PTypeStructure.(iistr).AgeWeightParamNames=AgeWeightParamNames.(Names_i{ii});
+            else
+                error(['You must input AgeWeightParamNames for permanent type ', Names_i{ii}, ' \n'])
+            end
+        end
+    end
+
+    %% FnsToEvaluate
+    % Figure out which functions are actually relevant to the present PType. Only the relevant ones need to be evaluated.
+    % The dependence of FnsToEvaluate and FnsToEvaluateFnParamNames are necessarily the same.
+    % Allows for FnsToEvaluate as structure.
+    l_d_temp=PTypeStructure.(iistr).l_d;
+    l_a_temp=PTypeStructure.(iistr).l_a;
+    l_z_temp=PTypeStructure.(iistr).l_z+PTypeStructure.(iistr).l_e;  
+    [FnsToEvaluate_temp,FnsToEvaluateParamNames_temp, WhichFnsForCurrentPType,FnsAndPTypeIndicator_ii]=PType_FnsToEvaluate(FnsToEvaluate,Names_i,ii,l_d_temp,l_a_temp,l_z_temp,0);
+    PTypeStructure.(iistr).FnsToEvaluate=FnsToEvaluate_temp;
+    PTypeStructure.(iistr).FnsToEvaluateParamNames=FnsToEvaluateParamNames_temp;
+    PTypeStructure.(iistr).WhichFnsForCurrentPType=WhichFnsForCurrentPType;
+    PTypeStructure.(iistr).FnsAndPTypeIndicator_ii=FnsAndPTypeIndicator_ii;
+    
+    %% PType masses
+    if isa(PTypeDistParamNames, 'array')
+        PTypeStructure.(iistr).PTypeWeight=PTypeDistParamNames(ii);
+    else
+        PTypeStructure.(iistr).PTypeWeight=PTypeStructure.(iistr).Parameters.(PTypeDistParamNames{1}); % Don't need '.(Names_i{ii}' as this was already done when putting it into PTypeStrucutre, and here I take it straing from PTypeStructure.(iistr).Parameters rather than from Parameters itself.
+    end
+    % Ptype masses
+    PTypeStructure.ptweights(ii,1)=PTypeStructure.(iistr).Parameters.(PTypeDistParamNames{1});
+end
+
+
+
+%% If using intermediateEqns, switch from structure to cell setup
+AggVarNames_mod=AggVarNames; % AggVarNames_mod is used to check which inputs need to depend on ptype for things that are done by ptype
+
+heteroagentoptions.useintermediateEqns=0;
+if isfield(heteroagentoptions,'intermediateEqns')
+    heteroagentoptions.useintermediateEqns=1;
+    intEqnNames=fieldnames(heteroagentoptions.intermediateEqns);
+    nIntEqns=length(intEqnNames);
+
+    if isfield(heteroagentoptions,'intermediateEqnsptype')
+        temp=heteroagentoptions.intermediateEqnsptype;
+        heteroagentoptions.intermediateEqnsptype=zeros(1,nIntEqns); % 1 indicates that this intermediate eqn is 'conditional on permanent type'
+        for gg1=1:length(temp)
+            for gg2=1:length(intEqnNames)
+                if strcmp(temp{gg1},intEqnNames{gg2})
+                    heteroagentoptions.intermediateEqnsptype(gg2)=1;
+                end
+            end
+        end
+    else
+        heteroagentoptions.intermediateEqnsptype=zeros(1,nIntEqns); % 1 indicates that this intermediate eqn is 'conditional on permanent type'
+    end
+    
+    heteroagentoptions.intermediateEqnsCell=cell(1,nIntEqns);
+    gg_c=0;
+    for gg=1:nIntEqns
+        intEqnnames_gg=intEqnNames{gg};
+        temp=getAnonymousFnInputNames(heteroagentoptions.intermediateEqns.(intEqnNames{gg}));
+        if heteroagentoptions.intermediateEqnsptype(gg)==1
+            AggVarNames_mod{length(AggVarNames_mod)+1}=intEqnNames{gg}; % add to AggVarNames_mod in case used as input later
+
+            for ii=1:N_i
+                temp_ii=temp;
+                gg_c=gg_c+1;
+                for tt=1:length(temp_ii)
+                    % Need to check if it is in AggVarNames_mod, in which case use '_name'
+                    if any(strcmp(AggVarNames_mod,temp_ii{tt}))
+                        for aa=1:length(AggVarNames_mod)
+                            if strcmp(AggVarNames_mod{aa},temp_ii{tt})
+                                temp_ii{tt}=[temp_ii{tt},'_',Names_i{ii}]; % use the '_name' for the AggVar inputs
+                            end
+                        end
+                    end
+                    % Need to check if it a parameter that depends on ptype, in which case use '_name'
+                    if any(strcmp(paramnamesptype,temp_ii{tt}))
+                        for pp=1:length(paramnamesptype)
+                            if strcmp(paramnamesptype{pp},temp_ii{tt})
+                                temp_ii{tt}=[temp_ii{tt},'_',Names_i{ii}]; % use the '_name' for the AggVar inputs
+                            end
+                        end
+                    end
+                end
+                heteroagentoptions.intermediateEqnParamNames(gg_c).Names=temp_ii;
+            end
+        else
+            gg_c=gg_c+1;
+            heteroagentoptions.intermediateEqnParamNames(gg_c).Names=temp;
+
+            % check if it is an _name, in which case need to put it into AggVarNames_mod so that it gets handled correctly if it is used as an input later
+            checkunderscorename=0;
+            for ii=1:N_i
+                lname=length(Names_i{ii});
+                if length(intEqnnames_gg)>lname+1 % only check if intEqnnames_gg is long enough to be possible
+                    if strcmp(intEqnnames_gg(end-lname:end),['_',Names_i{ii}])
+                        % E.g., creates Parameters.r.ptype001 from Parameters.r_ptype001
+                        checkunderscorename=checkunderscorename+1;
+                        intEqnNames_ggmod=intEqnnames_gg(1:end-lname-1);
+                    end
+                end
+            end
+            if checkunderscorename==1
+                if ~any(strcmp(AggVarNames_mod,intEqnNames_ggmod))
+                    AggVarNames_mod{length(AggVarNames_mod)+1}=intEqnNames_ggmod; % add to AggVarNames_mod in case used as input later
+                end
+            end
+        end
+        heteroagentoptions.intermediateEqnsCell{gg}=heteroagentoptions.intermediateEqns.(intEqnNames{gg});        
+    end
+    % Now:
+    %  heteroagentoptions.intermediateEqns is still the structure
+    %  heteroagentoptions.intermediateEqnsCell is cell
+    %  heteroagentoptions.intermediateEqnParamNames(gg_c).Names contains the names
+    % Note: 
+    % intermediateEqnParamNames is based on gg_c, so that they can differ when using by-ptype in which case they use '_name'
+
+end
+
+
+
+%% GE eqns, switch from structure to cell setup
+GEeqnNames=fieldnames(GeneralEqmEqns);
+nGeneralEqmEqns=length(GEeqnNames);
+
+GeneralEqmEqnsCell=cell(1,nGeneralEqmEqns);
+gg_c=0;
+for gg=1:nGeneralEqmEqns
+    temp=getAnonymousFnInputNames(GeneralEqmEqns.(GEeqnNames{gg}));
+    if heteroagentoptions.GEptype(gg)==1
+        for ii=1:N_i
+            temp_ii=temp;
+            gg_c=gg_c+1;
+            for tt=1:length(temp_ii)
+                % Need to check if it is in AggVarNames_mod, in which case use '_name'
+                if any(strcmp(AggVarNames_mod,temp_ii{tt}))
+                    for aa=1:length(AggVarNames_mod)
+                        if strcmp(AggVarNames_mod{aa},temp_ii{tt})
+                            temp_ii{tt}=[temp_ii{tt},'_',Names_i{ii}]; % use the '_name' for the AggVar inputs
+                        end
+                    end
+                end
+                % Need to check if it a parameter that depends on ptype, in which case use '_name'
+                if any(strcmp(paramnamesptype,temp_ii{tt}))
+                    for pp=1:length(paramnamesptype)
+                        if strcmp(paramnamesptype{pp},temp_ii{tt})
+                            temp_ii{tt}=[temp_ii{tt},'_',Names_i{ii}]; % use the '_name' for the AggVar inputs
+                        end
+                    end
+                end
+            end
+            GeneralEqmEqnParamNames(gg_c).Names=temp_ii;
+        end
+    else
+        gg_c=gg_c+1;
+        GeneralEqmEqnParamNames(gg_c).Names=temp;
+    end
+    GeneralEqmEqnsCell{gg}=GeneralEqmEqns.(GEeqnNames{gg});
+end
+% Now: 
+%  GeneralEqmEqns is still the structure
+%  GeneralEqmEqnsCell is cell
+%  GeneralEqmEqnParamNames(gg_c).Names contains the names
+% Note: 
+% GeneralEqmEqnParamNames is based on gg_c, so that they can differ when using by-ptype in which case they use '_name'
+
+
+%% Permit that some GEPriceParamNames might depend on PType
+GEparamsvec0=[]; % column vector
+GEpriceindexes=zeros(nGEprices,1);
+GEprice_ptype=zeros(nGEprices,1);
+for pp=1:nGEprices
+    if isstruct(Parameters.(GEPriceParamNames{pp}))
+        for ii=1:PTypeStructure.N_i
+            iistr=PTypeStructure.Names_i{ii};
+            GEparamsvec0=[GEparamsvec0; gather(Parameters.(GEPriceParamNames{pp}).(iistr))]; % reshape()' is making sure it is a row vector
+        end
+        GEpriceindexes(pp)=PTypeStructure.N_i;
+        GEprice_ptype(pp)=1;
+    else
+        GEparamsvec0=[GEparamsvec0;reshape(gather(Parameters.(GEPriceParamNames{pp})),[],1)]; % reshape() is making sure it is a column vector
+        GEpriceindexes(pp)=length(Parameters.(GEPriceParamNames{pp}));
+        if length(Parameters.(GEPriceParamNames{pp}))>1
+            GEprice_ptype(pp)=1;
+        end
+    end
+end
+GEpriceindexesB=[0; cumsum(GEpriceindexes)]; % unfortunately I have indexes set up different for GE and Calib, and transforming params follows calib
+GEpriceindexes=[[1; 1+cumsum(GEpriceindexes(1:end-1))],cumsum(GEpriceindexes)];
+
+% If the parameter is constrained in some way then we need to transform it
+[GEparamsvec0,heteroagentoptions]=ParameterConstraints_TransformParamsToUnconstrained(GEparamsvec0,GEpriceindexesB,GEPriceParamNames,heteroagentoptions,1);
+% Also converts the constraints info in estimoptions to be a vector rather than by name.
+
+
+% If you are saving the price history, preallocate for this
+if heteroagentoptions.pricehistory==1
+    GEpricepath=zeros(length(GEparamsvec0),heteroagentoptions.maxiter);
+    GEcondnpath=zeros(length(fieldnames(GeneralEqmEqns)),heteroagentoptions.maxiter);  % Note: this cannot yet handle ptype dependence
+    itercount=0;
+    save pricehistory.mat GEpricepath GEcondnpath itercount
+end
+
+%% Have now finished creating PTypeStructure. Time to do the actual finding the HeteroAgentStationaryEqm:
+
+
+%%
+if heteroagentoptions.maxiter>0 % Can use heteroagentoptions.maxiter=0 to just evaluate the current general eqm eqns
+
+    %%  Otherwise, use fminsearch to find the general equilibrium
+    if all(heteroagentoptions.GEptype==0)
+        if heteroagentoptions.fminalgo~=8 && heteroagentoptions.fminalgo~=3
+            GeneralEqmConditionsFnOpt=@(p) HeteroAgentStationaryEqm_Case1_MixHorz_PType_subfn(p, PTypeStructure, Parameters, GeneralEqmEqnsCell, GeneralEqmEqnParamNames, GEPriceParamNames, GEeqnNames, AggVarNames, nGEprices,heteroagentoptions);
+        elseif heteroagentoptions.fminalgo==3
+            heteroagentoptions.outputGEform=1; % vector
+            GeneralEqmConditionsFnOpt=@(p) HeteroAgentStationaryEqm_Case1_MixHorz_PType_subfn(p, PTypeStructure, Parameters, GeneralEqmEqnsCell, GeneralEqmEqnParamNames, GEPriceParamNames, GEeqnNames, AggVarNames, nGEprices,heteroagentoptions);
+        elseif heteroagentoptions.fminalgo==8
+            heteroagentoptions.outputGEform=1; % vector
+            weightsbackup=heteroagentoptions.multiGEweights;
+            heteroagentoptions.multiGEweights=sqrt(heteroagentoptions.multiGEweights); % To use a weighting matrix in lsqnonlin(), we work with the square-roots of the weights
+            GeneralEqmConditionsFnOpt=@(p) HeteroAgentStationaryEqm_Case1_MixHorz_PType_subfn(p, PTypeStructure, Parameters, GeneralEqmEqnsCell, GeneralEqmEqnParamNames, GEPriceParamNames, GEeqnNames, AggVarNames, nGEprices,heteroagentoptions);
+            heteroagentoptions.multiGEweights=weightsbackup; % change it back now that we have set up CalibrateLifeCycleModel_objectivefn()
+        end
+    else % some GE condns depend on ptype
+        if heteroagentoptions.fminalgo~=8 && heteroagentoptions.fminalgo~=3
+            GeneralEqmConditionsFnOpt=@(p) HeteroAgentStationaryEqm_Case1_MixHorz_PType_GEptype_subfn(p, PTypeStructure, Parameters, GeneralEqmEqns, GeneralEqmEqnsCell, GeneralEqmEqnParamNames, GEPriceParamNames,AggVarNames,nGEprices,GEpriceindexes,GEprice_ptype,heteroagentoptions);
+        elseif heteroagentoptions.fminalgo==3
+            heteroagentoptions.outputGEform=1; % vector
+            GeneralEqmConditionsFnOpt=@(p) HeteroAgentStationaryEqm_Case1_MixHorz_PType_GEptype_subfn(p, PTypeStructure, Parameters, GeneralEqmEqns, GeneralEqmEqnsCell, GeneralEqmEqnParamNames, GEPriceParamNames,AggVarNames,nGEprices,GEpriceindexes,GEprice_ptype,heteroagentoptions);
+        elseif heteroagentoptions.fminalgo==8
+            heteroagentoptions.outputGEform=1; % vector
+            weightsbackup=heteroagentoptions.multiGEweights;
+            heteroagentoptions.multiGEweights=sqrt(heteroagentoptions.multiGEweights); % To use a weighting matrix in lsqnonlin(), we work with the square-roots of the weights
+            GeneralEqmConditionsFnOpt=@(p) HeteroAgentStationaryEqm_Case1_MixHorz_PType_GEptype_subfn(p, PTypeStructure, Parameters, GeneralEqmEqns, GeneralEqmEqnsCell, GeneralEqmEqnParamNames, GEPriceParamNames,AggVarNames,nGEprices,GEpriceindexes,GEprice_ptype,heteroagentoptions);
+            heteroagentoptions.multiGEweights=weightsbackup; % change it back now that we have set up CalibrateLifeCycleModel_objectivefn()
+        end
+    end
+
+    % Choosing algorithm for the optimization problem
+    % https://au.mathworks.com/help/optim/ug/choosing-the-algorithm.html#bscj42s
+    minoptions = optimset('TolX',heteroagentoptions.toleranceGEprices,'TolFun',heteroagentoptions.toleranceGEcondns,'MaxFunEvals',heteroagentoptions.maxiter);
+    p_eqm_index=nan; % If not using p_grid then this is irrelevant/useless
+    if N_p~=0 % Solving on p_grid
+        p_gridvals=CreateGridvals(n_p,heteroagentoptions.p_grid,1);
+        GeneralEqmConditions=zeros(size(p_gridvals)); %
+        for pp_c=1:N_p
+            pvec=p_gridvals(pp_c,:);
+            GeneralEqmConditions(pp_c,:)=GeneralEqmConditionsFnOpt(pvec);
+        end
+        [~,p_eqm_index]=max(sum(GeneralEqmConditions.^2,2));
+        p_eqm_vec=p_gridvals(p_eqm_index,:);
+        heteroagentoptions.outputGEstruct=0; % Output the GeneralEqmConditions as a matrix
+    elseif heteroagentoptions.fminalgo==0 % fzero, is based on root-finding so it needs just the vector of GEcondns, not the sum-of-squares (it is not a minimization routine)
+        [p_eqm_vec,GeneralEqmConditions]=fzero(GeneralEqmConditionsFnOpt,GEparamsvec0,minoptions);
+    elseif heteroagentoptions.fminalgo==1
+        [p_eqm_vec,GeneralEqmConditions]=fminsearch(GeneralEqmConditionsFnOpt,GEparamsvec0,minoptions);
+    elseif heteroagentoptions.fminalgo==2
+        % Use the optimization toolbox so as to take advantage of automatic differentiation
+        z=optimvar('z',length(GEparamsvec0));
+        optimfun=fcn2optimexpr(GeneralEqmConditionsFnOpt, z);
+        prob = optimproblem("Objective",optimfun);
+        z0.z=GEparamsvec0;
+        [sol,GeneralEqmConditions]=solve(prob,z0);
+        p_eqm_vec=sol.z;
+        % Note, doesn't really work as automatic differentiation is only for
+        % supported functions, and the objective here is not a supported function
+    elseif heteroagentoptions.fminalgo==3
+        goal=zeros(length(GEparamsvec0),1);
+        weight=ones(length(GEparamsvec0),1); % I already implement weights via heteroagentoptions
+        [p_eqm_vec,GeneralEqmConditionsVec] = fgoalattain(GeneralEqmConditionsFnOpt,GEparamsvec0,goal,weight);
+        GeneralEqmConditions=sum(abs(GeneralEqmConditionsVec));
+    elseif heteroagentoptions.fminalgo==4 % CMA-ES algorithm (Covariance-Matrix adaptation - Evolutionary Stategy)
+        % https://en.wikipedia.org/wiki/CMA-ES
+        % https://cma-es.github.io/
+        % Code is cmaes.m from: https://cma-es.github.io/cmaes_sourcecode_page.html#matlab
+        if ~isfield(heteroagentoptions,'insigma')
+            % insigma: initial coordinate wise standard deviation(s)
+            heteroagentoptions.insigma=0.3*abs(GEparamsvec0)+0.1*(GEparamsvec0==0); % Set standard deviation to 30% of the initial parameter value itself (cannot input zero, so add 0.1 to any zeros)
+        end
+        if ~isfield(heteroagentoptions,'inopts')
+            % inopts: options struct, see defopts below
+            heteroagentoptions.inopts=[];
+        end
+        if isfield(heteroagentoptions,'toleranceGEcondns')
+            heteroagentoptions.inopts.StopFitness=heteroagentoptions.toleranceGEcondns;
+        end
+        % varargin (unused): arguments passed to objective function
+        if heteroagentoptions.verbose==1
+            disp('VFI Toolkit is using the CMA-ES algorithm, consider giving a cite to: Hansen, N. and S. Kern (2004). Evaluating the CMA Evolution Strategy on Multimodal Test Functions' )
+        end
+    	% This is a minor edit of cmaes, because I want to use 'GeneralEqmConditionsFnOpt' as a function_handle, but the original cmaes code only allows for 'GeneralEqmConditionsFnOpt' as a string
+        [p_eqm_vec,GeneralEqmConditions,counteval,stopflag,out,bestever] = cmaes_vfitoolkit(GeneralEqmConditionsFnOpt,GEparamsvec0,heteroagentoptions.insigma,heteroagentoptions.inopts); % ,varargin);
+    elseif heteroagentoptions.fminalgo==5
+        % Update based on rules in heteroagentoptions.fminalgo5.howtoupdate
+        % Set up the howtoupdate rules in the format needed
+        heteroagentoptions=setupGEnewprice3_shooting(heteroagentoptions,GeneralEqmEqns,GEPriceParamNames,N_i,GEpriceindexes');
+        % Get initial prices, p
+        p=nan(1,length(GEPriceParamNames));
+        for ii=1:length(GEPriceParamNames)
+            p(ii)=Parameters.(GEPriceParamNames{ii});
+        end
+        % Given current prices solve the model to get the general equilibrium conditions as a structure
+        itercounter=0;
+        p_change=Inf;
+        GeneralEqmConditions=Inf;
+        while (any(p_change>heteroagentoptions.toleranceGEprices) || GeneralEqmConditions>heteroagentoptions.toleranceGEcondns) && itercounter<heteroagentoptions.maxiter
+
+            p_i=GeneralEqmConditionsFnOpt(p); % using heteroagentoptions.outputGEform=1, so this is a vector
+
+            GeneralEqmConditionsVec=p_i; % Need later to look at convergence
+
+            % Update prices based on GEstruct following the howtoupdate rules
+            p_i=p_i(heteroagentoptions.fminalgo5.permute); % Rearrange GeneralEqmEqns into the order of the relevant prices
+            I_makescutoff=(abs(p_i)>heteroagentoptions.updateaccuracycutoff);
+            p_i=I_makescutoff.*p_i;
+            p_new=(p.*heteroagentoptions.fminalgo5.keepold)+heteroagentoptions.fminalgo5.add.*heteroagentoptions.fminalgo5.factor.*p_i-(1-heteroagentoptions.fminalgo5.add).*heteroagentoptions.fminalgo5.factor.*p_i;
+
+            % Calculate GeneralEqmConditions which measures convergence
+            if heteroagentoptions.multiGEcriterion==0
+                GeneralEqmConditions=sum(abs(heteroagentoptions.multiGEweights.*GeneralEqmConditionsVec));
+            elseif heteroagentoptions.multiGEcriterion==1 %the measure of market clearance is to take the sum of squares of clearance in each market
+                GeneralEqmConditions=sqrt(sum(heteroagentoptions.multiGEweights.*(GeneralEqmConditionsVec.^2)));
+            end
+
+            % Put new prices into Parameters
+            for ii=1:length(GEPriceParamNames)
+                Parameters.(GEPriceParamNames{ii})=p_new(ii);
+            end
+
+            p_change=abs(p_new-p); % note, this is a vector
+            % p_percentchange=max(abs(p_new-p)./abs(p));
+            % p_percentchange(p==0)=abs(p_new(p==0)); %-p(p==0)); but this is just zero anyway
+            % Update p for next iteration
+            p=p_new;
+            itercounter=itercounter+1; % increment iteration counter
+        end
+        p_eqm_vec=p_new; % Need to put it in p_eqm_vec so that it can be used to create the final output
+    elseif heteroagentoptions.fminalgo==6
+        if ~isfield(heteroagentoptions,'lb') || ~isfield(heteroagentoptions,'ub')
+            error('When using constrained optimization (heteroagentoptions.fminalgo=6) you must set the lower and upper bounds of the GE price parameters using heteroagentoptions.lb and heteroagentoptions.ub')
+        end
+        [p_eqm_vec,GeneralEqmConditions]=fmincon(GeneralEqmConditionsFnOpt,GEparamsvec0,[],[],[],[],heteroagentoptions.lb,heteroagentoptions.ub,[],minoptions);
+    elseif heteroagentoptions.fminalgo==7 % Matlab fsolve()
+        heteroagentoptions.multiGEcriterion=0;
+        [p_eqm_vec,GeneralEqmConditions]=fsolve(GeneralEqmConditionsFnOpt,GEparamsvec0,minoptions);
+    elseif heteroagentoptions.fminalgo==8 % Matlab lsqnonlin()
+        minoptions = optimoptions('lsqnonlin','FiniteDifferenceStepSize',1e-2,'TolX',heteroagentoptions.toleranceGEprices,'TolFun',heteroagentoptions.toleranceGEcondns,'MaxFunEvals',heteroagentoptions.maxiter,'MaxIter',heteroagentoptions.maxiter);
+        [p_eqm_vec,GeneralEqmConditions]=lsqnonlin(GeneralEqmConditionsFnOpt,GEparamsvec0,[],[],[],[],[],[],[],minoptions);
+    end
+    
+
+    % p_eqm_vec contains the (transformed) unconstrained parameters, not the original (constrained) parameter values.
+    [p_eqm_vec,~]=ParameterConstraints_TransformParamsToOriginal(p_eqm_vec,GEpriceindexesB,GEPriceParamNames,heteroagentoptions);
+    % p_eqm_vec is now the original (constrained) parameter values.
+    
+    for pp=1:nGEprices
+        if GEprice_ptype(pp)==0
+            p_eqm.(GEPriceParamNames{pp})=p_eqm_vec(GEpriceindexes(pp,1):GEpriceindexes(pp,2));
+        else
+            if heteroagentoptions.GEptype_vectoroutput==1
+                p_eqm.(GEPriceParamNames{pp})=p_eqm_vec(GEpriceindexes(pp,1):GEpriceindexes(pp,2));
+            elseif heteroagentoptions.GEptype_vectoroutput==0
+                temp=p_eqm_vec(GEpriceindexes(pp,1):GEpriceindexes(pp,2));
+                for ii=1:N_i
+                    p_eqm.(GEPriceParamNames{pp}).(PTypeStructure.Names_i{ii})=temp(ii);
+                end
+            end
+        end
+    end
+    
+%%
+elseif heteroagentoptions.maxiter==0 % Can use heteroagentoptions.maxiter=0 to just evaluate the current general eqm eqns
+    % Just use the prices that are currently in Params
+    p_eqm_vec=zeros(length(GEparamsvec0),1);
+    p_eqm=nan; % So user cannot misuse
+    p_eqm_index=nan; % In case user asks for it
+    for pp=1:length(GEPriceParamNames)
+        p_eqm_vec(pp)=Parameters.(GEPriceParamNames{pp});
+    end
+end
+
+
+
+%% Add an evaluation of the general eqm eqns so that these can be output as a vectors/structure rather than just the sum of squares
+if heteroagentoptions.outputGEstruct==1
+    heteroagentoptions.outputGEform=2; % output as struct
+elseif heteroagentoptions.outputGEstruct==2
+    heteroagentoptions.outputGEform=1; % output as vector
+end
+
+if heteroagentoptions.outputGEstruct==1 || heteroagentoptions.outputGEstruct==2
+    % Run once more to get the general eqm eqns in a nice form for output
+    % Using the original (constrained) parameters, so just ignore the  constraints (otherwise it would assume they are the transformed parameters)
+    if isfield(heteroagentoptions,'constrainpositive')
+        heteroagentoptions.constrainpositive=zeros(length(p_eqm_vec),1);
+    end
+    if isfield(heteroagentoptions,'constrain0to1')
+        heteroagentoptions.constrain0to1=zeros(length(p_eqm_vec),1);
+    end
+    if isfield(heteroagentoptions,'constrainAtoB')
+        heteroagentoptions.constrainAtoB=zeros(length(p_eqm_vec),1);
+    end
+    if all(heteroagentoptions.GEptype==0)
+        GeneralEqmConditionsFnOpt=@(p) HeteroAgentStationaryEqm_Case1_MixHorz_PType_subfn(p, PTypeStructure, Parameters, GeneralEqmEqnsCell, GeneralEqmEqnParamNames, GEPriceParamNames, GEeqnNames, AggVarNames, nGEprices,heteroagentoptions);
+    else
+        GeneralEqmConditionsFnOpt=@(p) HeteroAgentStationaryEqm_Case1_MixHorz_PType_GEptype_subfn(p, PTypeStructure, Parameters, GeneralEqmEqns, GeneralEqmEqnsCell, GeneralEqmEqnParamNames, GEPriceParamNames,AggVarNames,nGEprices,GEpriceindexes,GEprice_ptype,heteroagentoptions);
+    end
+    GeneralEqmConditions=GeneralEqmConditionsFnOpt(p_eqm_vec);
+end
+if heteroagentoptions.outputGEstruct==1
+    % put GeneralEqmConditions structure on cpu for purely cosmetic reasons
+    GEeqnNames=fieldnames(GeneralEqmEqns);
+    for gg=1:length(GEeqnNames)
+        GeneralEqmConditions.(GEeqnNames{gg})=gather(GeneralEqmConditions.(GEeqnNames{gg})); 
+    end
+end
+
+
+
+
+
+
+%% If using pricehistory, create a clean version for output to user
+if heteroagentoptions.pricehistory==1
+    load pricehistory.mat GEpricepath GEcondnpath itercount
+    delete('pricehistory.mat')
+    GEpricepath=GEpricepath(:,1:itercount); % drop the NaN at end
+    GEcondnpath=GEcondnpath(:,1:itercount); % drop the NaN at end
+    PriceHistory.itercount=itercount;
+    
+    for pp=1:nGEprices
+        if GEprice_ptype(pp)==0
+            PriceHistory.(GEPriceParamNames{pp})=GEpricepath(GEpriceindexes(pp,1):GEpriceindexes(pp,2),:);
+        else
+            if heteroagentoptions.GEptype_vectoroutput==1
+                PriceHistory.(GEPriceParamNames{pp})=GEpricepath(GEpriceindexes(pp,1):GEpriceindexes(pp,2),:);
+            elseif heteroagentoptions.GEptype_vectoroutput==0
+                temp=GEpricepath(GEpriceindexes(pp,1):GEpriceindexes(pp,2),:);
+                for ii=1:N_i
+                    PriceHistory.(GEPriceParamNames{pp}).(Names_i{ii})=temp(ii,:);
+                end
+            end
+        end
+    end
+    GENames=fieldnames(GeneralEqmEqns);
+    for gg=1:length(GENames)
+        PriceHistory.(GENames{gg})=GEcondnpath(gg,:);
+    end
+end
+
+
+%%
+if heteroagentoptions.pricehistory==0
+    if nargout==1
+        varargout={p_eqm};
+    elseif nargout==2
+        varargout={p_eqm,GeneralEqmConditions};
+    elseif nargout==3
+        varargout={p_eqm,p_eqm_index,GeneralEqmConditions};
+    end
+elseif heteroagentoptions.pricehistory==1
+    if nargout==1
+        varargout={p_eqm};
+    elseif nargout==2
+        varargout={p_eqm,GeneralEqmConditions};
+    elseif nargout==3
+        varargout={p_eqm,GeneralEqmConditions,PriceHistory};
+    elseif nargout==4
+        varargout={p_eqm,p_eqm_index,GeneralEqmConditions,PriceHistory};
+    end
+end
+
+
+
+end

--- a/HeterogeneousAgent/MixHorz/HeteroAgentStationaryEqm_Case1_MixHorz_PType_subfn.m
+++ b/HeterogeneousAgent/MixHorz/HeteroAgentStationaryEqm_Case1_MixHorz_PType_subfn.m
@@ -1,0 +1,252 @@
+function GeneralEqmConditions=HeteroAgentStationaryEqm_Case1_MixHorz_PType_subfn(GEpricesvec, PTypeStructure, Parameters, GeneralEqmEqnsCell, GeneralEqmEqnParamNames, GEPriceParamNames, GEeqnNames, AggVarNames, nGEprices, heteroagentoptions)
+
+heteroagentparamsvecindex=0:1:length(GEpricesvec);
+[GEpricesvec,penalty]=ParameterConstraints_TransformParamsToOriginal(GEpricesvec,heteroagentparamsvecindex,GEPriceParamNames,heteroagentoptions);
+
+if heteroagentoptions.verbose>0
+    GEpricesvec_tminus1=zeros(nGEprices,1);
+    AggVars_tminus1=NaN(length(AggVarNames),1);
+
+    for pp=1:nGEprices
+        GEpricesvec_tminus1(pp)=Parameters.(GEPriceParamNames{pp});
+    end
+    GEpricesvec_delta=GEpricesvec-GEpricesvec_tminus1; % Compute this to show max change per round
+    for aa=1:length(AggVarNames)
+        if isfield(Parameters,AggVarNames{aa})
+            AggVars_tminus1(aa)=Parameters.(AggVarNames{aa});
+        end
+    end
+    if heteroagentoptions.useintermediateEqns==1
+        intEqnnames=fieldnames(heteroagentoptions.intermediateEqns);
+        intermediateEqns_tminus1=zeros(length(intEqnnames),1);
+        for aa=1:length(intEqnnames)
+            if isfield(Parameters,intEqnnames{aa})
+                intEqns_tminus1(aa)=Parameters.(intEqnnames{aa});
+            end
+        end
+    end
+    % We don't do anything special for CustomModelStats, which are not as easily done as others above.
+end
+
+if heteroagentoptions.verbose==2
+    [~,maxidx]=max(GEpricesvec_delta.^2);
+    fprintf(' \n')
+    fprintf('Current GE prices: \n')
+    for pp=1:nGEprices
+        if pp==maxidx
+            cprintf('err','	%s: %8.4f \n',GEPriceParamNames{pp},GEpricesvec(pp))
+        else
+            fprintf('	%s: %8.4f \n',GEPriceParamNames{pp},GEpricesvec(pp))
+        end
+    end
+end
+
+%% 
+for pp=1:nGEprices
+    Parameters.(GEPriceParamNames{pp})=GEpricesvec(pp);
+end
+
+
+%%
+AggVars_ConditionalOnPType=zeros(PTypeStructure.numFnsToEvaluate,PTypeStructure.N_i); % Create AggVars conditional on ptype.
+
+for ii=1:PTypeStructure.N_i
+    
+    iistr=PTypeStructure.iistr{ii};
+    for pp=1:length(GEPriceParamNames)
+        PTypeStructure.(iistr).Parameters.(GEPriceParamNames{pp})=GEpricesvec(pp);
+    end
+    
+    if heteroagentoptions.gridsinGE(ii)==1
+        if isfinite(PTypeStructure.(iistr).N_j)
+            % Some of the shock grids depend on parameters that are determined in general eqm
+            [PTypeStructure.(iistr).z_gridvals_J, PTypeStructure.(iistr).pi_z_J, PTypeStructure.(iistr).vfoptions]=ExogShockSetup_FHorz(PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).z_gridvals_J,PTypeStructure.(iistr).pi_z_J,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).Parameters,PTypeStructure.(iistr).vfoptions,3);
+            % Convert z and e to age-dependent joint-grids and transtion matrix
+            % Note: Ignores which, just redoes both z and e
+            PTypeStructure.(iistr).simoptions.e_gridvals_J=PTypeStructure.(iistr).vfoptions.e_gridvals_J; % if no e, this is just empty anyway
+            PTypeStructure.(iistr).simoptions.pi_e_J=PTypeStructure.(iistr).vfoptions.pi_e_J;
+        else
+            % PType actually allows for infinite horizon as well
+            % Some of the shock grids depend on parameters that are determined in general eqm
+            [PTypeStructure.(iistr).z_gridvals, PTypeStructure.(iistr).pi_z, PTypeStructure.(iistr).vfoptions]=ExogShockSetup_InfHorz(PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).z_gridvals,PTypeStructure.(iistr).pi_z,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).Parameters,PTypeStructure.(iistr).vfoptions,3);
+            % Convert z and e to joint-grids and transtion matrix
+            % Note: Ignores which, just redoes both z and e
+            PTypeStructure.(iistr).simoptions.e_gridvals=PTypeStructure.(iistr).vfoptions.e_gridvals; % if no e, this is just empty anyway
+            PTypeStructure.(iistr).simoptions.pi_e=PTypeStructure.(iistr).vfoptions.pi_e;
+        end
+    end
+    
+    % If semiz is determined in GE
+    if heteroagentoptions.gridsinGE_semiexo(ii)==1
+        if isfinite(PTypeStructure.(iistr).N_j)
+            % Some of the shock grids depend on parameters that are determined in general eqm
+            PTypeStructure.(iistr).vfoptions=SemiExogShockSetup_FHorz(PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).d_grid,PTypeStructure.(iistr).Parameters,PTypeStructure.(iistr).vfoptions,2,3);
+            PTypeStructure.(iistr).simoptions.semiz_gridvals_J=PTypeStructure.(iistr).vfoptions.semiz_gridvals_J;
+            PTypeStructure.(iistr).simoptions.pi_semiz_J=PTypeStructure.(iistr).vfoptions.pi_semiz_J;
+        else
+            error('Semiexog in InfHorz not yet implemented')
+        end
+    end
+    
+    if isfinite(PTypeStructure.(iistr).N_j)
+        [V_ii, Policy_ii]=ValueFnIter_Case1_FHorz(PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).d_grid, PTypeStructure.(iistr).a_grid, PTypeStructure.(iistr).z_gridvals_J, PTypeStructure.(iistr).pi_z_J, PTypeStructure.(iistr).ReturnFn, PTypeStructure.(iistr).Parameters, PTypeStructure.(iistr).DiscountFactorParamNames, PTypeStructure.(iistr).ReturnFnParamNames, PTypeStructure.(iistr).vfoptions);
+        StationaryDist_ii=StationaryDist_FHorz_Case1(PTypeStructure.(iistr).jequaloneDist,PTypeStructure.(iistr).AgeWeightParamNames,Policy_ii,PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).pi_z_J,PTypeStructure.(iistr).Parameters,PTypeStructure.(iistr).simoptions);
+        % PTypeStructure.(iistr).simoptions.outputasstructure=0; % Want AggVars_ii as matrix to make it easier to add them across the PTypes (is set outside this script)
+        AggVars_ii=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist_ii, Policy_ii, PTypeStructure.(iistr).FnsToEvaluate, PTypeStructure.(iistr).Parameters, PTypeStructure.(iistr).FnsToEvaluateParamNames, PTypeStructure.(iistr).n_d, PTypeStructure.(iistr).n_a, PTypeStructure.(iistr).n_z, PTypeStructure.(iistr).N_j, PTypeStructure.(iistr).d_grid, PTypeStructure.(iistr).a_grid, PTypeStructure.(iistr).z_gridvals_J, PTypeStructure.(iistr).simoptions);
+    else  % PType actually allows for infinite horizon as well
+        [V_ii, Policy_ii]=ValueFnIter_InfHorz(PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).d_grid, PTypeStructure.(iistr).a_grid, PTypeStructure.(iistr).z_gridvals, PTypeStructure.(iistr).pi_z, PTypeStructure.(iistr).ReturnFn, PTypeStructure.(iistr).Parameters, PTypeStructure.(iistr).DiscountFactorParamNames, PTypeStructure.(iistr).ReturnFnParamNames, PTypeStructure.(iistr).vfoptions);
+        StationaryDist_ii=StationaryDist_InfHorz(Policy_ii,PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).pi_z,PTypeStructure.(iistr).simoptions,PTypeStructure.(iistr).Parameters);
+        % PTypeStructure.(iistr).simoptions.outputasstructure=0; % Want AggVars_ii as matrix to make it easier to add them across the PTypes (is set outside this script)
+        AggVars_ii=EvalFnOnAgentDist_AggVars_InfHorz(StationaryDist_ii, Policy_ii, PTypeStructure.(iistr).FnsToEvaluate, PTypeStructure.(iistr).Parameters, PTypeStructure.(iistr).FnsToEvaluateParamNames, PTypeStructure.(iistr).n_d, PTypeStructure.(iistr).n_a, PTypeStructure.(iistr).n_z, PTypeStructure.(iistr).d_grid, PTypeStructure.(iistr).a_grid, PTypeStructure.(iistr).z_gridvals, PTypeStructure.(iistr).simoptions);
+    end
+    AggVars_ConditionalOnPType(PTypeStructure.(iistr).FnsAndPTypeIndicator_ii,ii)=AggVars_ii;
+    % Put updated AggVars into subsequent PTypeStructure Parameters, so they can be used for subsequent PType evaluations
+    FnsToEvaluate_aa=fieldnames(PTypeStructure.(iistr).FnsToEvaluate);
+    for jj=ii+1:PTypeStructure.N_i
+        jjstr=PTypeStructure.iistr{jj};
+        for aa=1:length(AggVars_ii)
+            PTypeStructure.(jjstr).Parameters.(FnsToEvaluate_aa{aa})=AggVars_ii(aa);
+        end
+    end
+
+    if heteroagentoptions.useCustomModelStats==1
+        V.(iistr)=V_ii;
+        Policy.(iistr)=Policy_ii;
+        StationaryDist.(iistr)=StationaryDist_ii;
+    end
+end
+AggVars=sum(AggVars_ConditionalOnPType.*PTypeStructure.ptweights',2);
+% Note: AggVars is a vector
+
+
+
+%% Put GE parameters and AggVars in structure, so they can be used for intermediateEqns and GeneralEqmEqns
+% already did the basic GE params
+% for pp=1:nGEprices
+%     Parameters.(GEPriceParamNames{pp})=GEprices(pp);
+% end
+
+% We pushed AggVars down into the PTypeStructure parameters; this puts them into the unified Parameter structure
+for aa=1:length(AggVarNames)
+    Parameters.(AggVarNames{aa})=AggVars(aa);
+end
+
+%% Custom Model Stats
+if heteroagentoptions.useCustomModelStats==1
+    StationaryDist.ptweights=PTypeStructure.ptweights;
+    % A bunch of the inputs are stashed in heteroagentoptions.CustomModelStatsInputs
+    % Note: CustomStats deliberately does not get AgeWeightParamNames and PTypeDistParamNames, user will anyway know them
+    CustomStats=heteroagentoptions.CustomModelStats(V,Policy,StationaryDist,Parameters,heteroagentoptions.CustomModelStatsInputs.FnsToEvaluate,heteroagentoptions.CustomModelStatsInputs.n_d,heteroagentoptions.CustomModelStatsInputs.n_a,heteroagentoptions.CustomModelStatsInputs.n_z,heteroagentoptions.CustomModelStatsInputs.N_j,PTypeStructure.Names_i,heteroagentoptions.CustomModelStatsInputs.d_grid,heteroagentoptions.CustomModelStatsInputs.a_grid,heteroagentoptions.CustomModelStatsInputs.z_grid,heteroagentoptions.CustomModelStatsInputs.pi_z,heteroagentoptions,heteroagentoptions.CustomModelStatsInputs.vfoptions,heteroagentoptions.CustomModelStatsInputs.simoptions);
+    % Note: anything else you want, just 'hide' it in heteroagentoptions
+    customstatnames=fieldnames(CustomStats);
+    for pp=1:length(customstatnames)
+        Parameters.(customstatnames{pp})=CustomStats.(customstatnames{pp});
+    end
+end
+
+%% Intermediate Eqns
+if heteroagentoptions.useintermediateEqns==1
+    % Note: intermediateEqns just take in things from the Parameters structure, as do GeneralEqmEqns (AggVars get put into structure), hence just use the GeneralEqmConditions_Case1_v3g().
+    intEqnnames=fieldnames(heteroagentoptions.intermediateEqns);
+    intermediateEqnsVec=zeros(1,length(intEqnnames));
+    % Do the intermediateEqns, in order
+    for gg=1:length(intEqnnames)
+        intermediateEqnsVec(gg)=real(GeneralEqmConditions_Case1_v3g(heteroagentoptions.intermediateEqnsCell{gg}, heteroagentoptions.intermediateEqnParamNames(gg).Names, Parameters));
+        Parameters.(intEqnnames{gg})=intermediateEqnsVec(gg);
+    end
+end
+
+%% Evaluate General Eqm Eqns
+% use of real() is a hack that could disguise errors, but I couldn't find why matlab was treating output as complex
+GeneralEqmConditionsVec=zeros(1,length(GEeqnNames));
+for gg=1:length(GEeqnNames)
+    GeneralEqmConditionsVec(gg)=real(GeneralEqmConditions_Case1_v3g(GeneralEqmEqnsCell{gg}, GeneralEqmEqnParamNames(gg).Names, Parameters));
+end
+
+
+%% We might want to output GE conditions as a vector or structure
+if heteroagentoptions.outputGEform==0 % scalar
+    if heteroagentoptions.multiGEcriterion==0
+        GeneralEqmConditions=sum(abs(heteroagentoptions.multiGEweights.*GeneralEqmConditionsVec));
+    elseif heteroagentoptions.multiGEcriterion==1 %the measure of market clearance is to take the sum of squares of clearance in each market
+        GeneralEqmConditions=sum(heteroagentoptions.multiGEweights.*(GeneralEqmConditionsVec.^2));
+    end
+    if heteroagentoptions.outputgather==1
+        GeneralEqmConditions=gather(GeneralEqmConditions);
+    end
+elseif heteroagentoptions.outputGEform==1 % vector
+    GeneralEqmConditions=GeneralEqmConditionsVec;
+    if heteroagentoptions.outputgather==1
+        GeneralEqmConditions=gather(GeneralEqmConditions);
+    end
+elseif heteroagentoptions.outputGEform==2 % structure
+    clear GeneralEqmConditions
+    for gg=1:length(GEeqnNames)
+        GeneralEqmConditions.(GEeqnNames{gg})=GeneralEqmConditionsVec(gg);
+    end
+end
+
+%% Feedback on progress
+if heteroagentoptions.verbose==1 % When=2, we report these earlier
+    [~,maxidx]=max(GEpricesvec_delta.^2);
+    fprintf(' \n')
+    fprintf('Current GE prices: \n')
+    for pp=1:nGEprices
+        if pp==maxidx
+            cprintf('err',heteroagentoptions.verboseaccuracy1,GEPriceParamNames{pp},GEpricesvec(pp))
+        else
+            fprintf(heteroagentoptions.verboseaccuracy1,GEPriceParamNames{pp},GEpricesvec(pp))
+        end
+    end
+end
+if heteroagentoptions.verbose>=1
+    fprintf('Current aggregate variables: \n')
+    for aa=1:length(AggVarNames)
+        if ~isnan(AggVars_tminus1(aa))
+            cprintf('comment',heteroagentoptions.verboseaccuracy1,AggVarNames{aa},AggVars(aa)) % Note, this is done differently here because AggVars itself has been set as a matrix
+        else
+            fprintf(heteroagentoptions.verboseaccuracy1,AggVarNames{aa},AggVars(aa)) % Note, this is done differently here because AggVars itself has been set as a matrix
+        end
+    end
+    if heteroagentoptions.useintermediateEqns==1
+        intEqns_delta=intermediateEqnsVec-intermediateEqns_tminus1;
+        [~,maxidx]=max(intEqns_delta.^2);
+        fprintf('Current intermediateEqn variables: \n')
+        for aa=1:length(intEqnnames)
+            if aa==maxidx
+                cprintf('err',heteroagentoptions.verboseaccuracy1,intEqnnames{aa},intermediateEqnsVec(aa)) % Note, this is done differently here because AggVars itself has been set as a matrix
+            else
+                fprintf(heteroagentoptions.verboseaccuracy1,intEqnnames{aa},intermediateEqnsVec(aa)) % Note, this is done differently here because AggVars itself has been set as a matrix
+            end
+        end
+    end
+    if heteroagentoptions.useCustomModelStats==1
+        fprintf('Current CustomModelStats variables: \n')
+        for aa=1:length(customstatnames)
+            fprintf(heteroagentoptions.verboseaccuracy1,customstatnames{aa},CustomStats.(customstatnames{aa}))
+        end
+    end
+    fprintf('Current GeneralEqmEqns: \n')
+    [~,maxidx]=max(GeneralEqmConditionsVec.^2);
+    for gg=1:length(GEeqnNames)
+        if gg==maxidx
+            cprintf('err', heteroagentoptions.verboseaccuracy2,GEeqnNames{gg},GeneralEqmConditionsVec(gg))
+        else
+            fprintf(heteroagentoptions.verboseaccuracy2,GEeqnNames{gg},GeneralEqmConditionsVec(gg))
+        end
+    end
+end
+
+
+
+% If recording the price history, do that
+if heteroagentoptions.pricehistory==1
+    load pricehistory.mat GEpricepath GEcondnpath itercount
+    itercount=itercount+1;
+    GEpricepath(:,itercount)=GEpricesvec;
+    GEcondnpath(:,itercount)=GeneralEqmConditionsVec;
+    save pricehistory.mat GEpricepath GEcondnpath itercount
+end
+
+
+end

--- a/StationaryDist/MixHorz/StationaryDist_Case1_MixHorz_PType.m
+++ b/StationaryDist/MixHorz/StationaryDist_Case1_MixHorz_PType.m
@@ -1,0 +1,253 @@
+function StationaryDist=StationaryDist_Case1_MixHorz_PType(jequaloneDist,AgeWeightsParamNames,PTypeDistParamNames,Policy,n_d,n_a,n_z,N_j,Names_i,pi_z,Parameters,simoptions)
+% Allows for different permanent (fixed) types of agent. 
+% See ValueFnIter_Case1_FHorz_PType for general idea.
+%
+% simoptions.verbose=1 will give feedback
+% simoptions.verboseparams=1 will give further feedback on the param values of each permanent type
+%
+% jequaloneDist can either be same for all permanent types, or must be passed as a structure.
+% AgeWeightParamNames is either same for all permanent types, or must be passed as a structure.
+%
+%
+% How exactly to handle these differences between permanent (fixed) types
+% is to some extent left to the user. You can, for example, input
+% parameters that differ by permanent type as a vector with different rows f
+% for each type, or as a structure with different fields for each type.
+%
+% Any input that does not depend on the permanent type is just passed in
+% exactly the same form as normal.
+
+% Names_i can either be a cell containing the 'names' of the different
+% permanent types, or if there are no structures used (just parameters that
+% depend on permanent type and inputted as vectors or matrices as appropriate) 
+% then Names_i can just be the number of permanent types (but does not have to be, can still be names).
+if iscell(Names_i)
+    N_i=length(Names_i);
+else
+    N_i=Names_i; % It is the number of PTypes (which have not been given names)
+    Names_i={'ptype001'};
+    for ii=2:N_i
+        if ii<10
+            Names_i{ii}=['ptype00',num2str(ii)];
+        elseif ii<100
+            Names_i{ii}=['ptype0',num2str(ii)];
+        elseif ii<1000
+            Names_i{ii}=['ptype',num2str(ii)];
+        end
+    end
+end
+
+%% Setup simoptions a little (needs to be done here so for-loop can be parallelized)
+if ~exist('simoptions','var')
+    simoptions=struct(); % defaults are filled in later
+end
+if ~isfield(simoptions,'verbose')
+    simoptions.verbose=0;
+end
+if ~isfield(simoptions,'verboseparams')
+    simoptions.verboseparams=0;
+end
+if ~isfield(simoptions,'ptypestorecpu')
+    simoptions.ptypestorecpu=0; % GPU memory is limited, so switch solutions to the cpu. Off by default.
+end
+
+%% Check inputs
+if abs(sum(Parameters.(PTypeDistParamNames{1}))-1)>10^(-15)
+    warning('The permanent type mass weights must sum to one (PTypeDistParamNames points to weights that do not sum to one)')
+end
+
+%% Deal with jequaloneDist
+[jequaloneDist,idiminj1dist,Parameters]=jequaloneDist_PType(jequaloneDist,Parameters,simoptions,n_a,n_z,N_i,Names_i,PTypeDistParamNames,0);
+
+
+%%
+for ii=1:N_i
+    % First set up simoptions
+    simoptions_temp=PType_Options(simoptions,Names_i,ii);
+
+    if simoptions_temp.verbose==1
+        fprintf('Permanent type: %i of %i \n',ii, N_i)
+    end
+           
+    
+    Policy_temp=Policy.(Names_i{ii});
+    
+    % Go through everything which might be dependent on permanent type (PType)
+    % Notice that the way this is coded the grids (etc.) could be either
+    % fixed, or a function (that depends on age, and possibly on permanent
+    % type), or they could be a structure. Only in the case where they are
+    % a structure is there a need to take just a specific part and send
+    % only that to the 'non-PType' version of the command.
+    if isa(n_d,'struct')
+        n_d_temp=n_d.(Names_i{ii});
+    else
+        n_d_temp=n_d;
+    end
+    if isa(n_a,'struct')
+        n_a_temp=n_a.(Names_i{ii});
+    else
+        n_a_temp=n_a;
+    end
+    if isa(n_z,'struct')
+        n_z_temp=n_z.(Names_i{ii});
+    else
+        n_z_temp=n_z;
+    end
+    if isa(N_j,'struct')
+        N_j_temp=N_j.(Names_i{ii});
+    else
+        N_j_temp=N_j;
+    end
+
+    %% Exogenous shocks
+    if isstruct(pi_z)
+        pi_z_temp=pi_z.(Names_i{ii});
+    else
+        nn=size(pi_z,ndims(pi_z));
+        if nn==N_i
+            otherdims = repmat({':'},1,ndims(pi_z)-1);
+            pi_z_temp=pi_z(otherdims{:},ii);
+        else
+            pi_z_temp=pi_z;
+        end
+    end
+
+    % e
+    if isfield(simoptions_temp,'n_e')
+        % If vfoptions_temp.pi_semiz is a structure that was already dealt with by PType_Options() command
+        if ~isstruct(simoptions.pi_e)
+            % So just need to check if last dimension is of length N_i
+            nn=size(simoptions_temp.pi_e,ndims(simoptions_temp.pi_e));
+            if nn==N_i
+                otherdims = repmat({':'},1,ndims(simoptions_temp.pi_e)-1);
+                simoptions_temp.pi_e=simoptions_temp.pi_e(otherdims{:},ii);
+            end
+        end
+    end
+
+    % semiz
+    if isfield(simoptions_temp,'n_semiz')
+        % Might use SemiExoShockFn or pi_semiz, if the later we need to deal with it
+        if isfield(simoptions_temp,'pi_semiz')
+        % If simoptions_temp.pi_semiz is a structure that was already dealt with by PType_Options() command
+            if ~isstruct(simoptions.pi_semiz)
+                % So just need to check if last dimension is of length N_i
+                nn=size(simoptions_temp.pi_semiz,ndims(simoptions_temp.pi_semiz));
+                if nn==N_i
+                    otherdims = repmat({':'},1,ndims(simoptions_temp.pi_semiz)-1);
+                    simoptions_temp.pi_semiz=simoptions_temp.pi_semiz(otherdims{:},ii);
+                end
+            end
+        else
+            % To evaluate SemiExoShockFn, we still require semiz_grid
+            % If vfoptions_temp.semiz_grid is a structure that was already dealt with by PType_Options() command
+            if ~isstruct(simoptions.semiz_grid)
+                % So just need to check if last dimension is of length N_i
+                nn=size(simoptions_temp.semiz_grid,ndims(simoptions_temp.semiz_grid));
+                if nn==N_i
+                    otherdims = repmat({':'},1,ndims(simoptions_temp.semiz_grid)-1);
+                    simoptions_temp.semiz_grid=simoptions_temp.semiz_grid(otherdims{:},ii);
+                end
+            end
+        end
+    end
+    
+    %% Parameters
+    % Parameters are allowed to be given as structure, or as vector/matrix
+    % (in terms of their dependence on fixed type). So go through each of
+    % these in term.
+    Parameters_temp=Parameters;
+    FullParamNames=fieldnames(Parameters);
+    nFields=length(FullParamNames);
+    for kField=1:nFields
+        if isa(Parameters.(FullParamNames{kField}), 'struct') % Check for permanent type in structure form
+            names=fieldnames(Parameters.(FullParamNames{kField}));
+            for jj=1:length(names)
+                if strcmp(names{jj},Names_i{ii})
+                    Parameters_temp.(FullParamNames{kField})=Parameters.(FullParamNames{kField}).(names{jj});
+                end
+            end
+        elseif any(size(Parameters.(FullParamNames{kField}))==N_i) % Check for permanent type in vector/matrix form.
+            temp=Parameters.(FullParamNames{kField});
+            [~,ptypedim]=max(size(Parameters.(FullParamNames{kField}))==N_i); % Parameters as vector/matrix can be at most two dimensional, figure out which relates to PType.
+            if ptypedim==1
+                Parameters_temp.(FullParamNames{kField})=temp(ii,:);
+            elseif ptypedim==2
+                Parameters_temp.(FullParamNames{kField})=temp(:,ii);
+            end
+        end
+    end
+    
+    if simoptions_temp.verboseparams==1
+        sprintf('Parameter values for the current permanent type')
+        Parameters_temp
+    end
+    
+    %% jequaloneDist
+    if isa(jequaloneDist,'struct')
+        if isfield(jequaloneDist,Names_i{ii})
+            jequaloneDist_temp=jequaloneDist.(Names_i{ii});
+            % jequaloneDist_temp must be of mass one for the codes to work.
+            if abs(sum(jequaloneDist_temp(:))-1)>10^(-15) % jequaloneDist_temp(:))~=1, but allowing for small numerical errors
+                fprintf('Info for following error: sum(jequaloneDist_temp(:))-1=%8.16f (should be zero) \n', sum(jequaloneDist_temp(:))-1)
+                error(['The jequaloneDist must be of mass one for each type i (it is not for type ',Names_i{ii}])
+            end
+        else
+            if isfinite(N_j_temp)
+                error(['You must input a jequaloneDist for permanent type ', Names_i{ii}, ' \n'])
+            end
+        end
+    else
+        % Note: when jequaloneDist is not a structure all ptypes must have the same grids
+        if idiminj1dist==0 % ptype is not a dimension
+            jequaloneDist_temp=jequaloneDist;
+        else % idminj1dist==1
+            % ptype is a dimension, so need to get the jequaloneDist for ii and also normalize mass conditional on ptype to be one
+            if ndims(jequaloneDist)==5 % has all three of semiz,z,e [other two are a and i]
+                jequaloneDist_temp=jequaloneDist(:,:,:,:,ii)/sum(sum(jequaloneDist(:,:,:,:,ii))); % includes renormalizing so mass of one conditional on ptype
+            elseif ndims(jequaloneDist)==4 % has two of semiz,z,e
+                jequaloneDist_temp=jequaloneDist(:,:,:,ii)/sum(sum(jequaloneDist(:,:,:,ii))); % includes renormalizing so mass of one conditional on ptype
+            elseif ndims(jequaloneDist)==3 % has one of semiz,z,e
+                jequaloneDist_temp=jequaloneDist(:,:,ii)/sum(sum(jequaloneDist(:,:,ii))); % includes renormalizing so mass of one conditional on ptype
+            elseif ndims(jequaloneDist)==2 % has none of semiz,z,e
+                jequaloneDist_temp=jequaloneDist(:,ii)/sum(jequaloneDist(:,ii)); % includes renormalizing so mass of one conditional on ptype
+            end
+        end
+        if abs(sum(jequaloneDist_temp(:))-1)>10^(-12)
+            error(['The jequaloneDist must be of mass one for each type i (it is not for type ',Names_i{ii}, ' \n'])
+        end
+    end
+    
+    %%
+    AgeWeightParamNames_temp=AgeWeightsParamNames;
+    if isa(AgeWeightsParamNames,'struct')
+        if isfield(AgeWeightsParamNames,Names_i{ii})
+            AgeWeightParamNames_temp=AgeWeightsParamNames.(Names_i{ii});
+        else
+            if isfinite(N_j_temp)
+                error(['You must input AgeWeightParamNames for permanent type ', Names_i{ii}, ' \n'])
+            end
+        end
+    end
+    
+    if isfinite(N_j_temp)
+        StationaryDist_ii=StationaryDist_FHorz_Case1(jequaloneDist_temp,AgeWeightParamNames_temp,Policy_temp,n_d_temp,n_a_temp,n_z_temp,N_j_temp,pi_z_temp,Parameters_temp,simoptions_temp);
+    else % PType actually allows for infinite horizon as well
+        StationaryDist_ii=StationaryDist_InfHorz(Policy_temp,n_d_temp,n_a_temp,n_z_temp,pi_z_temp,simoptions_temp,Parameters_temp); % EntryExitParams not yet supported (is on my to-do list)
+    end
+    
+    if simoptions_temp.ptypestorecpu==1
+        StationaryDist.(Names_i{ii})=gather(StationaryDist_ii);
+    else
+        StationaryDist.(Names_i{ii})=StationaryDist_ii;
+    end
+    
+end
+
+if length(Parameters.(PTypeDistParamNames{:}))==N_i
+    StationaryDist.ptweights=reshape(Parameters.(PTypeDistParamNames{:}),[],1); % reshape is to make sure this is a column vector
+else
+    error('Parameter for PTypeDistParamNames does not have the same number of permanent types as N_i/Names_i \n')
+end
+
+end

--- a/StationaryDist/TransPathFHorz/AgentDistOnTransPath_Case1_FHorz.m
+++ b/StationaryDist/TransPathFHorz/AgentDistOnTransPath_Case1_FHorz.m
@@ -259,7 +259,7 @@ if simoptions.experienceasset==1
             aprimeFnParamsVec=CreateAgeMatrixFromParams(Parameters,aprimeFnParamNames,N_j);
             % [N_j,number of params]
             
-            [a2primeIndexes, a2primeProbs]=CreateaprimePolicyExperienceAsset_J(PolicyPath(:,:,:,tt),simoptions.aprimeFn, whichisdforexpasset, n_d, n_a1,n_a2, N_ze, N_j, simoptions.d_grid, a2_grid, aprimeFnParamsVec,0);
+            [a2primeIndexes, a2primeProbs]=CreateaprimePolicyExperienceAsset_J(PolicyPath(:,:,:,:,tt),simoptions.aprimeFn, whichisdforexpasset, n_d, n_a1,n_a2, N_ze, N_j, simoptions.d_grid, a2_grid, aprimeFnParamsVec,0);
             % Note: a2primeIndexes and a2primeProbs are both [N_a,N_z,N_j]
             % Note: a2primeIndexes is always the 'lower' point (the upper points are just aprimeIndexes+1), and the a2primeProbs are the probability of this lower point (prob of upper point is just 1 minus this).
             a2primeIndexesPath(:,:,:,tt)=a2primeIndexes(:,:,1:end-1);
@@ -423,7 +423,7 @@ else
         elseif length(n_aprime)==3
             PolicyaprimePath=reshape(PolicyPath(l_d+1,:,:,1:N_j-1,:)+n_aprime(1)*(PolicyPath(l_d+2,:,:,1:N_j-1,:)-1)+n_aprime(1)*n_aprime(2)*(PolicyPath(l_d+3,:,:,1:N_j-1,:)-1),[N_a*N_z*N_e,N_j-1,T]);
         elseif length(n_aprime)==4
-            PolicyaprimePath=reshape(PolicyPath(l_d+1,:,:,1:N_j-1,:)+n_aprime(1)*(PolicyPath(l_d+2,:,:,1:N_j-1,:)-1)+n_aprime(1)*n_aprime(2)*(PolicyPath(l_d+3,:,:,1:N_j-1,:)-1)+n_aprime(1)*n_aprime(2)*n_aprime(3)*(PolicyPath(l_d+4,:,:,:,1:N_j-1,:)-1),[N_a*N_z*N_e,N_j-1,T]);
+            PolicyaprimePath=reshape(PolicyPath(l_d+1,:,:,1:N_j-1,:)+n_aprime(1)*(PolicyPath(l_d+2,:,:,1:N_j-1,:)-1)+n_aprime(1)*n_aprime(2)*(PolicyPath(l_d+3,:,:,1:N_j-1,:)-1)+n_aprime(1)*n_aprime(2)*n_aprime(3)*(PolicyPath(l_d+4,:,:,1:N_j-1,:)-1),[N_a*N_z*N_e,N_j-1,T]);
         end
         if simoptions.fastOLG==0
             PolicyaprimezPath=PolicyaprimePath+repmat(repelem(N_a*gpuArray(0:1:N_z-1)',N_a,1),N_e,1);

--- a/StationaryDist/TransPathMixHorz/AgentDistOnTransPath_Case1_MixHorz_PType.m
+++ b/StationaryDist/TransPathMixHorz/AgentDistOnTransPath_Case1_MixHorz_PType.m
@@ -1,0 +1,197 @@
+function AgentDistPath=AgentDistOnTransPath_Case1_MixHorz_PType(AgentDist_initial, jequalOneDist, PricePath, ParamPath, PolicyPath, AgeWeightsParamNames,n_d,n_a,n_z,N_j,Names_i,pi_z, T,Parameters, transpathoptions, simoptions)
+% Remark to self: No real need for T as input, as this is anyway the length of PricePath
+
+AgentDistPath=struct();
+
+%%
+if iscell(Names_i)
+    N_i=length(Names_i);
+else
+    N_i=Names_i; % It is the number of PTypes (which have not been given names)
+    Names_i={'ptype001'};
+    for ii=2:N_i
+        if ii<10
+            Names_i{ii}=['ptype00',num2str(ii)];
+        elseif ii<100
+            Names_i{ii}=['ptype0',num2str(ii)];
+        elseif ii<1000
+            Names_i{ii}=['ptype',num2str(ii)];
+        end
+    end
+end
+
+
+%% Loop over permanent types
+for ii=1:N_i
+
+    % First set up transpathoptions
+    if exist('transpathoptions','var')
+        transpathoptions_temp=PType_Options(transpathoptions,Names_i,ii);
+        if ~isfield(transpathoptions_temp,'verbose')
+            transpathoptions_temp.verbose=0;
+        end
+        if ~isfield(transpathoptions_temp,'verboseparams')
+            transpathoptions_temp.verboseparams=0;
+        end
+    else
+        transpathoptions_temp.verbose=0;
+        transpathoptions_temp.verboseparams=0;
+    end
+    
+    % First set up simoptions
+    if exist('simoptions','var')
+        simoptions_temp=PType_Options(simoptions,Names_i,ii);
+        if ~isfield(simoptions_temp,'verbose')
+            simoptions_temp.verbose=0;
+        end
+        if ~isfield(simoptions_temp,'verboseparams')
+            simoptions_temp.verboseparams=0;
+        end
+        if ~isfield(simoptions_temp,'ptypestorecpu')
+            simoptions_temp.ptypestorecpu=1; % GPU memory is limited, so switch solutions to the cpu
+        end
+    else
+        simoptions_temp.verbose=0;
+        simoptions_temp.verboseparams=0;
+        simoptions_temp.ptypestorecpu=1; % GPU memory is limited, so switch solutions to the cpu
+    end 
+    
+    if simoptions_temp.verbose==1
+        fprintf('Permanent type: %i of %i \n',ii, N_i)
+    end
+           
+    PolicyPath_temp=PolicyPath.(Names_i{ii});
+
+    % Go through everything which might be dependent on permanent type (PType)
+    % Notice that the way this is coded the grids (etc.) could be either
+    % fixed, or a function (that depends on age, and possibly on permanent
+    % type), or they could be a structure. Only in the case where they are
+    % a structure is there a need to take just a specific part and send
+    % only that to the 'non-PType' version of the command.
+    if isa(n_d,'struct')
+        n_d_temp=n_d.(Names_i{ii});
+    else
+        n_d_temp=n_d;
+    end
+    if isa(n_a,'struct')
+        n_a_temp=n_a.(Names_i{ii});
+    else
+        n_a_temp=n_a;
+    end
+    if isa(n_z,'struct')
+        n_z_temp=n_z.(Names_i{ii});
+    else
+        n_z_temp=n_z;
+    end
+    if isa(N_j,'struct')
+        N_j_temp=N_j.(Names_i{ii});
+    else
+        N_j_temp=N_j;
+    end
+    if isa(pi_z,'struct')
+        pi_z_temp=pi_z.(Names_i{ii});
+    else
+        pi_z_temp=pi_z;
+    end
+    
+    % Parameters are allowed to be given as structure, or as vector/matrix
+    % (in terms of their dependence on fixed type). So go through each of
+    % these in term.
+    Parameters_temp=Parameters;
+    FullParamNames=fieldnames(Parameters);
+    nFields=length(FullParamNames);
+    for kField=1:nFields
+        if isa(Parameters.(FullParamNames{kField}), 'struct') % Check for permanent type in structure form
+            names=fieldnames(Parameters.(FullParamNames{kField}));
+            for jj=1:length(names)
+                if strcmp(names{jj},Names_i{ii})
+                    Parameters_temp.(FullParamNames{kField})=Parameters.(FullParamNames{kField}).(names{jj});
+                end
+            end
+        elseif any(size(Parameters.(FullParamNames{kField}))==N_i) % Check for permanent type in vector/matrix form.
+            temp=Parameters.(FullParamNames{kField});
+            [~,ptypedim]=max(size(Parameters.(FullParamNames{kField}))==N_i); % Parameters as vector/matrix can be at most two dimensional, figure out which relates to PType.
+            if ptypedim==1
+                Parameters_temp.(FullParamNames{kField})=temp(ii,:);
+            elseif ptypedim==2
+                Parameters_temp.(FullParamNames{kField})=temp(:,ii);
+            end
+        end
+    end
+    
+    if simoptions_temp.verboseparams==1
+        sprintf('Parameter values for the current permanent type')
+        Parameters_temp
+    end
+    
+    if isstruct(AgentDist_initial)
+        AgentDist_initial_temp=AgentDist_initial.(Names_i{ii});
+    else
+        AgentDist_initial_temp=AgentDist_initial; % NEED TO DEAL WITH THIS PROPERLY
+    end
+    if isfinite(N_j_temp)
+        if isstruct(AgeWeightsParamNames)
+            AgeWeightsParamNames_temp=AgeWeightsParamNames.(Names_i{ii});
+        else
+            AgeWeightsParamNames_temp=AgeWeightsParamNames;
+        end
+        if isstruct(jequalOneDist)
+            jequalOneDist_temp=jequalOneDist.(Names_i{ii});
+        else
+            jequalOneDist_temp=jequalOneDist;
+        end
+    end
+    
+
+    % PricePath can include parameters that differ by ptype
+    PricePath_temp=PricePath;
+    PricePathNames=fieldnames(PricePath);
+    for nn=1:length(PricePathNames)
+        if isstruct(PricePath_temp.(PricePathNames{nn}))
+            PricePath_temp.(PricePathNames{nn})=PricePath.(PricePathNames{nn}).(Names_i{ii});
+        elseif any(size(PricePath_temp.(PricePathNames{nn}))==N_i)
+            if size(PricePath_temp.(PricePathNames{nn}),1)==N_i
+                temp=PricePath_temp.(PricePathNames{nn});
+                PricePath_temp.(PricePathNames{nn})=temp(ii,:);
+            elseif size(PricePath_temp.(PricePathNames{nn}),2)==N_i
+                temp=PricePath_temp.(PricePathNames{nn});
+                PricePath_temp.(PricePathNames{nn})=temp(:,ii);
+            end
+        end
+    end
+
+    % ParamPath can include parameters that differ by ptype
+    ParamPath_temp=ParamPath;
+    ParamPathNames=fieldnames(ParamPath);
+    for nn=1:length(ParamPathNames)
+        if isstruct(ParamPath_temp.(ParamPathNames{nn}))
+            ParamPath_temp.(ParamPathNames{nn})=ParamPath.(ParamPathNames{nn}).(Names_i{ii});
+        elseif any(size(ParamPath_temp.(ParamPathNames{nn}))==N_i)
+            if size(ParamPath_temp.(ParamPathNames{nn}),1)==N_i
+                temp=ParamPath_temp.(ParamPathNames{nn});
+                ParamPath_temp.(ParamPathNames{nn})=temp(ii,:);
+            elseif size(ParamPath_temp.(ParamPathNames{nn}),2)==N_i
+                temp=ParamPath_temp.(ParamPathNames{nn});
+                ParamPath_temp.(ParamPathNames{nn})=temp(:,ii);
+            end
+        end
+    end
+    
+    
+    % Compute the agent distribution path for permanent type ii
+    if isfinite(N_j_temp)
+        AgentDistPath_ii=AgentDistOnTransPath_Case1_FHorz(AgentDist_initial_temp, jequalOneDist_temp, PricePath_temp, ParamPath_temp, PolicyPath_temp, AgeWeightsParamNames_temp,n_d_temp,n_a_temp,n_z_temp,N_j_temp,pi_z_temp, T,Parameters_temp, transpathoptions_temp, simoptions_temp);
+    else
+        AgentDistPath_ii=AgentDistOnTransPath_InfHorz(AgentDist_initial_temp, PolicyPath_temp, n_d_temp,n_a_temp,n_z_temp,pi_z_temp,T,simoptions_temp, Parameters_temp, PricePath_temp, ParamPath_temp);
+    end
+    % Note: T cannot depend on ptype, nor can PricePath depend on ptype
+
+    AgentDistPath.(Names_i{ii})=AgentDistPath_ii;
+
+end
+
+
+AgentDistPath.ptweights=AgentDist_initial.ptweights;
+
+
+end

--- a/SubCodes/ExoShocks/ExogShockSetup_TPath_InfHorz.m
+++ b/SubCodes/ExoShocks/ExogShockSetup_TPath_InfHorz.m
@@ -1,0 +1,113 @@
+function [z_gridvals, pi_z, transpathoptions, options]=ExogShockSetup_TPath_InfHorz(n_z,z_grid,pi_z,N_a,Parameters,PricePathNames,ParamPathNames,transpathoptions,options,gridpiboth)
+% Convert z and e to age-dependent joint-grids and transtion matrix
+% Can input vfoptions OR simoptions
+% output: z_gridvals, pi_z, transpathoptions, options
+
+% Sets up
+% transpathoptions.zpathtrivial=1; % z_gridvals and pi_z are not varying over the path
+%                              =0; % they vary over path, so z_gridvals_T and pi_z_T
+% and
+% transpathoptions.gridsinGE=1; % grids depend on a GE parameter and so need to be recomputed every iteration
+%                           =0; % grids are exogenous
+%
+
+% gridpiboth=4: sometimes (trans path GE) we want both grid and transition probabilties
+% gridpiboth=3: sometimes (value fn iter) we want both grid and transition probabilties
+% gridpiboth=2: sometimes (agent dist)    we want just transition probabilties
+% gridpiboth=1: sometimes (FnsToEvaluate) we want just grid
+
+
+%% Check basic setup
+N_z=prod(n_z);
+
+transpathoptions.gridsinGE=0; % will be overwritten if appropriate
+transpathoptions.zpathtrivial=1;  % will be overwritten if appropriate
+
+%% Check if z_grid and/or pi_z depend on prices.
+% If 'exogenous shock fn' is used, then precompute it to save evaluating it numerous times
+% Check if using 'exogenous shock fn' (exogenous state has a grid and transition matrix that depends on age)
+
+l_z=0;
+if N_z>0
+    l_z=length(n_z);
+
+    if isfield(options,'ExogShockFn') % Just calculate grid and transition probabilities anyway
+        options.ExogShockFnParamNames=getAnonymousFnInputNames(options.ExogShockFn);
+        % First, check if ExogShockFn depends on a PricePath parameter
+        overlap=0;
+        for ii=1:length(options.ExogShockFnParamNames)
+            if any(strcmp(options.ExogShockFnParamNames{ii},PricePathNames))
+                overlap=1;
+            end
+        end
+        if overlap==1
+            transpathoptions.gridsinGE=1;
+            transpathoptions.zpathtrivial=0; % z_grid and pi_z vary over the path
+            error('Not yet implemented to use ExogShockFn which includes parameters from PricePath (contact me)')
+        else % overlap==0
+            % Next,check if ExogShockFn depends on a ParamPath parameter
+            overlap2=0;
+            for ii=1:length(options.ExogShockFnParamNames)
+                if strcmp(options.ExogShockFnParamNames{ii},ParamPathNames)
+                    overlap2=1;
+                end
+            end
+            if overlap2==0
+                ExogShockFnParamsVec=CreateVectorFromParams(Parameters, options.ExogShockFnParamNames);
+                ExogShockFnParamsCell=cell(length(ExogShockFnParamsVec),1);
+                for ii=1:length(ExogShockFnParamsVec)
+                    ExogShockFnParamsCell(ii,1)={ExogShockFnParamsVec(ii)};
+                end
+                [z_grid,pi_z]=options.ExogShockFn(ExogShockFnParamsCell{:});
+            elseif overlap2==1 % ExogShockFn depends on a ParamPath parameter
+                transpathoptions.zpathtrivial=0; % z_grid and pi_z vary over the path
+                for tt=1:T
+                    for ii=1:length(ParamPathNames)
+                        Parameters.(ParamPathNames{ii})=ParamPathStruct.(ParamPathNames{ii});
+                    end
+                    % Note, we know the PricePath is irrelevant for the current purpose
+                    ExogShockFnParamsVec=CreateVectorFromParams(Parameters, options.ExogShockFnParamNames);
+                    ExogShockFnParamsCell=cell(length(ExogShockFnParamsVec),1);
+                    for ii=1:length(ExogShockFnParamsVec)
+                        ExogShockFnParamsCell(ii,1)={ExogShockFnParamsVec(ii)};
+                    end
+                    [z_grid,pi_z]=options.ExogShockFn(ExogShockFnParamsCell{:});
+                    transpathoptions.pi_z_T(:,:,tt)=pi_z;
+                    transpathoptions.z_grid_T(:,tt)=z_grid;
+                end
+            end
+        end
+
+    else % Not ExogShockFn, or at least not any more
+        if gridpiboth==1 % for most FnsToEvaluate, we don't use pi_z
+            if all(size(z_grid)==[prod(n_z),length(n_z)]) % joint grid
+                z_gridvals=z_grid;
+            elseif all(size(z_grid)==[sum(n_z),1]) % basic grid
+                z_gridvals=CreateGridvals(n_z,z_grid,1);
+            end
+        elseif gridpiboth==2 % For agent dist, we don't use grid
+            z_gridvals=[];
+        elseif gridpiboth==3 || gridpiboth==4 % For value fn, both z_gridvals and pi_z
+            if all(size(z_grid)==[prod(n_z),length(n_z)]) % joint grid
+                z_gridvals=z_grid;
+            elseif all(size(z_grid)==[sum(n_z),1]) % basic grid
+                z_gridvals=gpuArray(CreateGridvals(n_z,z_grid,1));
+            end
+        end
+    end
+    % Make sure they are on grid
+    pi_z=gpuArray(pi_z);
+    z_gridvals=gpuArray(z_gridvals);
+
+    if ~isfield(transpathoptions,'zpathtrivial')
+        transpathoptions.zpathtrivial=1;
+    end
+
+    % z_gridvals is [N_z,l_z]
+    % pi_z is [N_z,N_z]
+    % pi_z and z_gridvals are both gpuArrays
+
+end
+
+
+end

--- a/TransitionPaths/MixHorz/TransitionPath_Case1_MixHorz_PType.m
+++ b/TransitionPaths/MixHorz/TransitionPath_Case1_MixHorz_PType.m
@@ -1,0 +1,1013 @@
+function varargout=TransitionPath_Case1_MixHorz_PType(PricePath0, ParamPath, T, V_final, AgentDist_initial, jequalOneDist, n_d, n_a, n_z, N_j, Names_i, d_grid,a_grid,z_grid, pi_z, ReturnFn, FnsToEvaluate, GeneralEqmEqns, Parameters, DiscountFactorParamNames, AgeWeightsParamNames, PTypeDistParamNames, transpathoptions, simoptions, vfoptions)
+% This code will work for all transition paths except those that involve at
+% change in the transition matrix pi_z (can handle a change in pi_z, but
+% only if it is a 'surprise', not anticipated changes) 
+%
+% PricePathOld is a structure with fields names being the Prices and each field containing a T-by-1 path.
+% ParamPath is a structure with fields names being the parameter names of those parameters which change over the path and each field containing a T-by-1 path.
+
+% Remark to self: No real need for T as input, as this is anyway the length of PricePathOld
+
+% Create N_i so I can use it
+if iscell(Names_i)
+    N_i=length(Names_i);
+else
+    N_i=Names_i;
+end
+
+
+%% Check which transpathoptions have been used, set all others to defaults 
+if exist('transpathoptions','var')==0
+    disp('No transpathoptions given, using defaults')
+    %If transpathoptions is not given, just use all the defaults
+    transpathoptions.tolerance=10^(-4);
+    transpathoptions.parallel=1+(gpuDeviceCount>0); % GPU where available, otherwise parallel CPU.
+    transpathoptions.GEnewprice=1; % 1 is shooting algorithm, 0 is that the GE should evaluate to zero and the 'new' is the old plus the "non-zero" (for each time period seperately); 
+                                   % 2 is to do optimization routine with 'distance between old and new path', 3 is just same as 0, but easier to set up
+    transpathoptions.GEptype={}; % zeros(1,length(fieldnames(GeneralEqmEqns))); % 1 indicates that this general eqm condition is 'conditional on permanent type' [input should be a cell of names; it gets reformatted internally to be this form]
+    transpathoptions.PricePathptype_vectoroutput=0; % PricePath that depends on ptype defaults to being output as a structure
+    transpathoptions.oldpathweight=0.9; % default =0.9
+    transpathoptions.weightscheme=1; % default =1
+    transpathoptions.Ttheta=1;
+    transpathoptions.maxiter=500; % Based on personal experience anything that hasn't converged well before this is just hung-up on trying to get the 4th decimal place (typically because the number of grid points was not large enough to allow this level of accuracy).
+    transpathoptions.verbose=0;
+    transpathoptions.graphpricepath=0; % 1: creates a graph of the 'current' price path which updates each iteration.
+    transpathoptions.graphaggvarspath=0; % 1: creates a graph of the 'current' aggregate variables which updates each iteration.
+    transpathoptions.graphGEcondns=0;  % 1: creates a graph of the 'current' general eqm conditions which updates each iteration.
+    transpathoptions.historyofpricepath=0;
+    transpathoptions.stockvars=0;
+    transpathoptions.fastOLG=0; % fastOLG is done as (a,j,z), rather than standard (a,z,j)
+    % transpathoptions.updateageweights % Don't declare if not being used
+else
+    %Check transpathoptions for missing fields, if there are some fill them with the defaults
+    if ~isfield(transpathoptions,'tolerance')
+        transpathoptions.tolerance=10^(-4);
+    end
+    if ~isfield(transpathoptions,'parallel')
+        transpathoptions.parallel=1+(gpuDeviceCount>0);
+    end
+    if ~isfield(transpathoptions,'GEnewprice')
+        transpathoptions.GEnewprice=1; % 0 is that the GE should evaluate to zero and the 'new' is the old plus the "non-zero" (for each time period seperately);
+                                       % 1 is shooting algorithm, 
+                                       % 2 is to do optimization routine with 'distance between old and new path'
+                                       % 3 is just same as 0, but easier to set 
+    end
+    if ~isfield(transpathoptions,'GEptype')
+        transpathoptions.GEptype={}; %zeros(1,length(fieldnames(GeneralEqmEqns))); % 1 indicates that this general eqm condition is 'conditional on permanent type'
+    end
+    if ~isfield(transpathoptions,'PricePathptype_vectoroutput')
+        transpathoptions.PricePathptype_vectoroutput=0; % PricePath that depends on ptype defaults to being output as a structure
+    end
+    if ~isfield(transpathoptions,'oldpathweight')
+        transpathoptions.oldpathweight=0.9;
+        % Note that when using transpathoptions.GEnewprice==3
+        % Implicitly it is setting transpathoptions.oldpathweight=0
+        % because the user anyway has to specify them as part of setup
+    end
+    if ~isfield(transpathoptions,'weightscheme')
+        transpathoptions.weightscheme=1;
+    end
+    if ~isfield(transpathoptions,'Ttheta')
+        transpathoptions.Ttheta=1;
+    end
+    if ~isfield(transpathoptions,'maxiter')
+        transpathoptions.maxiter=1000;
+    end
+    if ~isfield(transpathoptions,'verbose')
+        transpathoptions.verbose=0;
+    end
+    if ~isfield(transpathoptions,'graphpricepath')
+        transpathoptions.graphpricepath=0; % 1: creates a graph of the 'current' price path which updates each iteration.
+    end
+    if ~isfield(transpathoptions,'graphaggvarspath')
+        transpathoptions.graphaggvarspath=0; % 1: creates a graph of the 'current' aggregate variables which updates each iteration.
+    end
+    if ~isfield(transpathoptions,'graphGEcondns')
+        transpathoptions.graphGEcondns=0;  % 1: creates a graph of the 'current' general eqm conditions which updates each iteration.
+    end
+    if ~isfield(transpathoptions,'historyofpricepath')
+        transpathoptions.historyofpricepath=0;
+    end
+    if ~isfield(transpathoptions,'stockvars') % stockvars is solely for internal use, the user does not need to set it
+        if ~isfield(transpathoptions,'stockvarinit') && ~isfield(transpathoptions,'stockvars') && ~isfield(transpathoptions,'stockvars')
+            transpathoptions.stockvars=0;
+        else
+            transpathoptions.stockvars=1; % If stockvars has not itself been declared, but at least one of the stock variable options has then set stockvars to 1.
+        end
+    end
+    if transpathoptions.stockvars==1 % Note: If this is not inputted then it is created by the above lines.
+        if ~isfield(transpathoptions,'stockvarinit')
+            error('transpathoptions includes some Stock Variable options but is missing stockvarinit \n')
+        elseif ~isfield(transpathoptions,'stockvarpath0')
+            error('transpathoptions includes some Stock Variable options but is missing stockvarpath0 \n')
+        elseif ~isfield(transpathoptions,'stockvareqns')
+            error('transpathoptions includes some Stock Variable options but is missing stockvareqns \n')
+        end
+    end
+    if ~isfield(transpathoptions,'fastOLG')
+        transpathoptions.fastOLG=0; % fastOLG is done as (a,j,z), rather than standard (a,z,j)
+    end
+    % transpathoptions.updateageweights %Don't declare if not being used
+end
+
+if transpathoptions.parallel~=2
+    error('Sorry but transition paths are not implemented for cpu, you will need a gpu to use them')
+end
+
+%% Reformat transpathoptions.GEptype from cell of names into vector of 1s and 0s
+if isempty(transpathoptions.GEptype)
+    transpathoptions.GEptype=zeros(1,length(fieldnames(GeneralEqmEqns))); % 1 indicates that this general eqm condition is 'conditional on permanent type'
+else
+    temp=transpathoptions.GEptype;
+    transpathoptions.GEptype=zeros(1,length(fieldnames(GeneralEqmEqns))); % 1 indicates that this general eqm condition is 'conditional on permanent type'
+    GEeqnNames=fieldnames(GeneralEqmEqns);
+    for gg1=1:length(temp)
+        for gg2=1:length(GEeqnNames)
+            if strcmp(temp{gg1},GEeqnNames{gg2})
+                transpathoptions.GEptype(gg2)=1;
+            end
+        end
+    end
+end
+
+
+%% Some internal commands require a few vfoptions and simoptions to be set
+vfoptions.EVpre=0; % Not actually an option that can be used here
+if ~isfield(vfoptions,'verbose')
+    vfoptions.verbose=0;
+end
+if ~isfield(vfoptions,'experienceasset')
+    for ii=1:N_i
+        vfoptions.experienceasset.(Names_i{ii})=0;
+    end
+else
+    % User created vfoptions.PType.experienceasset; we have Names_i
+    for ii=1:N_i
+        if isfield(vfoptions.experienceasset, Names_i{ii})
+            if ~isfield(vfoptions, 'aprimeFn') || ~isfield(vfoptions.aprimeFn, Names_i{ii})
+                error('To use an experience asset you must define vfoptions.aprimeFn')
+            end
+        else
+            vfoptions.experienceasset.(Names_i{ii})=0;
+        end
+    end
+end
+if ~isfield(vfoptions,'lowmemory')
+    for ii=1:N_i
+        vfoptions.lowmemory.(Names_i{ii})=0;
+    end
+else
+    % User created vfoptions.PType.lowmemory; we have Names_i
+    for ii=1:N_i
+        if ~isfield(vfoptions.lowmemory, Names_i{ii})
+            vfoptions.lowmemory.(Names_i{ii})=0;
+        end
+    end
+end
+
+%% Get AgeWeights from Parameters
+if isstruct(AgeWeightsParamNames)
+    for ii=1:N_i
+        try
+            AgeWeights=Parameters.(AgeWeightsParamNames.(Names_i{ii}){1});
+            if length(AgeWeights)~=N_j.(Names_i{ii})
+                error('Ageweights does not have age-like length')
+            else
+                break
+            end
+        catch
+            if ii==N_i
+                error(['Failed to find parameter ', AgeWeightsParamNames.(Names_i{ii}){1}])
+            end
+        end
+    end
+else
+    try
+        AgeWeights=Parameters.(AgeWeightsParamNames{1});
+    catch
+        error(['Failed to find parameter ', AgeWeightsParamNames{1}])
+    end
+end
+% Later, when creating PTypeStructure, we get the ptype-specific versions out of this and create an AgeWeights_T structure.
+
+%%
+[PricePath0,ParamPath,PricePathNames,ParamPathNames,PricePathSizeVec,ParamPathSizeVec,PricePathSizeVec_ii,ParamPathSizeVec_ii]=PricePathParamPath_MixHorz_StructToMatrix(PricePath0,ParamPath,N_j,T,N_i);
+
+if transpathoptions.verbose>1
+    PricePathNames
+    ParamPathNames
+end
+
+
+%% Check some inputs
+if isstruct(GeneralEqmEqns)
+    if length(PricePathNames)~=length(fieldnames(GeneralEqmEqns))
+        fprintf('length(PricePathNames)=%i and length(fieldnames(GeneralEqmEqns))=%i (relates to following error) \n', length(PricePathNames), length(fieldnames(GeneralEqmEqns)))
+        error('Initial PricePath contains fewer variables than GeneralEqmEqns (structure) \n')
+    end
+else
+    if length(PricePathNames)~=length(GeneralEqmEqns)
+        error('Initial PricePath contains fewer variables than GeneralEqmEqns')
+    end
+end
+
+
+%% Create PTypeStructure
+
+% PTypeStructure.Names_i never really gets used. Just makes things easier
+% to read when you are looking at PTypeStructure (which only ever exists
+% internally to the VFI Toolkit)
+if iscell(Names_i)
+    PTypeStructure.Names_i=Names_i;
+    PTypeStructure.N_i=length(Names_i);
+else
+    PTypeStructure.N_i=Names_i;
+    PTypeStructure.Names_i={'ptype001'};
+    for ii=2:PTypeStructure.N_i
+        if ii<10
+            PTypeStructure.Names_i{ii}=['ptype00',num2str(ii)];
+        elseif ii<100
+            PTypeStructure.Names_i{ii}=['ptype0',num2str(ii)];
+        elseif ii<1000
+            PTypeStructure.Names_i{ii}=['ptype',num2str(ii)];
+        end
+    end
+end
+
+
+%% Fill out all of PTypeStructure
+PTypeStructure.FnsAndPTypeIndicator=zeros(length(FnsToEvaluate),PTypeStructure.N_i,'gpuArray');
+
+if transpathoptions.verbose==1
+    fprintf('Setting up the permanent types for transition \n')
+end
+
+for ii=1:PTypeStructure.N_i
+
+    iistr=PTypeStructure.Names_i{ii};
+    PTypeStructure.iistr{ii}=iistr;
+    
+    if exist('vfoptions','var') % vfoptions.verbose (allowed to depend on permanent type)
+        PTypeStructure.(iistr).vfoptions=PType_Options(vfoptions,Names_i,ii); % some vfoptions will differ by permanent type, will clean these up as we go before they are passed
+    end
+    
+    if exist('simoptions','var') % vfoptions.verbose (allowed to depend on permanent type)
+        PTypeStructure.(iistr).simoptions=PType_Options(simoptions,Names_i,ii); % some simoptions will differ by permanent type, will clean these up as we go before they are passed
+    end
+    
+    % Need to fill in some defaults
+    PTypeStructure.(iistr).vfoptions.parallel=2; % hardcode
+    PTypeStructure.(iistr).simoptions.parallel=2; % hardcode
+    PTypeStructure.(iistr).simoptions.fastOLG=0; % hardcode TESTING
+    if ~isfield(PTypeStructure.(iistr).vfoptions,'n_e')
+        PTypeStructure.(iistr).n_e=0;
+    else
+        PTypeStructure.(iistr).n_e=PTypeStructure.(iistr).vfoptions.n_e;
+    end
+    if ~isfield(PTypeStructure.(iistr).vfoptions,'divideandconquer')
+        PTypeStructure.(iistr).vfoptions.divideandconquer=0; %default
+    else
+        if PTypeStructure.(iistr).vfoptions.divideandconquer==1
+            PTypeStructure.(iistr).vfoptions.level1n=ceil(n_a.(iistr)/50); % default
+        end
+    end
+    if ~isfield(PTypeStructure.(iistr).vfoptions,'gridinterplayer')
+        PTypeStructure.(iistr).vfoptions.gridinterplayer=0; %default
+    end
+    if ~isfield(PTypeStructure.(iistr).simoptions,'gridinterplayer')
+        PTypeStructure.(iistr).simoptions.gridinterplayer=0; %default
+    end
+    % Model setup
+    if ~isfield(PTypeStructure.(iistr).vfoptions,'exoticpreferences')
+        PTypeStructure.(iistr).vfoptions.exoticpreferences='None'; % not yet implemented, so hardcodes None
+    else
+        if ~strcmp(PTypeStructure.(iistr).vfoptions.exoticpreferences,'None')
+            error('transition paths cannot yet handle exoticpreferences')
+        end
+    end
+    if ~isfield(PTypeStructure.(iistr).vfoptions,'experienceasset')
+        PTypeStructure.(iistr).vfoptions.experienceasset=0;
+    end
+    if ~isfield(PTypeStructure.(iistr).simoptions,'experienceasset')
+        PTypeStructure.(iistr).simoptions.experienceasset=0;
+    end
+
+    % Go through everything which might be dependent on permanent type (PType)
+    % Notice that the way this is coded the grids (etc.) could be either
+    % fixed, or a function (that depends on age, and possibly on permanent
+    % type), or they could be a structure. Only in the case where they are
+    % a structure is there a need to take just a specific part and send
+    % only that to the 'non-PType' version of the command.
+    
+    % Start with those that determine whether the current permanent type is finite or
+    % infinite horizon, and whether it is Case 1 or Case 2
+    % Figure out which case is relevant to the current PType. This is done
+    % using N_j which for the current type will evaluate to 'Inf' if it is
+    % infinite horizon and a finite number for any other finite horizon.
+    % First, check if it is a structure, and otherwise just get the
+    % relevant value.
+    
+    % Horizon is determined via N_j
+    if isstruct(N_j)
+        PTypeStructure.(iistr).N_j=N_j.(iistr);
+    elseif isscalar(N_j)
+        PTypeStructure.(iistr).N_j=N_j;
+    else
+        PTypeStructure.(iistr).N_j=N_j(ii);
+    end
+    
+    if isa(n_d,'struct')
+        PTypeStructure.(iistr).n_d=n_d.(iistr);
+    else
+        PTypeStructure.(iistr).n_d=n_d;
+    end
+    N_d=prod(PTypeStructure.(iistr).n_d);
+    PTypeStructure.(iistr).N_d=N_d;
+    if N_d==0
+        PTypeStructure.(iistr).l_d=0;
+    else
+        PTypeStructure.(iistr).l_d=length(PTypeStructure.(iistr).n_d);
+    end
+    if isa(n_a,'struct')
+        PTypeStructure.(iistr).n_a=n_a.(iistr);
+    else
+        PTypeStructure.(iistr).n_a=n_a;
+    end
+    N_a=prod(PTypeStructure.(iistr).n_a);
+    PTypeStructure.(iistr).N_a=N_a;
+    PTypeStructure.(iistr).l_a=length(PTypeStructure.(iistr).n_a);
+    PTypeStructure.(iistr).l_aprime=PTypeStructure.(iistr).l_a;
+    if PTypeStructure.(iistr).vfoptions.experienceasset==1
+        PTypeStructure.(iistr).l_aprime=PTypeStructure.(iistr).l_aprime-1;
+    end
+    if isa(n_z,'struct')
+        PTypeStructure.(iistr).n_z=n_z.(iistr);
+    else
+        PTypeStructure.(iistr).n_z=n_z;
+    end
+    N_z=prod(PTypeStructure.(iistr).n_z);
+    PTypeStructure.(iistr).N_z=N_z;
+    if N_z==0
+        PTypeStructure.(iistr).l_z=0;
+    else
+        PTypeStructure.(iistr).l_z=length(n_z);
+    end
+    N_e=prod(PTypeStructure.(iistr).n_e);
+    PTypeStructure.(iistr).N_e=N_e;
+    if N_e==0
+        PTypeStructure.(iistr).l_e=0;
+    else
+        PTypeStructure.(iistr).l_e=length(PTypeStructure.(iistr).n_e);
+    end
+
+    if isa(d_grid,'struct')
+        PTypeStructure.(iistr).d_grid=gpuArray(d_grid.(iistr));
+    else
+        PTypeStructure.(iistr).d_grid=gpuArray(d_grid);
+    end
+    if isa(a_grid,'struct')
+        PTypeStructure.(iistr).a_grid=gpuArray(a_grid.(iistr));
+    else
+        PTypeStructure.(iistr).a_grid=gpuArray(a_grid);
+    end
+    if isa(z_grid,'struct')
+        PTypeStructure.(iistr).z_grid=gpuArray(z_grid.(iistr));
+    else
+        PTypeStructure.(iistr).z_grid=gpuArray(z_grid);
+    end
+
+    if PTypeStructure.(iistr).vfoptions.experienceasset
+        % Borrowed from TransitionPaths/InfHorz/TransitionPath_Case1.m
+        % Split decision variables into the standard ones and the one relevant to the experience asset
+        if isscalar(PTypeStructure.(iistr).n_d)
+            PTypeStructure.(iistr).n_d1=0;
+        else
+            PTypeStructure.(iistr).n_d1=PTypeStructure.(iistr).n_d(1:end-1);
+        end
+        PTypeStructure.(iistr).n_d2=PTypeStructure.(iistr).n_d(end); % n_d2 is the decision variable that influences next period vale of the experience asset
+        PTypeStructure.(iistr).d1_grid=PTypeStructure.(iistr).d_grid(1:sum(PTypeStructure.(iistr).n_d1));
+        PTypeStructure.(iistr).d2_grid=PTypeStructure.(iistr).d_grid(sum(PTypeStructure.(iistr).n_d1)+1:end);
+        % Split endogenous assets into the standard ones and the experience asset
+        if isscalar(PTypeStructure.(iistr).n_a)
+            PTypeStructure.(iistr).n_a1=0;
+        else
+            PTypeStructure.(iistr).n_a1=PTypeStructure.(iistr).n_a(1:end-1);
+        end
+        PTypeStructure.(iistr).n_a2=PTypeStructure.(iistr).n_a(end); % n_a2 is the experience asset
+        PTypeStructure.(iistr).a1_grid=PTypeStructure.(iistr).a_grid(1:sum(PTypeStructure.(iistr).n_a1));
+        PTypeStructure.(iistr).a2_grid=PTypeStructure.(iistr).a_grid(sum(PTypeStructure.(iistr).n_a1)+1:end);
+
+        % aprimeFnParamNames in same fashion
+        l_d2=length(PTypeStructure.(iistr).n_d2);
+        l_a2=length(PTypeStructure.(iistr).n_a2);
+        temp=getAnonymousFnInputNames(PTypeStructure.(iistr).vfoptions.aprimeFn);
+        if length(temp)>(l_d2+l_a2)
+            PTypeStructure.(iistr).aprimeFnParamNames={temp{l_d2+l_a2+1:end}}; % the first inputs will always be (d2,a2)
+        else
+            PTypeStructure.(iistr).aprimeFnParamNames={};
+        end
+
+        PTypeStructure.(iistr).N_a1=prod(PTypeStructure.(iistr).n_a1);
+
+        % to be able to EvalFnsOnAgentDist using fastOLG we also need
+        PTypeStructure.(iistr).a_gridvals=gpuArray(CreateGridvals(PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).a_grid,1)); % a_grivdals is [N_a,l_a]
+        % use fine grid for aprime_gridvals
+        if PTypeStructure.(iistr).vfoptions.gridinterplayer==0
+            PTypeStructure.(iistr).aprime_gridvals=PTypeStructure.(iistr).a_gridvals;
+        elseif PTypeStructure.(iistr).vfoptions.gridinterplayer==1
+            if isscalar(PTypeStructure.(iistr).n_a)
+                n_aprime=PTypeStructure.(iistr).n_a+(PTypeStructure.(iistr).n_a-1)*PTypeStructure.(iistr).vfoptions.ngridinterp;
+                aprime_grid=interp1(gpuArray(1:1:PTypeStructure.(iistr).N_a)',PTypeStructure.(iistr).a_grid,gpuArray(linspace(1,PTypeStructure.(iistr).N_a,n_aprime))');
+                PTypeStructure.(iistr).aprime_gridvals=CreateGridvals(n_aprime,aprime_grid,1);
+            else
+                a1_grid=PTypeStructure.(iistr).a_grid(1:PTypeStructure.(iistr).n_a(1));
+                n_a1prime=PTypeStructure.(iistr).n_a(1)+(PTypeStructure.(iistr).n_a(1)-1)*PTypeStructure.(iistr).vfoptions.ngridinterp;
+                n_aprime=[n_a1prime,PTypeStructure.(iistr).n_a(2:end)];
+                a1prime_grid=interp1(gpuArray(1:1:PTypeStructure.(iistr).n_a(1))',a1_grid,gpuArray(linspace(1,PTypeStructure.(iistr).n_a(1),n_a1prime))');
+                aprime_grid=[a1prime_grid; PTypeStructure.(iistr).a_grid(PTypeStructure.(iistr).n_a(1)+1:end)];
+                PTypeStructure.(iistr).aprime_gridvals=CreateGridvals(n_aprime,aprime_grid,1);
+            end
+        end
+        PTypeStructure.(iistr).d_gridvals=CreateGridvals(PTypeStructure.(iistr).n_d,gpuArray(PTypeStructure.(iistr).d_grid),1);
+        % if N_d==0
+        %     PTypeStructure.(iistr).daprime_gridvals=gpuArray(PTypeStructure.(iistr).a_gridvals);
+        % else
+        %     PTypeStructure.(iistr).daprime_gridvals=gpuArray([kron(ones(N_a,1),CreateGridvals(PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).d_grid,1)), kron(PTypeStructure.(iistr).a_gridvals,ones(PTypeStructure.(iistr).N_d,1))]); % daprime_gridvals is [N_d*N_aprime,l_d+l_aprime]
+        % end
+    else
+        % to be able to EvalFnsOnAgentDist using fastOLG we also need
+        PTypeStructure.(iistr).a_gridvals=gpuArray(CreateGridvals(PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).a_grid,1)); % a_grivdals is [N_a,l_a]
+        % use fine grid for aprime_gridvals
+        if PTypeStructure.(iistr).vfoptions.gridinterplayer==0
+            PTypeStructure.(iistr).aprime_gridvals=PTypeStructure.(iistr).a_gridvals;
+        elseif PTypeStructure.(iistr).vfoptions.gridinterplayer==1
+            if isscalar(PTypeStructure.(iistr).n_a)
+                n_aprime=PTypeStructure.(iistr).n_a+(PTypeStructure.(iistr).n_a-1)*PTypeStructure.(iistr).vfoptions.ngridinterp;
+                aprime_grid=interp1(gpuArray(1:1:PTypeStructure.(iistr).N_a)',PTypeStructure.(iistr).a_grid,gpuArray(linspace(1,PTypeStructure.(iistr).N_a,n_aprime))');
+                PTypeStructure.(iistr).aprime_gridvals=CreateGridvals(n_aprime,aprime_grid,1);
+            else
+                a1_grid=PTypeStructure.(iistr).a_grid(1:PTypeStructure.(iistr).n_a(1));
+                n_a1prime=PTypeStructure.(iistr).n_a(1)+(PTypeStructure.(iistr).n_a(1)-1)*PTypeStructure.(iistr).vfoptions.ngridinterp;
+                n_aprime=[n_a1prime,PTypeStructure.(iistr).n_a(2:end)];
+                a1prime_grid=interp1(gpuArray(1:1:PTypeStructure.(iistr).n_a(1))',a1_grid,gpuArray(linspace(1,PTypeStructure.(iistr).n_a(1),n_a1prime))');
+                aprime_grid=[a1prime_grid; PTypeStructure.(iistr).a_grid(PTypeStructure.(iistr).n_a(1)+1:end)];
+                PTypeStructure.(iistr).aprime_gridvals=CreateGridvals(n_aprime,aprime_grid,1);
+            end
+        end
+        PTypeStructure.(iistr).d_gridvals=CreateGridvals(PTypeStructure.(iistr).n_d,gpuArray(PTypeStructure.(iistr).d_grid),1);
+        % if N_d==0
+        %     PTypeStructure.(iistr).daprime_gridvals=gpuArray(PTypeStructure.(iistr).a_gridvals);
+        % else
+        %     PTypeStructure.(iistr).daprime_gridvals=gpuArray([kron(ones(N_a,1),CreateGridvals(PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).d_grid,1)), kron(PTypeStructure.(iistr).a_gridvals,ones(PTypeStructure.(iistr).N_d,1))]); % daprime_gridvals is [N_d*N_aprime,l_d+l_aprime]
+        % end
+    end
+
+    if isa(pi_z,'struct')
+        PTypeStructure.(iistr).pi_z=pi_z.(iistr); % Different grids by permanent type, but not depending on age. (same as the case just above; this case can occour with or without the existence of vfoptions, as long as there is no vfoptions.agedependentgrids)
+    else
+        PTypeStructure.(iistr).pi_z=pi_z;
+    end
+    
+    PTypeStructure.(iistr).ReturnFn=ReturnFn;
+    if isa(ReturnFn,'struct')
+        PTypeStructure.(iistr).ReturnFn=ReturnFn.(iistr);
+    end
+    
+    % Parameters are allowed to be given as structure, or as vector/matrix (in terms of their dependence on permanent type). 
+    % So go through each of these in term.
+    % ie. Parameters.alpha=[0;1]; or Parameters.alpha.ptype1=0; Parameters.alpha.ptype2=1;
+    PTypeStructure.(iistr).Parameters=Parameters;
+    FullParamNames=fieldnames(Parameters); % all the different parameters
+    nFields=length(FullParamNames);
+    for kField=1:nFields
+        if isa(Parameters.(FullParamNames{kField}), 'struct') % Check the current parameter for permanent type in structure form
+            % Check if this parameter is used for the current permanent type (it may or may not be, some parameters are only used be a subset of permanent types)
+            if isfield(Parameters.(FullParamNames{kField}),iistr)
+                PTypeStructure.(iistr).Parameters.(FullParamNames{kField})=Parameters.(FullParamNames{kField}).(iistr);
+            end
+        elseif sum(size(Parameters.(FullParamNames{kField}))==PTypeStructure.N_i)>=1 % Check for permanent type in vector/matrix form.
+            temp=Parameters.(FullParamNames{kField});
+            [~,ptypedim]=max(size(Parameters.(FullParamNames{kField}))==PTypeStructure.N_i); % Parameters as vector/matrix can be at most two dimensional, figure out which relates to PType, it should be the row dimension, if it is not then give a warning.
+            if ptypedim==1
+                PTypeStructure.(iistr).Parameters.(FullParamNames{kField})=temp(ii,:);
+            elseif ptypedim==2
+                if ~strcmp(FullParamNames{kField},PTypeDistParamNames{1})
+                    sprintf('Possible Warning: some parameters appear to have been imputted with dependence on permanent type indexed by column rather than row \n')
+                    sprintf(['Specifically, parameter: ', FullParamNames{kField}, ' \n'])
+                    sprintf('(it is possible this is just a coincidence of number of columns) \n')
+                    dbstack
+                end
+            end
+        end
+    end
+    % THIS TREATMENT OF PARAMETERS COULD BE IMPROVED TO BETTER DETECT INPUT SHAPE ERRORS.
+    PTypeStructure.ParametersRaw=Parameters; % For use in General eqm conditions (as we might want them across ptypes for some purposes)
+    
+    
+    % The parameter names can be made to depend on the permanent-type
+    PTypeStructure.(iistr).DiscountFactorParamNames=DiscountFactorParamNames;
+    if isa(DiscountFactorParamNames,'struct')
+        PTypeStructure.(iistr).DiscountFactorParamNames=DiscountFactorParamNames.(iistr);
+    end
+
+    % Implement new way of handling ReturnFn inputs (note l_d, l_a, l_z are just created for this and then not used for anything else later)
+    if PTypeStructure.(iistr).n_d(1)==0
+        l_d=0;
+    else
+        l_d=length(PTypeStructure.(iistr).n_d);
+    end
+    if PTypeStructure.(iistr).vfoptions.experienceasset
+        l_aprime=length(PTypeStructure.(iistr).n_a1);
+        l_a=l_aprime+length(PTypeStructure.(iistr).n_a2);
+    else
+        l_aprime=length(PTypeStructure.(iistr).n_a);
+        l_a=l_aprime;
+    end
+    l_z=length(PTypeStructure.(iistr).n_z);
+    if PTypeStructure.(iistr).n_z(1)==0
+        l_z=0;
+    end
+    if isfield(PTypeStructure.(iistr).vfoptions,'SemiExoStateFn')
+        l_z=l_z+length(PTypeStructure.(iistr).vfoptions.n_semiz);
+    end
+    l_e=0;
+    if isfield(PTypeStructure.(iistr).vfoptions,'n_e')
+        if PTypeStructure.(iistr).vfoptions.n_e(1)~=0
+            l_e=length(PTypeStructure.(iistr).vfoptions.n_e);
+        end
+    end
+    %% Implement new way of handling ReturnFn inputs
+    ReturnFnParamNames=ReturnFnParamNamesFn(PTypeStructure.(iistr).ReturnFn,PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).vfoptions,Parameters);
+    PTypeStructure.(iistr).ReturnFnParamNames=ReturnFnParamNames;
+    
+
+    %% Figure out which functions are actually relevant to the present PType. And then change to FnsToEvaluate as cell so that it is not being recomputed all the time 
+    % Only the relevant ones need to be evaluated.
+    % The dependence of FnsToEvaluateFn and FnsToEvaluateFnParamNames are necessarily the same.
+    PTypeStructure.(iistr).FnsToEvaluate={};
+    PTypeStructure.(iistr).FnsToEvaluateParamNames={};
+
+    FnNames=fieldnames(FnsToEvaluate);
+    PTypeStructure.numFnsToEvaluate=length(fieldnames(FnsToEvaluate));
+    PTypeStructure.(iistr).WhichFnsForCurrentPType=zeros(PTypeStructure.numFnsToEvaluate,1);
+    jj=1; % jj indexes the FnsToEvaluate that are relevant to the current PType
+    for kk=1:PTypeStructure.numFnsToEvaluate
+        if isstruct(FnsToEvaluate.(FnNames{kk}))
+            if isfield(FnsToEvaluate.(FnNames{kk}), iistr)
+                PTypeStructure.(iistr).FnsToEvaluate.(FnNames{kk})=FnsToEvaluate.(FnNames{kk}).(iistr);
+                % % Figure out FnsToEvaluateParamNames
+                % temp=getAnonymousFnInputNames(FnsToEvaluate.(FnNames{kk}).(Names_i{ii}));
+                % PTypeStructure.(iistr).FnsToEvaluateParamNames(jj).Names={temp{l_d+l_a+l_a+l_z+l_e+1:end}}; % the first inputs will always be (d,aprime,a,z)
+                PTypeStructure.(iistr).WhichFnsForCurrentPType(kk)=jj; jj=jj+1;
+                PTypeStructure.FnsAndPTypeIndicator(kk,ii)=1;
+                % else
+                %  % do nothing as this FnToEvaluate is not relevant for the current PType
+                % % Implicitly, PTypeStructure.(iistr).WhichFnsForCurrentPType(kk)=0
+            end
+        else
+            % If the Fn is not a structure (if it is a function) it is assumed to be relevant to all PTypes.
+            PTypeStructure.(iistr).FnsToEvaluate.(FnNames{kk})=FnsToEvaluate.(FnNames{kk});
+            % Figure out FnsToEvaluateParamNames
+            temp=getAnonymousFnInputNames(FnsToEvaluate.(FnNames{kk}));
+            PTypeStructure.(iistr).FnsToEvaluateParamNames(jj).Names={temp{l_d+l_aprime+l_a+l_z+l_e+1:end}}; % the first inputs will always be (d,aprime,a,z)
+            PTypeStructure.(iistr).WhichFnsForCurrentPType(kk)=jj; jj=jj+1;
+            PTypeStructure.FnsAndPTypeIndicator(kk,ii)=1;
+        end
+    end
+
+    % Now that all the relevant FnsToEvaluate for type ii are in PTypeStructure.(iistr).FnsToEvaluate
+    PTypeStructure.(iistr).l_daprime=PTypeStructure.(iistr).l_d+PTypeStructure.(iistr).l_aprime;
+    PTypeStructure.(iistr).AggVarNames=fieldnames(PTypeStructure.(iistr).FnsToEvaluate);
+    PTypeStructure.(iistr).FnsToEvaluateCell=cell(1,length(PTypeStructure.(iistr).AggVarNames));
+    for ff=1:length(PTypeStructure.(iistr).AggVarNames)
+        temp=getAnonymousFnInputNames(PTypeStructure.(iistr).FnsToEvaluate.(PTypeStructure.(iistr).AggVarNames{ff}));
+        if length(temp)>(PTypeStructure.(iistr).l_daprime+PTypeStructure.(iistr).l_a+PTypeStructure.(iistr).l_z+PTypeStructure.(iistr).l_e)
+            PTypeStructure.(iistr).FnsToEvaluateParamNames(ff).Names={temp{PTypeStructure.(iistr).l_daprime+PTypeStructure.(iistr).l_a+PTypeStructure.(iistr).l_z+PTypeStructure.(iistr).l_e+1:end}}; % the first inputs will always be (d,aprime,a,z)
+        else
+            PTypeStructure.(iistr).FnsToEvaluateParamNames(ff).Names={};
+        end
+        PTypeStructure.(iistr).FnsToEvaluateCell{ff}=PTypeStructure.(iistr).FnsToEvaluate.(PTypeStructure.(iistr).AggVarNames{ff});
+    end
+    % Change FnsToEvaluate out of structure form, but want to still create AggVars as a structure
+    PTypeStructure.(iistr).simoptions.outputasstructure=1;
+
+
+    %% Set up exogenous shock processes
+    if isfinite(PTypeStructure.(iistr).N_j)
+        [PTypeStructure.(iistr).z_gridvals_J, PTypeStructure.(iistr).pi_z_J, PTypeStructure.(iistr).pi_z_J_sim, PTypeStructure.(iistr).e_gridvals_J, PTypeStructure.(iistr).pi_e_J, PTypeStructure.(iistr).pi_e_J_sim, PTypeStructure.(iistr).ze_gridvals_J_fastOLG, transpathoptions, PTypeStructure.(iistr).simoptions]=ExogShockSetup_TPath_FHorz(PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).z_grid,PTypeStructure.(iistr).pi_z,PTypeStructure.(iistr).N_a,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).Parameters,PricePathNames,ParamPathNames,transpathoptions,PTypeStructure.(iistr).simoptions,4);
+        % Convert z and e to age-dependent joint-grids and transtion matrix
+        % output: z_gridvals_J, pi_z_J, e_gridvals_J, pi_e_J, transpathoptions,vfoptions,simoptions
+    else
+        [PTypeStructure.(iistr).z_gridvals, PTypeStructure.(iistr).pi_z, transpathoptions, PTypeStructure.(iistr).simoptions]=ExogShockSetup_TPath_InfHorz(PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).z_grid,PTypeStructure.(iistr).pi_z,PTypeStructure.(iistr).N_a,PTypeStructure.(iistr).Parameters,PricePathNames,ParamPathNames,transpathoptions,PTypeStructure.(iistr).simoptions,4);
+    end
+
+    %% If using any non-standard endogenous states, setup for those (both FHorz and InfHorz btw)
+    [PTypeStructure.(iistr).vfoptions,PTypeStructure.(iistr).simoptions]=SetupNonStandardEndoStates_FHorz_TPath(PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).d_grid,PTypeStructure.(iistr).a_grid,PTypeStructure.(iistr).vfoptions,PTypeStructure.(iistr).simoptions);
+    
+    %% Organise V_final and AgentDist_initial
+    % Reshape V_final
+    if ~isfinite(PTypeStructure.(iistr).N_j)
+        % If no z, then N_z=1 here
+        V_final.(iistr)=reshape(V_final.(iistr),[N_a,N_z]);
+    elseif transpathoptions.fastOLG==0
+        N_j_temp=PTypeStructure.(iistr).N_j;
+        if N_z==0
+            if N_e==0
+                V_final.(iistr)=reshape(V_final.(iistr),[N_a,N_j_temp]);
+            else
+                V_final.(iistr)=reshape(V_final.(iistr),[N_a,N_e,N_j_temp]);
+            end
+        else
+            if N_e==0
+                V_final.(iistr)=reshape(V_final.(iistr),[N_a,N_z,N_j_temp]);
+            else
+                V_final.(iistr)=reshape(V_final.(iistr),[N_a,N_z,N_e,N_j_temp]);
+            end
+        end
+    else % transpathoptions.fastOLG==1
+        N_j_temp=PTypeStructure.(iistr).N_j;
+        if N_z==0
+            if N_e==0
+                V_final.(iistr)=reshape(V_final.(iistr),[N_a,N_j_temp]);
+            else
+                V_final.(iistr)=reshape(permute(V_final.(iistr),[1,3,2]),[N_a*N_j_temp,N_e]);
+            end
+        else
+            if N_e==0
+                V_final.(iistr)=reshape(permute(V_final.(iistr),[1,3,2]),[N_a*N_j_temp,N_z]);
+            else
+                V_final.(iistr)=reshape(permute(V_final.(iistr),[1,4,2,3]),[N_a*N_j_temp,N_z,N_e]);
+            end
+        end
+    end
+    % Reshape AgentDist_initial and turn AgeWeights_T into appropriate size so that we can always just do AgentDist.*AgeWeights
+    % Note when simoptions.fastOLG==1 we have shapes of [N_a*N_j_temp*whatever,1-or-N_e] instead of [N_a,whatever-and-maybe-N_e,N_j_temp]
+    AgentDist_init=AgentDist_initial.(iistr);
+    if isfinite(PTypeStructure.(iistr).N_j)
+        N_j_temp=PTypeStructure.(iistr).N_j;
+        if N_z==0
+            if N_e==0
+                AgentDist_init=reshape(AgentDist_init,[N_a,N_j_temp]); % if simoptions.fastOLG==0
+                AgeWeights_init=sum(AgentDist_init,1); % [1,N_j]
+                if PTypeStructure.(iistr).simoptions.fastOLG
+                    AgentDist_init=reshape(AgentDist_init,[N_a*N_j_temp,1]);
+                    AgeWeights_init=repelem(AgeWeights_init',N_a,1);
+                end
+            else
+                AgentDist_init=reshape(AgentDist_init,[N_a*N_e,N_j_temp]); % if simoptions.fastOLG==0
+                AgeWeights_init=sum(AgentDist_init,1); % [1,N_j]
+                if PTypeStructure.(iistr).simoptions.fastOLG % simoptions.fastOLG==1, so AgentDist is treated as : (a,j,z)-by-1
+                    AgentDist_init=reshape(permute(reshape(AgentDist_init,[N_a,N_e,N_j_temp]),[1,3,2]),[N_a*N_j_temp,N_e]);
+                    AgeWeights_init=repelem(AgeWeights_init',N_a,1);
+                end
+            end
+        else
+            if N_e==0
+                AgentDist_init=reshape(AgentDist_init,[N_a*N_z,N_j_temp]); % if simoptions.fastOLG==0
+                AgeWeights_init=sum(AgentDist_init,1); % [1,N_j]
+                if PTypeStructure.(iistr).simoptions.fastOLG % simoptions.fastOLG==1, so AgentDist is treated as : (a,j,z)-by-1
+                    AgentDist_init=reshape(permute(reshape(AgentDist_init,[N_a,N_z,N_j_temp]),[1,3,2]),[N_a*N_j_temp*N_z,1]);
+                    AgeWeights_init=repelem(AgeWeights_init',N_a,1);
+                end
+            else
+                AgentDist_init=reshape(AgentDist_init,[N_a*N_z*N_e,N_j_temp]); % if simoptions.fastOLG==0
+                AgeWeights_init=sum(AgentDist_init,1); % [1,N_j]
+                if PTypeStructure.(iistr).simoptions.fastOLG % simoptions.fastOLG==1, so AgentDist is treated as : (a,j,z)-by-1
+                    AgentDist_init=reshape(permute(reshape(AgentDist_init,[N_a,N_z,N_e,N_j_temp]),[1,4,2,3]),[N_a*N_j_temp*N_z,N_e]);
+                    AgeWeights_init=repelem(AgeWeights_init',N_a,1);
+                end
+            end
+        end
+
+        % Get AgeWeights and switch into the transpathoptions.ageweightstrivial=0 setup (and this is what subfns hardcode when doing PTypes)
+        % It is assumed there is only one Age Weight Parameter (name))
+        % AgeWeights_T is (a,j,z)-by-T (create as N_j-by-T to start, then switch)
+        if isstruct(AgeWeights)
+            AgeWeights_ii=AgeWeights.(iistr);
+            if all(size(AgeWeights_ii)==[N_j_temp,1])
+                % Does not depend on transition path period
+                PTypeStructure.(iistr).AgeWeights_T=gather(AgeWeights_ii.*ones(1,T));
+            elseif all(size(AgeWeights)==[1,N_j_temp])
+                % Does not depend on transition path period
+                PTypeStructure.(iistr).AgeWeights_T=gather(AgeWeights_ii'.*ones(1,T));
+            else
+                fprintf('Following error applies to agent permanent type: %s \n',iistr)
+                error('The age weights parameter seems to be the wrong size')
+            end
+        else % not a structure, so must apply to all permanent types
+            if all(size(AgeWeights)==[N_j_temp,1])
+                % Does not depend on transition path period
+                PTypeStructure.(iistr).AgeWeights_T=gather(AgeWeights.*ones(1,T));
+            elseif all(size(AgeWeights)==[1,N_j_temp])
+                % Does not depend on transition path period
+                PTypeStructure.(iistr).AgeWeights_T=gather(AgeWeights'.*ones(1,T));
+            else
+                error('The age weights parameter seems to be the wrong size')
+            end
+        end
+    
+        %% Set up jequalOneDist_T.(iistr) [hardcodes transpathoptions.trivialjequalonedist=0]
+        if ~isstruct(jequalOneDist)
+            jequalOneDist_temp=gpuArray(jequalOneDist);
+        else % jequalOneDist is a structure
+            jequalOneDist_temp=gpuArray(jequalOneDist.(iistr));
+        end
+        % Check if jequalOneDistPath is a path or not (and reshape appropriately)
+        temp=size(jequalOneDist_temp);
+        if temp(end)==T % jequalOneDist depends on T
+            transpathoptions.(iistr).trivialjequalonedist=0;
+            if N_z==0
+                if N_e==0
+                    jequalOneDist_temp=reshape(jequalOneDist_temp,[N_a,T]);
+                else
+                    jequalOneDist_temp=reshape(jequalOneDist_temp,[N_a*N_e,T]); % simoptions.fastOLG==1
+                end
+            else
+                if N_e==0
+                    jequalOneDist_temp=reshape(jequalOneDist_temp,[N_a*N_z,T]); % simoptions.fastOLG==1
+                else
+                    jequalOneDist_temp=reshape(jequalOneDist_temp,[N_a*N_z*N_e,T]); % simoptions.fastOLG==1
+                end
+            end
+            PTypeStructure.(iistr).jequalOneDist_T=jequalOneDist_temp;
+        else
+            transpathoptions.(iistr).trivialjequalonedist=1;
+            if N_z==0
+                if N_e==0
+                    jequalOneDist_temp=reshape(jequalOneDist_temp,[N_a,1]);
+                else
+                    jequalOneDist_temp=reshape(jequalOneDist_temp,[N_a*N_e,1]); % simoptions.fastOLG==1
+                end
+            else
+                if N_e==0
+                    jequalOneDist_temp=reshape(jequalOneDist_temp,[N_a*N_z,1]); % simoptions.fastOLG==1
+                else
+                    jequalOneDist_temp=reshape(jequalOneDist_temp,[N_a*N_z*N_e,1]); % simoptions.fastOLG==1 (how different than simoptions.fastOLG==0?)
+                end
+            end
+            PTypeStructure.(iistr).jequalOneDist=jequalOneDist_temp;
+        end
+
+        % Check ParamPath to see if the AgeWeights vary over the transition
+        % (and overwrite PTypeStructure.(iistr).AgeWeights_T if it does)
+        temp=strcmp(ParamPathNames,AgeWeightsParamNames.(iistr){1});
+        if any(temp)
+            transpathoptions.ageweightstrivial=0; % AgeWeights vary over the transition
+            [~,kk]=max(temp); % Get index for the AgeWeightsParamNames{1} in ParamPathNames
+            % Create AgeWeights_T
+            PTypeStructure.(iistr).AgeWeights_T=ParamPath(:,ParamPathSizeVec(1,kk):ParamPathSizeVec(2,kk))'; % This will always be N_j-by-T (as transpose)
+            % Note: still leave it in ParamPath just in case it is used in AggVars or somesuch
+        end
+
+        % Because ptypes hardcodes transpathoptions.ageweightstrivial=0, we need
+        if PTypeStructure.(iistr).simoptions.fastOLG==1
+            if N_z==0
+                PTypeStructure.(iistr).AgeWeights_T=repelem(PTypeStructure.(iistr).AgeWeights_T,N_a,1); % simoptions.fastOLG=1 so this is (a,j)-by-1
+            else
+                PTypeStructure.(iistr).AgeWeights_T=repmat(repelem(PTypeStructure.(iistr).AgeWeights_T,N_a,1),N_z,1); % simoptions.fastOLG=1 so this is (a,j,z)-by-1
+            end
+        end
+    else % InfHorz case
+        if N_z==0
+            AgentDist_init=reshape(AgentDist_init,[N_a,1]);
+        else
+            AgentDist_init=reshape(AgentDist_init,[N_a*N_z,1]);
+        end
+    end
+
+    AgentDist_initial.(iistr)=AgentDist_init;
+    clear AgentDist_init
+    
+    %% Which parts of ParamPath and PricePath relate to ptype ii
+    % Some ParamPath and PricePath parameters may depend on ptype
+    PTypeStructure.(iistr).RelevantPricePath=ones(1,size(PricePath0,2)); % start will all relevant
+    for pp=1:length(PricePathNames)
+        if PricePathSizeVec(2,pp)-PricePathSizeVec(1,pp)+1==PTypeStructure.N_i
+            % This depends on ii, so only keep the ii-th one
+            PTypeStructure.(iistr).RelevantPricePath(PricePathSizeVec(1,pp):PricePathSizeVec(2,pp))=zeros(1,PTypeStructure.N_i);
+            PTypeStructure.(iistr).RelevantPricePath(PricePathSizeVec(1,pp)+ii-1)=1;
+        end
+    end
+    PTypeStructure.(iistr).RelevantPricePath=logical(PTypeStructure.(iistr).RelevantPricePath); % logical, so easier to use later
+    PTypeStructure.(iistr).RelevantParamPath=ones(1,size(ParamPath,2)); % start will all relevant
+    for pp=1:length(ParamPathNames)
+        if ParamPathSizeVec(2,pp)-ParamPathSizeVec(1,pp)+1==PTypeStructure.N_i
+            % This depends on ii, so only keep the ii-th one
+            PTypeStructure.(iistr).RelevantParamPath(ParamPathSizeVec(1,pp):ParamPathSizeVec(2,pp))=zeros(1,PTypeStructure.N_i);
+            PTypeStructure.(iistr).RelevantParamPath(ParamPathSizeVec(1,pp)+ii-1)=1;
+        end
+    end
+    PTypeStructure.(iistr).RelevantParamPath=logical(PTypeStructure.(iistr).RelevantParamPath); % logical, so easier to use later
+
+
+    if ii==1
+        PTypeStructure.PricePath_Idependsonptype=zeros(1,length(PricePathNames));
+        for pp=1:length(PricePathNames)
+            if PricePathSizeVec(2,pp)-PricePathSizeVec(1,pp)+1==PTypeStructure.N_i
+                PTypeStructure.PricePath_Idependsonptype(pp)=1; % This depends on ii
+            end
+        end
+        PTypeStructure.ParamPath_Idependsonptype=zeros(1,length(ParamPathNames));
+        for pp=1:length(ParamPathNames)
+            if ParamPathSizeVec(2,pp)-ParamPathSizeVec(1,pp)+1==PTypeStructure.N_i
+                PTypeStructure.ParamPath_Idependsonptype(pp)=1; % This depends on ii
+            end
+        end
+    end
+end
+
+%% If using intermediateEqns, switch from structure to cell setup
+transpathoptions.useintermediateEqns=0;
+if isfield(transpathoptions,'intermediateEqns')
+    transpathoptions.useintermediateEqns=1;
+    intEqnNames=fieldnames(transpathoptions.intermediateEqns);
+    nIntEqns=length(intEqnNames);
+
+    transpathoptions.intermediateEqnsCell=cell(1,nIntEqns);
+    for gg=1:nIntEqns
+        temp=getAnonymousFnInputNames(transpathoptions.intermediateEqns.(intEqnNames{gg}));
+        transpathoptions.intermediateEqnParamNames(gg).Names=temp;
+        transpathoptions.intermediateEqnsCell{gg}=transpathoptions.intermediateEqns.(intEqnNames{gg});        
+    end
+    % Now:
+    %  transpathoptions.intermediateEqns is still the structure
+    %  transpathoptions.intermediateEqnsCell is cell
+    %  transpathoptions.intermediateEqnParamNames(gg).Names contains the names
+end
+
+%% GE eqns, switch from structure to cell setup
+GEeqnNames=fieldnames(GeneralEqmEqns);
+nGeneralEqmEqns=length(GEeqnNames);
+nGeneralEqmEqns_acrossptypes=sum(transpathoptions.GEptype==0)+N_i*sum(transpathoptions.GEptype==1);
+
+GeneralEqmEqnsCell=cell(1,nGeneralEqmEqns);
+for gg=1:nGeneralEqmEqns
+    temp=getAnonymousFnInputNames(GeneralEqmEqns.(GEeqnNames{gg}));
+    GeneralEqmEqnParamNames(gg).Names=temp;
+    GeneralEqmEqnsCell{gg}=GeneralEqmEqns.(GEeqnNames{gg});
+end
+% Now: 
+%  GeneralEqmEqns is still the structure
+%  GeneralEqmEqnsCell is cell
+%  GeneralEqmEqnParamNames(ff).Names contains the names
+
+
+
+%%
+if transpathoptions.stockvars==1 
+    error('transpathoptions.stockvars=1 not yet implemented with PType \n')
+end
+
+if transpathoptions.verbose==1
+    fprintf('Completed setup, beginning transition computination \n')
+end
+
+
+%% If using a shooting algorithm, set that up
+transpathoptions=setupGEnewprice3_shooting(transpathoptions,GeneralEqmEqns,PricePathNames,N_i,PricePathSizeVec);
+
+%% Check if using _tminus1 and/or _tplus1 variables, and update PTypeStructure
+if isstruct(FnsToEvaluate) && isstruct(GeneralEqmEqns)
+    [tplus1priceNames,tminus1priceNames,tminus1AggVarsNames,tminus1paramNames,tplus1pricePathkk]=inputsFindtplus1tminus1(FnsToEvaluate,GeneralEqmEqns,PricePathNames,ParamPathNames,Names_i);
+    if isstruct(tminus1AggVarsNames)
+        AggVarsPTypes=fieldnames(tminus1AggVarsNames);
+        for ii=1:length(AggVarsPTypes)
+            PTypeStructure.(AggVarsPTypes{ii}).tminus1AggVarsNames=tminus1AggVarsNames.(AggVarsPTypes{ii});
+        end
+    end
+else
+    tplus1priceNames=[];
+    tminus1priceNames=[];
+    tminus1paramNames=[];
+    tminus1AggVarsNames=[];
+    tplus1pricePathkk=[];  % I cannot remember what this was even for (how is it different rom tplus1priceNames??)
+end
+
+use_tplus1price=0;
+if ~isempty(tplus1priceNames)
+    use_tplus1price=1;
+end
+use_tminus1price=0;
+if ~isempty(tminus1priceNames)
+    use_tminus1price=1;
+    if isstruct(tminus1AggVarsNames)
+        AggVarsPTypes=fieldnames(tminus1AggVarsNames);
+        for nn=1:length(AggVarsPTypes)
+            for ii=1:length(tminus1AggVarsNames.(AggVarsPTypes{nn}))
+                if ~isfield(transpathoptions.initialvalues,tminus1AggVarsNames.(AggVarsPTypes{nn}){ii})
+                    error('Using %s as an input (to FnsToEvaluate or GeneralEqmEqns) but it is not in transpathoptions.initialvalues \n',tminus1AggVarsNames.(AggVarsPTypes{nn}){ii})
+                end
+            end
+        end
+    else
+        for ii=1:length(tminus1AggVarsNames)
+            if ~isfield(transpathoptions.initialvalues,tminus1AggVarsNames{ii})
+                error('Using %s as an input (to FnsToEvaluate or GeneralEqmEqns) but it is not in transpathoptions.initialvalues \n',tminus1AggVarsNames{ii})
+            end
+        end
+    end
+end
+use_tminus1params=0;
+if ~isempty(tminus1paramNames)
+    use_tminus1params=1;
+    for ii=1:length(tminus1paramNames)
+        if ~isfield(transpathoptions.initialvalues,tminus1paramNames{ii})
+            error('Using %s as an input (to FnsToEvaluate or GeneralEqmEqns) but it is not in transpathoptions.initialvalues \n',tminus1paramNames{ii})
+        end
+    end
+end
+use_tminus1AggVars=0;
+if ~isempty(tminus1AggVarsNames)
+    use_tminus1AggVars=1;
+    if isstruct(tminus1AggVarsNames)
+        AggVarsPTypes=fieldnames(tminus1AggVarsNames);
+        for nn=1:length(AggVarsPTypes)
+            for ii=1:length(tminus1AggVarsNames.(AggVarsPTypes{nn}))
+                if ~isfield(transpathoptions.initialvalues,tminus1AggVarsNames.(AggVarsPTypes{nn}){ii})
+                    error('Using %s as an input (to FnsToEvaluate or GeneralEqmEqns) but it is not in transpathoptions.initialvalues \n',tminus1AggVarsNames.(AggVarsPTypes{nn}){ii})
+                end
+            end
+        end
+    else
+        for ii=1:length(tminus1AggVarsNames)
+            if ~isfield(transpathoptions.initialvalues,tminus1AggVarsNames{ii})
+                error('Using %s as an input (to FnsToEvaluate or GeneralEqmEqns) but it is not in transpathoptions.initialvalues \n',tminus1AggVarsNames{ii})
+            end
+        end
+    end
+end
+% Note: I used this approach (rather than just creating _tplus1 and _tminus1 for everything) as it will be same computation.
+
+if transpathoptions.verbose>1
+    use_tplus1price
+    use_tminus1price
+    use_tminus1params
+    use_tminus1AggVars
+    % tplus1pricePathkk
+end
+
+
+if transpathoptions.verbose>=1
+    transpathoptions
+end
+
+%% Shooting algorithm
+if transpathoptions.GEnewprice~=2
+    % For permanent types, there is just one shooting command,
+    % because things like z,e, and fastOLG, as well as ExpAsset are handled on a per-PType basis (to permit that they differ across ptype)
+    [PricePath,GEcondnPath]=TransitionPath_Case1_MixHorz_PType_shooting(PricePath0, PricePathNames, ParamPath, ParamPathNames, T, V_final, AgentDist_initial, FnsToEvaluate, GeneralEqmEqns, PricePathSizeVec, ParamPathSizeVec, PricePathSizeVec_ii, ParamPathSizeVec_ii, GEeqnNames,nGeneralEqmEqns,nGeneralEqmEqns_acrossptypes,GeneralEqmEqnsCell,GeneralEqmEqnParamNames, use_tminus1price, use_tminus1params, use_tplus1price, use_tminus1AggVars, tminus1priceNames, tminus1paramNames, tplus1priceNames, tminus1AggVarsNames, transpathoptions, PTypeStructure);
+
+    % Switch the solution into structure for output.
+    pp_indexinpricepath=zeros(1,length(PricePathNames));
+    pp_c=0;
+    for pp=1:length(PricePathNames)
+        if PTypeStructure.PricePath_Idependsonptype(pp)==0
+            pp_c=pp_c+1;
+            pp_indexinpricepath(pp)=pp_c;
+        else
+            pp_c=pp_c+1;
+            pp_indexinpricepath(pp)=pp_c;
+            pp_c=pp_c+(PTypeStructure.N_i-1);
+        end
+    end
+
+    for pp=1:length(PricePathNames)
+        if PTypeStructure.PricePath_Idependsonptype(pp)==0
+            PricePathStruct.(PricePathNames{pp})=PricePath(:,pp_indexinpricepath(pp));
+        else
+            if transpathoptions.PricePathptype_vectoroutput==1
+                PricePathStruct.(PricePathNames{pp})=PricePath(:,pp_indexinpricepath(pp):pp_indexinpricepath(pp)+PTypeStructure.N_i-1);
+            elseif transpathoptions.PricePathptype_vectoroutput==0
+                for ii=1:N_i
+                    PricePathStruct.(PricePathNames{pp}).(Names_i{ii})=PricePath(:,pp_indexinpricepath(pp)+ii-1);
+                end
+            end
+        end
+    end
+
+    if nargout==1
+        varargout={PricePathStruct};
+    elseif nargout==2
+        varargout={PricePathStruct,GEcondnPath};
+    end
+
+    return
+end
+
+
+%%
+if transpathoptions.GEnewprice==2 % Function minimization
+    % Have not attempted implementing this for PType yet, no point until I
+    % get it to be useful without PType
+    error('Have not yet implemented transpathoptions.GEnewprice=2')
+
+    if nargout==1
+        varargout={PricePathStruct};
+    elseif nargout==2
+        varargout={PricePathStruct,GEcondnPath};
+    end
+
+end
+
+
+end

--- a/TransitionPaths/MixHorz/TransitionPath_Case1_MixHorz_PType_shooting.m
+++ b/TransitionPaths/MixHorz/TransitionPath_Case1_MixHorz_PType_shooting.m
@@ -1,0 +1,637 @@
+function [PricePathOld,GEcondnPath]=TransitionPath_Case1_MixHorz_PType_shooting(PricePathOld, PricePathNames, ParamPath, ParamPathNames, T, V_final, AgentDist_initial, FullFnsToEvaluate, GeneralEqmEqns, PricePathSizeVec, ParamPathSizeVec, PricePathSizeVec_ii, ParamPathSizeVec_ii, GEeqnNames,nGeneralEqmEqns,nGeneralEqmEqns_acrossptypes,GeneralEqmEqnsCell,GeneralEqmEqnParamNames, use_tminus1price, use_tminus1params, use_tplus1price, use_tminus1AggVars, tminus1priceNames, tminus1paramNames, tplus1priceNames, tminus1AggVarsNames, transpathoptions, PTypeStructure)
+% This code will work for all transition paths except those that involve at
+% change in the transition matrix pi_z (can handle a change in pi_z, but
+% only if it is a 'surprise', not anticipated changes) 
+
+% PricePathOld is matrix of size T-by-'number of prices'
+% ParamPath is matrix of size T-by-'number of parameters that change over path'
+
+% Remark to self: No real need for T as input, as this is anyway the length of PricePathOld
+
+N_i=PTypeStructure.N_i; % For convenience
+FullAggVarNames=fieldnames(FullFnsToEvaluate);
+
+l_p=size(PricePathOld,2);
+
+if transpathoptions.verbose==1
+    % Set up some things to be used later
+    pathnametitles=cell(1,2*length(PricePathNames));
+    for ii=1:length(PricePathNames)
+        pathnametitles{ii}={['Old ',PricePathNames{ii},', ']};
+        pathnametitles{ii+length(PricePathNames)}={['New ',PricePathNames{ii},', ']};
+    end
+    % Make it something I can just print to screen
+    pathnametitles=append(pathnametitles{:});
+    pathnametitles=pathnametitles{1};
+    pathnametitles=pathnametitles(1:end-2);
+end
+
+
+%% Setup used for graphs
+% For graph of the Prices
+if length(PricePathNames)>12
+    ncolumns_pricepath=4;
+elseif length(PricePathNames)>6
+    ncolumns_pricepath=3;
+else
+    ncolumns_pricepath=2;
+end
+nrows_pricepath=ceil(length(PricePathNames)/ncolumns_pricepath);
+
+pp_indexinpricepath=zeros(1,length(PricePathNames));
+pp_c=0;
+for pp=1:length(PricePathNames)
+    if PTypeStructure.PricePath_Idependsonptype(pp)==0
+        pp_c=pp_c+1;
+        pp_indexinpricepath(pp)=pp_c;
+    else
+        pp_c=pp_c+1;
+        pp_indexinpricepath(pp)=pp_c;
+        pp_c=pp_c+(N_i-1);
+    end
+end
+
+% For graph of the AggVars
+if length(FullAggVarNames)>12
+    ncolumns_aggvars=4;
+elseif length(FullAggVarNames)>6
+    ncolumns_aggvars=3;
+else
+    ncolumns_aggvars=2;
+end
+nrows_aggvars=ceil(length(FullAggVarNames)/ncolumns_aggvars);
+
+% which AggVars are used in a GE condition that gets evaluated based on ptype (so can plot them too)
+aa_aggvarbyptype=zeros(1,length(FullAggVarNames));
+for aa=1:length(FullAggVarNames)
+    for gg=1:length(GEeqnNames)
+        if transpathoptions.GEptype(gg)==1
+            % if any(strcmp(GeneralEqmEqnParamNames(gg).Names,FullAggVarNames{aa}). But we have to allow for the inputs to GE to have endings like _tminus1
+            temp=FullAggVarNames{aa};
+            for aa2=1:length(GeneralEqmEqnParamNames(gg).Names)
+                temp2=GeneralEqmEqnParamNames(gg).Names{aa2};
+                if length(temp2)==length(temp)
+                    if strcmp(temp2,temp)
+                        aa_aggvarbyptype(aa)=1; % aa AggVar is in this GE condition that depends on ptype
+                    end
+                elseif length(temp2)>length(temp)
+                    if strcmp(temp2(1:length(temp)+1),[temp,'_']) % all the 'versions' have an underscore (e.g. _tminus1 or _tplus1)
+                        aa_aggvarbyptype(aa)=1; % aa AggVar is in this GE condition that depends on ptype
+                    end
+                end
+            end
+        end
+    end
+end
+
+% For graph of the General Eqm Conditions
+if length(GEeqnNames)>12
+    ncolumns_GEcondns=4;
+elseif length(GEeqnNames)>6
+    ncolumns_GEcondns=3;
+else
+    ncolumns_GEcondns=2;
+end
+nrows_GEcondns=ceil(length(GEeqnNames)/ncolumns_GEcondns);
+
+gg_indexinGEcondns=zeros(1,length(GEeqnNames));
+gg_c=0;
+for gg=1:length(GEeqnNames)
+    if transpathoptions.GEptype(gg)==0
+        gg_c=gg_c+1;
+        gg_indexinGEcondns(gg)=gg_c;
+    else
+        gg_c=gg_c+1;
+        gg_indexinGEcondns(gg)=gg_c;
+        gg_c=gg_c+(N_i-1);
+    end
+end
+
+%%
+for ii=1:N_i
+    iistr=PTypeStructure.Names_i{ii};
+    if isfinite(PTypeStructure.(iistr).N_j)
+        [PTypeStructure.(iistr).PolicyIndexesPath,PTypeStructure.(iistr).N_probs,PTypeStructure.(iistr).II1,PTypeStructure.(iistr).II2,PTypeStructure.(iistr).exceptlastj,PTypeStructure.(iistr).exceptfirstj,PTypeStructure.(iistr).justfirstj]=TransitionPath_FHorz_substeps_Step0_setup(PTypeStructure.(iistr).l_d,PTypeStructure.(iistr).l_aprime,PTypeStructure.(iistr).N_a,PTypeStructure.(iistr).N_z,PTypeStructure.(iistr).N_e,PTypeStructure.(iistr).N_j,T,transpathoptions,PTypeStructure.(iistr).vfoptions,PTypeStructure.(iistr).simoptions);
+    else
+        [PTypeStructure.(iistr).PolicyIndexesPath,PTypeStructure.(iistr).N_probs,PTypeStructure.(iistr).II1,PTypeStructure.(iistr).II2]=TransitionPath_InfHorz_substeps_Step0_setup(PTypeStructure.(iistr).l_d,PTypeStructure.(iistr).l_aprime,PTypeStructure.(iistr).N_a,PTypeStructure.(iistr).N_z,PTypeStructure.(iistr).N_e,T,transpathoptions,PTypeStructure.(iistr).vfoptions,PTypeStructure.(iistr).simoptions);
+    end
+end
+
+%%
+PricePathDist=Inf;
+pathcounter=1;
+
+PricePathNew=zeros(size(PricePathOld),'gpuArray'); PricePathNew(T,:)=PricePathOld(T,:);
+
+
+
+%%
+while PricePathDist>transpathoptions.tolerance && pathcounter<=transpathoptions.maxiter
+    
+    %% For each agent type, first go back through the value & policy fns, then forwards through agent dist and agg vars.
+    % After that is finished we can put the AggVars together, evaluate GE conditions, and update price path
+    AggVarsFullPath=zeros(PTypeStructure.numFnsToEvaluate,T-1,N_i); % Does not include period T
+    for ii=1:N_i
+        iistr=PTypeStructure.Names_i{ii};
+        
+        % Following few lines I would normally do outside of the while loop, but have to set them for each ptype
+        % AgentDist=AgentDist_initial.(iistr);
+        % WARNING: The following would overwrite themselves next iteration
+        % V_final=V_final.(iistr);
+        % AgeWeights_T=AgeWeights_T.(iistr);
+        % jequalOneDist_T=jequalOneDist_T.(iistr);
+
+        % Some parts of PricePath and ParamPath may depend on ptype
+        % Get just the values that correspond to the current ptype
+        PricePathOld_ii=PricePathOld(:,PTypeStructure.(iistr).RelevantPricePath);
+        ParamPath_ii=ParamPath(:,PTypeStructure.(iistr).RelevantParamPath);
+
+        % Have not yet set up the following to allow dependence on ptype (should do this at some point)
+        PricePathNames_ii=PricePathNames;
+        ParamPathNames_ii=ParamPathNames;
+
+        PolicyIndexesPath_ii=PTypeStructure.(iistr).PolicyIndexesPath;
+
+        if isfinite(PTypeStructure.(iistr).N_j)
+            %% Go from T-1 to 1 calculating the Value function and Optimal policy function at each step.
+            [~,PolicyIndexesPath_ii]=TransitionPath_FHorz_substeps_Step1_ValueFnIter(T,PolicyIndexesPath_ii,V_final.(iistr),PTypeStructure.(iistr).Parameters,PricePathOld_ii,ParamPath_ii,PricePathSizeVec_ii,ParamPathSizeVec_ii,PricePathNames_ii,ParamPathNames_ii,PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).n_e,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).N_z,PTypeStructure.(iistr).N_e,PTypeStructure.(iistr).d_gridvals, PTypeStructure.(iistr).a_grid, PTypeStructure.(iistr).z_gridvals_J,PTypeStructure.(iistr).e_gridvals_J,PTypeStructure.(iistr).pi_z_J,PTypeStructure.(iistr).pi_e_J,PTypeStructure.(iistr).ReturnFn,PTypeStructure.(iistr).DiscountFactorParamNames, PTypeStructure.(iistr).ReturnFnParamNames, transpathoptions,PTypeStructure.(iistr).vfoptions);
+    
+            %% Modify PolicyIndexesPath into forms needed for forward iteration
+            [PolicyPath_ForAgentDistIter_ii,PolicyProbsPath_ii,PolicyValuesPath_ii]=TransitionPath_FHorz_substeps_Step2_AdjustPolicy(PolicyIndexesPath_ii,T,PTypeStructure.(iistr).Parameters,PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).n_e,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).l_d,PTypeStructure.(iistr).l_aprime,PTypeStructure.(iistr).N_a,PTypeStructure.(iistr).N_z,PTypeStructure.(iistr).N_e,PTypeStructure.(iistr).N_probs,PTypeStructure.(iistr).d_gridvals,PTypeStructure.(iistr).aprime_gridvals,transpathoptions,PTypeStructure.(iistr).vfoptions,PTypeStructure.(iistr).simoptions);
+        else
+            %% Go from T-1 to 1 calculating the Value function and Optimal policy function at each step.
+            warning("TransitionPath_Case1_MixHorz_PType_shooting not yet hanlding e_gridvals and/or pi_e")
+            [~,PolicyIndexesPath_ii]=TransitionPath_InfHorz_substeps_Step1_ValueFnIter(T,PolicyIndexesPath_ii,V_final.(iistr),PTypeStructure.(iistr).Parameters,PricePathOld_ii,ParamPath_ii,PricePathSizeVec_ii,ParamPathSizeVec_ii,PricePathNames_ii,ParamPathNames_ii,PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).n_e,PTypeStructure.(iistr).N_z,PTypeStructure.(iistr).N_e,PTypeStructure.(iistr).d_gridvals, PTypeStructure.(iistr).a_grid, PTypeStructure.(iistr).z_gridvals,[],PTypeStructure.(iistr).pi_z,[],PTypeStructure.(iistr).ReturnFn,PTypeStructure.(iistr).DiscountFactorParamNames, PTypeStructure.(iistr).ReturnFnParamNames, transpathoptions,PTypeStructure.(iistr).vfoptions);
+
+            %% Modify PolicyIndexesPath into forms needed for forward iteration
+            [PolicyPath_ForAgentDistIter_ii,PolicyProbsPath_ii,PolicyValuesPath_ii]=TransitionPath_InfHorz_substeps_Step2_AdjustPolicy(PolicyIndexesPath_ii,T,PTypeStructure.(iistr).Parameters,PTypeStructure.(iistr).n_d,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).n_e,PTypeStructure.(iistr).l_d,PTypeStructure.(iistr).l_aprime,PTypeStructure.(iistr).N_a,PTypeStructure.(iistr).N_z,PTypeStructure.(iistr).N_e,PTypeStructure.(iistr).N_probs,PTypeStructure.(iistr).d_gridvals,PTypeStructure.(iistr).aprime_gridvals,transpathoptions,PTypeStructure.(iistr).vfoptions,PTypeStructure.(iistr).simoptions);
+        end
+
+        %% Iterate forward over t: iterate agent dist, calculate aggvars, evaluate general eqm
+        % Call AgentDist the current periods distn and AgentDistnext the next periods distn which we must calculate
+        AgentDist_ii=AgentDist_initial.(iistr);
+        AggVarNames_ii=PTypeStructure.(iistr).AggVarNames;
+        AggVarsPath_ii=zeros(length(AggVarNames_ii),T-1);
+        for tt=1:T-1
+
+            % Get t-1 PricePath and ParamPath before we update them
+            if use_tminus1price==1
+                for pp=1:length(tminus1priceNames)
+                    if tt>1
+                        Parameters.([tminus1priceNames{pp},'_tminus1'])=Parameters.(tminus1priceNames{pp});
+                    else
+                        Parameters.([tminus1priceNames{pp},'_tminus1'])=transpathoptions.initialvalues.(tminus1priceNames{pp});
+                    end
+                end
+            end
+            if use_tminus1params==1
+                for pp=1:length(tminus1paramNames)
+                    if tt>1
+                        Parameters.([tminus1paramNames{pp},'_tminus1'])=Parameters.(tminus1paramNames{pp});
+                    else
+                        Parameters.([tminus1paramNames{pp},'_tminus1'])=transpathoptions.initialvalues.(tminus1paramNames{pp});
+                    end
+                end
+            end
+            % Get t-1 AggVars before we update them
+            if use_tminus1AggVars==1
+                for pp=1:length(tminus1AggVarsNames.(iistr))
+                    if tt>1
+                        % The AggVars have not yet been updated, so they still contain previous period values
+                        Parameters.([tminus1AggVarsNames.(iistr){pp},'_tminus1'])=Parameters.(tminus1AggVarsNames.(iistr){pp});
+                    else
+                        Parameters.([tminus1AggVarsNames.(iistr){pp},'_tminus1'])=transpathoptions.initialvalues.(tminus1AggVarsNames.(iistr){pp});
+                    end
+                end
+            end
+
+            % Update current PricePath and ParamPath
+            for kk=1:length(PricePathNames)
+                Parameters.(PricePathNames{kk})=PricePathOld_ii(tt,PricePathSizeVec(1,kk):PricePathSizeVec(2,kk));
+            end
+            for kk=1:length(ParamPathNames)
+                Parameters.(ParamPathNames{kk})=ParamPath_ii(tt,ParamPathSizeVec(1,kk):ParamPathSizeVec(2,kk));
+            end
+
+            % Get t+1 PricePath
+            if use_tplus1price==1
+                for pp=1:length(tplus1priceNames)
+                    kk=tplus1pricePathkk(pp);
+                    Parameters.([tplus1priceNames{pp},'_tplus1'])=PricePathOld_ii(tt+1,PricePathSizeVec(1,kk):PricePathSizeVec(2,kk)); % Make is so that the time t+1 variables can be used
+                end
+            end
+
+            if isfinite(PTypeStructure.(iistr).N_j)
+                %% Get the current optimal policy, and iterate the agent dist
+                if transpathoptions.(iistr).trivialjequalonedist==0
+                    PTypeStructure.(iistr).jequalOneDist=PTypeStructure.(iistr).jequalOneDist_T(:,tt+1);  % Note: t+1 as we are about to create the next period AgentDist
+                end
+                if ndims(PTypeStructure.(iistr).AgeWeights_T)==2
+                    AgeWeights_ii=PTypeStructure.(iistr).AgeWeights_T(:,tt);
+                elseif PTypeStructure.(iistr).simoptions.fastOLG==0 || PTypeStructure.(iistr).N_e>0
+                    AgeWeights_ii=PTypeStructure.(iistr).AgeWeights_T(:,:,tt);
+                else % simoptions.fastOLG==1
+                    AgeWeights_ii=PTypeStructure.(iistr).AgeWeights_T(:,tt);
+                end
+    
+                AgentDistnext_ii=TransitionPath_FHorz_substeps_Step3tt_IterAgentDist(AgentDist_ii,PolicyPath_ForAgentDistIter_ii,PolicyProbsPath_ii,tt,PTypeStructure.(iistr).N_a,PTypeStructure.(iistr).N_z,PTypeStructure.(iistr).N_e,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).N_probs,PTypeStructure.(iistr).pi_z_J,PTypeStructure.(iistr).pi_z_J_sim,PTypeStructure.(iistr).pi_e_J,PTypeStructure.(iistr).pi_e_J_sim,PTypeStructure.(iistr).II1,PTypeStructure.(iistr).II2,PTypeStructure.(iistr).exceptlastj,PTypeStructure.(iistr).exceptfirstj,PTypeStructure.(iistr).justfirstj,PTypeStructure.(iistr).jequalOneDist,transpathoptions,PTypeStructure.(iistr).simoptions);
+    
+                %% AggVars
+                if PTypeStructure.(iistr).N_z==0 && PTypeStructure.(iistr).N_e==0
+                    PVP_ii_t=PolicyValuesPath_ii(:,:,:,tt);
+                else
+                    PVP_ii_t=PolicyValuesPath_ii(:,:,:,:,tt);
+                end
+                AggVars_ii=TransitionPath_FHorz_substeps_Step4tt_AggVars(AgentDist_ii,AgeWeights_ii,PVP_ii_t,tt,PTypeStructure.(iistr).FnsToEvaluateCell,PTypeStructure.(iistr).FnsToEvaluateParamNames,AggVarNames_ii,PTypeStructure.(iistr).Parameters,PTypeStructure.(iistr).N_j,PTypeStructure.(iistr).l_d,PTypeStructure.(iistr).l_aprime,PTypeStructure.(iistr).l_a,PTypeStructure.(iistr).l_z,PTypeStructure.(iistr).l_e,PTypeStructure.(iistr).N_d,PTypeStructure.(iistr).N_a,PTypeStructure.(iistr).N_z,PTypeStructure.(iistr).N_e,PTypeStructure.(iistr).a_gridvals,PTypeStructure.(iistr).ze_gridvals_J_fastOLG,transpathoptions);
+            else
+                warning("TransitionPath_Case1_MixHorz_PType_shooting not hanlding pi_e yet")
+                AgentDistnext_ii=TransitionPath_InfHorz_substeps_Step3tt_IterAgentDist(AgentDist_ii,PolicyPath_ForAgentDistIter_ii,PolicyProbsPath_ii,tt,PTypeStructure.(iistr).N_a,PTypeStructure.(iistr).N_z,PTypeStructure.(iistr).N_e,PTypeStructure.(iistr).N_probs,PTypeStructure.(iistr).pi_z,[],PTypeStructure.(iistr).II1,PTypeStructure.(iistr).II2,transpathoptions,PTypeStructure.(iistr).simoptions);
+                if PTypeStructure.(iistr).N_z==0
+                    PVP_ii_t=PolicyValuesPath_ii(:,:,tt);
+                else
+                    PVP_ii_t=PolicyValuesPath_ii(:,:,:,tt);
+                end
+                AggVars_ii=TransitionPath_InfHorz_substeps_Step4tt_AggVars(AgentDist_ii,PVP_ii_t,tt,PTypeStructure.(iistr).FnsToEvaluateCell,PTypeStructure.(iistr).FnsToEvaluateParamNames,AggVarNames_ii,PTypeStructure.(iistr).Parameters,PTypeStructure.(iistr).n_a,PTypeStructure.(iistr).n_z,PTypeStructure.(iistr).n_e,PTypeStructure.(iistr).N_z,PTypeStructure.(iistr).N_e,PTypeStructure.(iistr).a_gridvals,PTypeStructure.(iistr).z_gridvals,transpathoptions);
+            end
+
+            for ff=1:length(AggVarNames_ii)
+                Parameters.(AggVarNames_ii{ff})=AggVars_ii.(AggVarNames_ii{ff}).Mean;
+            end
+
+            % Keep AggVars in the AggVarsPath
+            for ff=1:length(AggVarNames_ii)
+                AggVarsPath_ii(ff,tt)=AggVars_ii.(AggVarNames_ii{ff}).Mean;
+            end
+
+            %% GE EQNS THAT DEPEND ON PTYPE SHOULD BE DONE HERE!!!
+
+            AgentDist_ii=AgentDistnext_ii;
+        end
+
+        AggVarsFullPath(logical(PTypeStructure.(iistr).WhichFnsForCurrentPType),:,ii)=AggVarsPath_ii;
+
+    end % done loop over ii
+    
+    
+    %% Note: Cannot yet do transition paths in which the mass of each agent type changes.
+    % AggVarsPooledPath=sum(reshape(PTypeStructure.FnsAndPTypeIndicator,[PTypeStructure.numFnsToEvaluate,1,PTypeStructure.N_i]).*AggVarsFullPath.*shiftdim(AgentDist_init.ptweights,-2),3); % Weighted sum over agent type dimension
+    % Note: don't need the above line, as I already dealt with PTypeStructure.FnsAndPTypeIndicator when creating AggVarsFullPath
+    AggVarsPooledPath=sum(AggVarsFullPath.*shiftdim(AgentDist_initial.ptweights,-2),3); % Weighted sum over agent type dimension
+    
+    
+    %% Do the general eqm conditions and create PricePathNew based on these
+    if all(transpathoptions.GEptype==0)
+        GECondnPath=zeros(T,length(GEeqnNames));
+
+        % NEEDED???  Restore all AggVarNames and tminus1AggVarsNames for GEeqns
+        AggVarNames=cell(1,N_i);
+        tminus1AggVarsNames=cell(1,N_i);
+        use_tminus1AggVars=0;
+        for ii=1:N_i
+            iistr=PTypeStructure.Names_i{ii};
+            AggVarNames{ii}=PTypeStructure.(iistr).AggVarNames;
+            if isfield(PTypeStructure.(iistr), 'tminus1AggVarsNames')
+                use_tminus1AggVars=1;
+                tminus1AggVarsNames{ii}=PTypeStructure.(iistr).tminus1AggVarsNames;
+            end
+        end
+        AggVarNames=vertcat(AggVarNames{:});
+        tminus1AggVarsNames=vertcat(tminus1AggVarsNames{:});
+
+        % Parameters that may be relevant to General Eqm
+        Parameters=PTypeStructure.ParametersRaw;
+
+        for tt=1:T-1
+
+            % Get t-1 PricePath and ParamPath before we update them
+            if use_tminus1price==1
+                for pp=1:length(tminus1priceNames)
+                    if tt>1
+                        Parameters.([tminus1priceNames{pp},'_tminus1'])=Parameters.(tminus1priceNames{pp});
+                    else
+                        Parameters.([tminus1priceNames{pp},'_tminus1'])=transpathoptions.initialvalues.(tminus1priceNames{pp});
+                    end
+                end
+            end
+            if use_tminus1params==1
+                for pp=1:length(tminus1paramNames)
+                    if tt>1
+                        Parameters.([tminus1paramNames{pp},'_tminus1'])=Parameters.(tminus1paramNames{pp});
+                    else
+                        Parameters.([tminus1paramNames{pp},'_tminus1'])=transpathoptions.initialvalues.(tminus1paramNames{pp});
+                    end
+                end
+            end
+            % Get t-1 AggVars before we update them
+            if use_tminus1AggVars==1
+                for pp=1:length(tminus1AggVarsNames)
+                    if tt>1
+                        % The AggVars have not yet been updated, so they still contain previous period values
+                        Parameters.([tminus1AggVarsNames{pp},'_tminus1'])=Parameters.(tminus1AggVarsNames{pp});
+                    else
+                        Parameters.([tminus1AggVarsNames{pp},'_tminus1'])=transpathoptions.initialvalues.(tminus1AggVarsNames{pp});
+                    end
+                end
+            end
+
+            % Update current PricePath and ParamPath
+            for kk=1:length(PricePathNames)
+                Parameters.(PricePathNames{kk})=PricePathOld(tt,PricePathSizeVec(1,kk):PricePathSizeVec(2,kk));
+            end
+            for kk=1:length(ParamPathNames)
+                Parameters.(ParamPathNames{kk})=ParamPath(tt,ParamPathSizeVec(1,kk):ParamPathSizeVec(2,kk));
+            end
+            
+            % Update current AggVars [we have to add this as GE conditions are in a separate tt loop to the AggVars]
+            for ff=1:length(FullAggVarNames)
+                Parameters.(FullAggVarNames{ff})=AggVarsPooledPath(ff,tt);
+            end
+            
+            % Get t+1 PricePath
+            if use_tplus1price==1
+                for pp=1:length(tplus1priceNames)
+                    kk=tplus1pricePathkk(pp);
+                    Parameters.([tplus1priceNames{pp},'_tplus1'])=PricePathOld(tt+1,PricePathSizeVec(1,kk):PricePathSizeVec(2,kk)); % Make is so that the time t+1 variables can be used
+                end
+            end
+
+            %% Intermediate Eqns
+            if transpathoptions.useintermediateEqns==1
+                % Note: intermediateEqns just take in things from the Parameters structure, as do GeneralEqmEqns (AggVars get put into structure), hence just use the GeneralEqmConditions_Case1_v3g().
+                intEqnnames=fieldnames(transpathoptions.intermediateEqns);
+                intermediateEqnsVec=zeros(1,length(intEqnnames));
+                % Do the intermediateEqns, in order
+                for gg=1:length(intEqnnames)
+                    intermediateEqnsVec(gg)=real(GeneralEqmConditions_Case1_v3g(transpathoptions.intermediateEqnsCell{gg}, transpathoptions.intermediateEqnParamNames(gg).Names, Parameters));
+                    Parameters.(intEqnnames{gg})=intermediateEqnsVec(gg);
+                end
+            end
+
+            %% General Eqm Eqns
+            % Evaluate the general eqm conditions, and based on them create PricePathNew (interpretation depends on transpathoptions)
+            [PricePathNew_tt,GEcondnPath_tt]=updatePricePathNew_TPath_tt(Parameters,GeneralEqmEqnsCell,GeneralEqmEqnParamNames,PricePathOld(tt,:),transpathoptions);
+            PricePathNew(tt,:)=PricePathNew_tt;
+            GEcondnPath(tt,:)=GEcondnPath_tt;
+            
+        end % Done loop over tt, evaluating the GE conditions
+    else % Some GE conditions depend on PType
+        GECondnPath=zeros(T,nGeneralEqmEqns_acrossptypes);
+        error("need to fit these loops together")
+
+        % NEEDED??? Restore AggVarNames and tminus1AggVarsNames by PType for GEeqns
+        AggVarNames=cell(1,N_i);
+        tminus1AggVarsNames=cell(1,N_i);
+        use_tminus1AggVars=0;
+        for ii=1:N_i
+            iistr=PTypeStructure.Names_i{ii};
+            AggVarNames{ii}=PTypeStructure.(iistr).AggVarNames;
+            tminus1AggVarsNames{ii}=PTypeStructure.(iistr).tminus1AggVarsNames;
+            if ~isempty(tminus1AggVarsNames{ii})
+                use_tminus1AggVars=1;
+            end
+        end
+        AggVarNames=vertcat(AggVarNames{:});
+        tminus1AggVarsNames=vertcat(tminus1AggVarsNames{:});
+        
+        % Parameters that may be relevant to General Eqm
+        Parameters=PTypeStructure.ParametersRaw;
+        for ii=1:N_i
+            iistr=PTypeStructure.Names_i{ii};
+            Parameters_ii.(iistr)=PTypeStructure.(iistr).Parameters; % For use with General Eqm conditions that are evaluated conditional on ptype
+        end
+
+        % Some of the General eqm eqns depend on ptype
+        for tt=1:T-1
+
+            
+            % Get t-1 PricePath and ParamPath before we update them
+            if use_tminus1price==1
+                for pp=1:length(tminus1priceNames)
+                    if tt>1
+                        Parameters.([tminus1priceNames{pp},'_tminus1'])=Parameters.(tminus1priceNames{pp});
+                    else
+                        Parameters.([tminus1priceNames{pp},'_tminus1'])=transpathoptions.initialvalues.(tminus1priceNames{pp});
+                    end
+                    if isstruct(Parameters.([tminus1priceNames{pp},'_tminus1']))
+                        for ii=1:N_i
+                            iistr=PTypeStructure.Names_i{ii};
+                            Parameters_ii.(iistr).([tminus1priceNames{pp},'_tminus1'])=Parameters.([tminus1priceNames{pp},'_tminus1']).(iistr);
+                        end
+                    elseif length(Parameters.([tminus1priceNames{pp},'_tminus1']))==N_i % Depends on ptype
+                        for ii=1:N_i
+                            iistr=PTypeStructure.Names_i{ii};
+                            tempii=Parameters.([tminus1priceNames{pp},'_tminus1']);
+                            Parameters_ii.(iistr).([tminus1priceNames{pp},'_tminus1'])=tempii(ii);
+                        end
+                    end
+                end
+            end
+            if use_tminus1params==1
+                for pp=1:length(tminus1paramNames)
+                    if tt>1
+                        Parameters.([tminus1paramNames{pp},'_tminus1'])=Parameters.(tminus1paramNames{pp});
+                    else
+                        Parameters.([tminus1paramNames{pp},'_tminus1'])=transpathoptions.initialvalues.(tminus1paramNames{pp});
+                    end
+                    if isstruct(Parameters.([tminus1paramNames{pp},'_tminus1']))
+                        for ii=1:N_i
+                            iistr=PTypeStructure.Names_i{ii};
+                            Parameters_ii.(iistr).([tminus1paramNames{pp},'_tminus1'])=Parameters.([tminus1paramNames{pp},'_tminus1']).(iistr);
+                        end
+                    elseif length(Parameters.([tminus1paramNames{pp},'_tminus1']))==N_i % Depends on ptype
+                        for ii=1:N_i
+                            iistr=PTypeStructure.Names_i{ii};
+                            tempii=Parameters.([tminus1paramNames{pp},'_tminus1']);
+                            Parameters_ii.(iistr).([tminus1paramNames{pp},'_tminus1'])=tempii(ii);
+                        end
+                    end
+                end
+            end
+            
+            % Get t-1 AggVars before we update them
+            if use_tminus1AggVars==1
+                for pp=1:length(tminus1AggVarsNames)
+                    if tt>1
+                        % The AggVars have not yet been updated, so they still contain previous period values
+                        Parameters.([tminus1AggVarsNames{pp},'_tminus1'])=Parameters.(tminus1AggVarsNames{pp});
+                    else
+                        Parameters.([tminus1AggVarsNames{pp},'_tminus1'])=transpathoptions.initialvalues.(tminus1AggVarsNames{pp});
+                    end
+                    if tt>1
+                        if length(Parameters.(tminus1AggVarsNames{pp}))==N_i % Depends on ptype
+                            for ii=1:N_i
+                                iistr=PTypeStructure.Names_i{ii};
+                                Parameters_ii.(iistr).([tminus1AggVarsNames{pp},'_tminus1'])=Parameters_ii.(iistr).(tminus1AggVarsNames{pp});
+                            end
+                        end
+                    else
+                        if isstruct(transpathoptions.initialvalues.(tminus1AggVarsNames{pp}))
+                            for ii=1:N_i
+                                iistr=PTypeStructure.Names_i{ii};
+                                Parameters_ii.(iistr).([tminus1AggVarsNames{pp},'_tminus1'])=transpathoptions.initialvalues.(tminus1AggVarsNames{pp}).(iistr);
+                            end
+                        elseif length(transpathoptions.initialvalues.(tminus1AggVarsNames{pp}))==N_i % Depends on ptype
+                            temp=transpathoptions.initialvalues.(tminus1AggVarsNames{pp});
+                            for ii=1:N_i
+                                iistr=PTypeStructure.Names_i{ii};
+                                Parameters_ii.(iistr).([tminus1AggVarsNames{pp},'_tminus1'])=temp(ii);
+                            end
+                        end
+                    end
+                end
+            end
+            
+            
+            % Update current PricePath and ParamPath
+            for kk=1:length(PricePathNames)
+                Parameters.(PricePathNames{kk})=PricePathOld(tt,PricePathSizeVec(1,kk):PricePathSizeVec(2,kk));
+                if (PricePathSizeVec(2,kk)-PricePathSizeVec(1,kk)+1)==N_i
+                    for ii=1:N_i
+                        iistr=PTypeStructure.Names_i{ii};
+                        Parameters_ii.(iistr).(PricePathNames{kk})=PricePathOld(tt,PricePathSizeVec(1,kk)+ii-1);
+                    end
+                end
+            end
+            for kk=1:length(ParamPathNames)
+                Parameters.(ParamPathNames{kk})=ParamPath(tt,ParamPathSizeVec(1,kk):ParamPathSizeVec(2,kk));
+                if (ParamPathSizeVec(2,kk)-ParamPathSizeVec(1,kk)+1)==N_i
+                    for ii=1:N_i
+                        iistr=PTypeStructure.Names_i{ii};
+                        Parameters_ii.(iistr).(ParamPathNames{kk})=PricePathOld(tt,ParamPathSizeVec(1,kk)+ii-1);
+                    end
+                end
+            end
+
+            % Update current AggVars [we have to add this when doing ptype as GE conditions are in a separate tt loop to the AggVars]
+            for ff=1:length(FullAggVarNames)
+                Parameters.(FullAggVarNames{ff})=AggVarsPooledPath(ff,tt);
+                % Keep the AggVars conditional on ptype for all the AggVars; overkill but that is fine
+                for ii=1:N_i
+                    iistr=PTypeStructure.Names_i{ii};
+                    Parameters_ii.(iistr).(FullAggVarNames{ff})=AggVarsFullPath(ff,tt,ii);
+                end
+            end
+            
+            
+            % Get t+1 PricePath
+            if use_tplus1price==1
+                for pp=1:length(tplus1priceNames)
+                    kk=tplus1pricePathkk(pp);
+                    Parameters.([tplus1priceNames{pp},'_tplus1'])=PricePathOld(tt+1,PricePathSizeVec(1,kk):PricePathSizeVec(2,kk)); % Make is so that the time t+1 variables can be used
+                    if isstruct(Parameters.([tplus1priceNames{pp},'_tplus1']))
+                        for ii=1:N_i
+                            iistr=PTypeStructure.Names_i{ii};
+                            Parameters_ii.(iistr).([tplus1priceNames{pp},'_tplus1'])=Parameters.([tplus1priceNames{pp},'_tplus1']).(iistr);
+                        end
+                    elseif length(Parameters.([tplus1priceNames{pp},'_tplus1']))==N_i % Depends on ptype
+                        temp=Parameters.([tplus1priceNames{pp},'_tplus1']);
+                        for ii=1:N_i
+                            iistr=PTypeStructure.Names_i{ii};
+                            Parameters_ii.(iistr).([tplus1priceNames{pp},'_tplus1'])=temp(ii);
+                        end
+                    end
+                end
+            end
+
+
+            if transpathoptions.GEnewprice==1 % The GeneralEqmEqns are not really general eqm eqns, but instead have been given in the form of GEprice updating formulae
+                % Loop over the general eqm conditions, so we can deal seperately with those that depend on ptype and those that do not
+                gg_c=0;
+                for gg=1:nGeneralEqmEqns
+                    if transpathoptions.GEptype(gg)==0
+                        gg_c=gg_c+1;
+                        PricePathNew(tt,gg_c)=real(GeneralEqmConditions_Case1_v3g(GeneralEqmEqnsCell{gg},GeneralEqmEqnParamNames(gg).Names, Parameters));
+                    elseif transpathoptions.GEptype(gg)==1
+                        gg_c=gg_c+1;
+                        PricePathNew(tt,gg_c)=real(GeneralEqmConditions_Case1_v3g(GeneralEqmEqnsCell{gg}, GeneralEqmEqnParamNames(gg).Names, Parameters_ii.(iistr)));
+                    end
+                end
+            % Note there is no GEnewprice==2, it uses a completely different code
+            elseif transpathoptions.GEnewprice==3 % Version of shooting algorithm where the new value is the current value +- fraction*(GECondn)
+                p_i=zeros(1,length(GeneralEqmEqnsCell)+sum(transpathoptions.GEptype),'gpuArray');
+                gg_c=0;
+                for gg=1:nGeneralEqmEqns
+                    if transpathoptions.GEptype(gg)==0
+                        gg_c=gg_c+1;
+                        p_i(gg_c)=real(GeneralEqmConditions_Case1_v3g(GeneralEqmEqnsCell{gg}, GeneralEqmEqnParamNames(gg).Names, Parameters));
+                    elseif transpathoptions.GEptype(gg)==1
+                        for ii=1:N_i
+                            iistr=PTypeStructure.Names_i{ii};
+                            gg_c=gg_c+1;
+                            p_i(gg_c)=real(GeneralEqmConditions_Case1_v3g(GeneralEqmEqnsCell{gg}, GeneralEqmEqnParamNames(gg).Names, Parameters_ii.(iistr)));
+                        end
+                    end
+                end
+
+                p_i=p_i(transpathoptions.GEnewprice3.permute); % Rearrange GeneralEqmEqns into the order of the relevant prices
+                I_makescutoff=(abs(p_i)>transpathoptions.updateaccuracycutoff);
+                p_i=I_makescutoff.*p_i;
+                PricePathNew(tt,:)=(PricePathOld(tt,:).*transpathoptions.GEnewprice3.keepold)+transpathoptions.GEnewprice3.add.*transpathoptions.GEnewprice3.factor.*p_i-(1-transpathoptions.GEnewprice3.add).*transpathoptions.GEnewprice3.factor.*p_i;
+                GEcondnPath(tt,:)=p_i;
+            end
+
+        end % Done loop over tt, evaluating the GE conditions
+
+    end
+    
+
+    %% Now we just check for convergence, update prices, and give some feedback on progress
+    % See how far apart the price paths are
+    PricePathDist=max(abs(reshape(PricePathNew(1:T-1,:)-PricePathOld(1:T-1,:),[numel(PricePathOld(1:T-1,:)),1])));
+    % Notice that the distance is always calculated ignoring the time t=T periods, as these needn't ever converges
+    
+    if transpathoptions.verbose==1     
+        % Would be nice to have a way to get the iteration count without having the whole printout of path values (I think that would be useful?)
+        pathnametitles
+        [PricePathOld,PricePathNew]
+    end
+    
+    % Create plots of the transition path (before we update pricepath)
+    createTPathFeedbackPlots(PricePathNames,FullAggVarNames,GEeqnNames,PricePathOld,AggVarsPooledPath,GEcondnPath,transpathoptions);
+    
+    % Set price path to be 9/10ths the old path and 1/10th the new path (but making sure to leave prices in periods 1 & T unchanged).
+    if transpathoptions.weightscheme==0
+        PricePathOld=PricePathNew; % The update weights are already in GEnewprice setup
+    elseif transpathoptions.weightscheme==1 % Just a constant weighting
+        PricePathOld(1:T-1,:)=transpathoptions.oldpathweight.*PricePathOld(1:T-1,:)+(1-transpathoptions.oldpathweight).*PricePathNew(1:T-1,:);
+    elseif transpathoptions.weightscheme==2 % A exponentially decreasing weighting on new path from (1-oldpathweight) in first period, down to 0.1*(1-oldpathweight) in T-1 period.
+        % I should precalculate these weighting vectors
+        Ttheta=transpathoptions.Ttheta;
+        PricePathOld(1:Ttheta,:)=transpathoptions.oldpathweight*PricePathOld(1:Ttheta,:)+(1-transpathoptions.oldpathweight)*PricePathNew(1:Ttheta,:);
+        PricePathOld(Ttheta:T-1,:)=((transpathoptions.oldpathweight+(1-exp(linspace(0,log(0.2),T-Ttheta)))*(1-transpathoptions.oldpathweight))'*ones(1,l_p)).*PricePathOld(Ttheta:T-1,:)+((exp(linspace(0,log(0.2),T-Ttheta)).*(1-transpathoptions.oldpathweight))'*ones(1,l_p)).*PricePathNew(Ttheta:T-1,:);
+    elseif transpathoptions.weightscheme==3 % A gradually opening window.
+        if (pathcounter*3)<T-1
+            PricePathOld(1:(pathcounter*3),:)=transpathoptions.oldpathweight*PricePathOld(1:(pathcounter*3),:)+(1-transpathoptions.oldpathweight)*PricePathNew(1:(pathcounter*3),:);
+        else
+            PricePathOld(1:T-1,:)=transpathoptions.oldpathweight*PricePathOld(1:T-1,:)+(1-transpathoptions.oldpathweight)*PricePathNew(1:T-1,:);
+        end
+    elseif transpathoptions.weightscheme==4 % Combines weightscheme 2 & 3
+        if (pathcounter*3)<T-1
+            PricePathOld(1:(pathcounter*3),:)=((transpathoptions.oldpathweight+(1-exp(linspace(0,log(0.2),pathcounter*3)))*(1-transpathoptions.oldpathweight))'*ones(1,l_p)).*PricePathOld(1:(pathcounter*3),:)+((exp(linspace(0,log(0.2),pathcounter*3)).*(1-transpathoptions.oldpathweight))'*ones(1,l_p)).*PricePathNew(1:(pathcounter*3),:);
+        else
+            PricePathOld(1:T-1,:)=((transpathoptions.oldpathweight+(1-exp(linspace(0,log(0.2),T-1)))*(1-transpathoptions.oldpathweight))'*ones(1,l_p)).*PricePathOld(1:T-1,:)+((exp(linspace(0,log(0.2),T-1)).*(1-transpathoptions.oldpathweight))'*ones(1,l_p)).*PricePathNew(1:T-1,:);
+        end
+    end
+    
+    TransPathConvergence=PricePathDist/transpathoptions.tolerance; %So when this gets to 1 we have convergence
+    if transpathoptions.verbose==1
+        fprintf('Number of iterations on transition path: %i \n',pathcounter)
+        fprintf('Current distance between old and new price path (in L-Infinity norm): %8.6f \n', PricePathDist)
+        fprintf('Ratio of current distance to the convergence tolerance: %.2f (convergence when reaches 1) \n',TransPathConvergence)
+    end
+    
+    if transpathoptions.historyofpricepath==1
+        % Store the whole history of the price path and save it every ten iterations
+        PricePathHistory{pathcounter,1}=PricePathDist;
+        PricePathHistory{pathcounter,2}=PricePathOld;        
+        if rem(pathcounter,10)==1
+            save ./SavedOutput/TransPath_Internal.mat PricePathHistory
+        end
+    end
+
+    pathcounter=pathcounter+1;
+
+end
+
+
+end

--- a/TransitionPaths/Subcodes/PricePathParamPath_MixHorz_StructToMatrix.m
+++ b/TransitionPaths/Subcodes/PricePathParamPath_MixHorz_StructToMatrix.m
@@ -1,4 +1,4 @@
-function varargout=PricePathParamPath_FHorz_StructToMatrix(PricePathStruct,ParamPathStruct,N_j,T,N_i)
+function varargout=PricePathParamPath_MixHorz_StructToMatrix(PricePathStruct,ParamPathStruct,N_j,T,N_i)
 % varargout={PricePath,ParamPath,PricePathNames,ParamPathNames,PricePathSizeVec,ParamPathSizeVec}
 % but for models with permanent types, include N_i as input and get
 % varargout={PricePath,ParamPath,PricePathNames,ParamPathNames,PricePathSizeVec,ParamPathSizeVec,PricePathSizeVec_ii,ParamPathSizeVec_ii}
@@ -82,7 +82,7 @@ else
             PricePathSizeVec(pp)=length(tempptypenames)*tempsize(tempsize~=T); % Get the dimension which is not T
             for ii=1:N_i
                 N_j_temp=N_j.(Names_i{ii});
-                if ~any(PricePathSizeVec(pp)==[1,N_i,N_j_temp,N_i*N_j_temp])
+                if isfinite(N_j_temp) && ~any(PricePathSizeVec(pp)==[1,N_i,N_j_temp,N_i*N_j_temp])
                     error(['PricePath for ', PricePathNames{pp}, ' appears to be the wrong size (should be 1-by-T or N_j-by-T or N_i-by-T)'])
                 end
             end
@@ -92,7 +92,7 @@ else
             PricePathSizeVec(pp)=tempsize(tempsize~=T); % Get the dimension which is not T
             for ii=1:N_i
                 N_j_temp=N_j.(Names_i{ii});
-                if ~any(PricePathSizeVec(pp)==[1,N_i,N_j_temp])
+                if isfinite(N_j_temp) && ~any(PricePathSizeVec(pp)==[1,N_i,N_j_temp])
                     error(['PricePath for ', PricePathNames{pp}, ' appears to be the wrong size (should be 1-by-T or N_j-by-T or N_i-by-T)'])
                 end
             end
@@ -145,7 +145,7 @@ else
             ParamPathSizeVec(pp)=length(tempptypenames)*tempsize(tempsize~=T); % Get the dimension which is not T
             for ii=1:N_i
                 N_j_temp=N_j.(Names_i{ii});
-                if ~any(ParamPathSizeVec(pp)==[1,N_i,N_j_temp,N_i*N_j_temp])
+                if isfinite(N_j_temp) && ~any(ParamPathSizeVec(pp)==[1,N_i,N_j_temp,N_i*N_j_temp])
                     error(['ParamPath for ', ParamPathNames{pp}, ' appears to be the wrong size (should be 1-by-T or N_j-by-T or N_i-by-T)'])
                 end
             end
@@ -155,7 +155,7 @@ else
             ParamPathSizeVec(pp)=tempsize(tempsize~=T); % Get the dimension which is not T
             for ii=1:N_i
                 N_j_temp=N_j.(Names_i{ii});
-                if ~any(ParamPathSizeVec(pp)==[1,N_i,N_j_temp])
+                if isfinite(N_j_temp) && ~any(ParamPathSizeVec(pp)==[1,N_i,N_j_temp])
                     error(['ParamPath for ', ParamPathNames{pp}, ' appears to be the wrong size (should be 1-by-T or N_j-by-T or N_i-by-T)'])
                 end
             end

--- a/TransitionPaths/Subcodes/inputsFindtplus1tminus1.m
+++ b/TransitionPaths/Subcodes/inputsFindtplus1tminus1.m
@@ -1,20 +1,50 @@
-function [tplus1priceNames,tminus1priceNames,tminus1AggVarsNames,tminus1paramNames,tplus1pricePathkk]=inputsFindtplus1tminus1(FnsToEvaluate,GeneralEqmEqns,PricePathNames,ParamPathNames)
+function [tplus1priceNames,tminus1priceNames,tminus1AggVarsNames,tminus1paramNames,tplus1pricePathkk]=inputsFindtplus1tminus1(FnsToEvaluate,GeneralEqmEqns,PricePathNames,ParamPathNames,Names_i)
 % Subscript that is used to determine if there are any '_tminus1' or
 % '_tplus1' variables used as inputs to FnsToEvaluate or GeneralEqmEqns
 % (Used as part of transition path codes)
 % Look for the _tplus1 in PricePath, and for _tminus1 in AggVars, PricePath, and ParamPath
 
-% Check for using _tminus1 (for price or AggVars) or _tplus1
-FnInputNames={};
+if ~exist('Names_i','var')
+    Names_i={};
+end
+
+% Check for using _tminus1 (for price or AggVars) or _tplus1, honoring PType
+FnInputNames={}; % FnNames beloning to no PType
+PTypeFnInputNames=struct(); % Built as we find them
 ninputs=0;
 % Get all the input names for FnsToEvaluate
 AggVarNames=fieldnames(FnsToEvaluate);
+PTypeAggVarNames=struct();
 for ff=1:length(AggVarNames)
-    temp=getAnonymousFnInputNames(FnsToEvaluate.(AggVarNames{ff}));
+    if ~isempty(Names_i)
+        temp={};
+        for ii=1:length(Names_i)
+            if isfield(FnsToEvaluate.(AggVarNames{ff}), Names_i{ii})
+                if ~isfield(PTypeAggVarNames, Names_i{ii})
+                    PTypeAggVarNames.(Names_i{ii})={};
+                    PTypeFnInputNames.(Names_i{ii})={};
+                end
+                PTypeAggVarNames.(Names_i{ii})=[PTypeAggVarNames.(Names_i{ii});AggVarNames{ff}];
+                temp=getAnonymousFnInputNames(FnsToEvaluate.(AggVarNames{ff}).(Names_i{ii}));
+                PTypeFnInputNames.(Names_i{ii})=[PTypeFnInputNames.(Names_i{ii});temp]; % Note, this will include the (d,aprime,a,z), but that is irrelevant to our current purposes
+                break
+            end
+        end
+        if isempty(temp)
+            error(['Could not find', AggVarNames{ff}, 'with PType in {', Names_i, '}'])
+        end
+    else
+        temp=getAnonymousFnInputNames(FnsToEvaluate.(AggVarNames{ff}));
+        FnInputNames={FnInputNames{:},temp{:}}; % Note, this will include the (d,aprime,a,z), but that is irrelevant to our current purposes
+    end
     tempninputs=length(temp);
-    FnInputNames={FnInputNames{:},temp{:}}; % Note, this will include the (d,aprime,a,z), but that is irrelevant to our current purposes
     ninputs=ninputs+tempninputs;
 end
+for ii=1:length(Names_i) % If Names_i is empty this loop is not executed
+    name_matches=ismember(AggVarNames, PTypeAggVarNames.(Names_i{ii}));
+    AggVarNames(name_matches)=[];
+end
+
 % Get all the input names for GeneralEqmEqns
 GEeqnNames=fieldnames(GeneralEqmEqns);
 for gg=1:length(GEeqnNames)
@@ -25,6 +55,9 @@ for gg=1:length(GEeqnNames)
 end
 % Now, get rid of all the duplicates
 FnInputNames=unique(FnInputNames);
+for ii=1:length(Names_i) % If Names_i is empty this loop is not executed
+    PTypeFnInputNames.(Names_i{ii})=unique(PTypeFnInputNames.(Names_i{ii}));
+end
 
 % Find any which are _tplus1 or _tminus1
 tplus1Names={};
@@ -53,6 +86,10 @@ tplus1priceNames={}; ntplus1prices=0;
 tminus1priceNames={}; ntminus1prices=0;
 tminus1paramNames={}; ntminus1params=0;
 tminus1AggVarsNames={}; ntminus1AggVars=0;
+for ii=1:length(Names_i)
+    PType_tminus1AggVarsNames.(Names_i{ii})={};
+    PType_ntminus1AggVars.(Names_i{ii})=0;
+end
 tplus1pricePathkk=[];
 
 % Check that they are prices, otherwise error
@@ -87,14 +124,38 @@ for ii=1:ntminus1
         end
     end
 end
-for ii=1:ntminus1
-    for kk=1:length(AggVarNames)
-        if strcmp(tminus1Names{ii},AggVarNames{kk})
-            ntminus1AggVars=ntminus1AggVars+1;
-            tminus1AggVarsNames{ntminus1AggVars}=tminus1Names{ii};
-            tminus1UsedAsPriceOrAggVar(ii)=1;
+if isempty(Names_i)
+    for ii=1:ntminus1
+        for kk=1:length(AggVarNames)
+            if strcmp(tminus1Names{ii},AggVarNames{kk})
+                ntminus1AggVars=ntminus1AggVars+1;
+                tminus1AggVarsNames{ntminus1AggVars}=tminus1Names{ii};
+                tminus1UsedAsPriceOrAggVar(ii)=1;
+            end
         end
     end
+    % Return the array of tminus1AggVarsNames
+elseif ntminus1>0
+    for ii=1:ntminus1
+        for nn=1:length(Names_i)
+            AggVarNames_nn=PTypeAggVarNames.(Names_i{nn});
+            for kk=1:length(AggVarNames_nn)
+                if strcmp(tminus1Names{ii},AggVarNames_nn{kk})
+                    PType_ntminus1AggVars.(Names_i{nn})=PType_ntminus1AggVars.(Names_i{nn})+1;
+                    PType_tminus1AggVarsNames.(Names_i{nn}){PType_ntminus1AggVars.(Names_i{nn})}=tminus1Names{ii};
+                    tminus1UsedAsPriceOrAggVar(ii)=1;
+                end
+            end
+        end
+    end
+    % It is easier to leave empty values than remove/retest the fields
+    % for ii=1:length(Names_i)
+    %     if isempty(PType_tminus1AggVarsNames.(Names_i{ii}))
+    %         PType_tminus1AggVarsNames=rmfield(PType_tminus1AggVarsNames, Names_i{ii});
+    %     end
+    % end
+    % Return the PType structure of the arrays of tminus1AggVarsNames
+    tminus1AggVarsNames=PType_tminus1AggVarsNames;
 end
 % Check that they have all been used, otherwise error
 if prod(tplus1UsedAsPriceOrAggVar)==0

--- a/ValueFnIter/MixHorz_PType/ValueFnIter_Case1_MixHorz_PType.m
+++ b/ValueFnIter/MixHorz_PType/ValueFnIter_Case1_MixHorz_PType.m
@@ -1,0 +1,230 @@
+function [V, Policy]=ValueFnIter_Case1_MixHorz_PType(n_d,n_a,n_z, N_j,Names_i,d_grid, a_grid, z_grid, pi_z, ReturnFn, Parameters, DiscountFactorParamNames, vfoptions)
+
+%
+% vfoptions.verbose=1 will give feedback
+% vfoptions.verboseparams=1 will give further feedback on the param values of each permanent type
+%
+V=struct();
+Policy=struct();
+
+% N_d=prod(n_d);
+% N_a=prod(n_a);
+% N_z=prod(n_z);
+% N_i=prod(n_i);
+
+if iscell(Names_i)
+    N_i=length(Names_i);
+else
+    N_i=Names_i; % It is the number of PTypes (which have not been given names)
+    Names_i={'ptype001'};
+    for ii=2:N_i
+        if ii<10
+            Names_i{ii}=['ptype00',num2str(ii)];
+        elseif ii<100
+            Names_i{ii}=['ptype0',num2str(ii)];
+        elseif ii<1000
+            Names_i{ii}=['ptype',num2str(ii)];
+        end
+    end
+end
+
+for ii=1:N_i
+        
+    % First set up vfoptions
+    if exist('vfoptions','var')
+        vfoptions_temp=PType_Options(vfoptions,Names_i,ii);
+        if ~isfield(vfoptions_temp,'verbose')
+            vfoptions_temp.verbose=0;
+        end
+        if ~isfield(vfoptions_temp,'verboseparams')
+            vfoptions_temp.verboseparams=0;
+        end
+        if ~isfield(vfoptions_temp,'ptypestorecpu')
+            vfoptions_temp.ptypestorecpu=0; % GPU memory is limited, so switch solutions to the cpu. Off by default.
+        end
+    else
+        vfoptions_temp.verbose=0;
+        vfoptions_temp.verboseparams=0;
+        vfoptions_temp.ptypestorecpu=0; % GPU memory is limited, so switch solutions to the cpu. Off by default.
+    end 
+    
+    if vfoptions_temp.verbose==1
+        fprintf('Permanent type: %i of %i \n',ii, N_i)
+    end
+    
+    % Go through everything which might be dependent on fixed type (PType)
+    % [THIS could be better coded, 'names' are same for all these and just need to be found once outside of ii loop]
+    if isstruct(n_d)
+        n_d_temp=n_d.(Names_i{ii});
+    else
+        n_d_temp=n_d;
+    end
+    if isstruct(n_a)
+        n_a_temp=n_a.(Names_i{ii});
+    else
+        n_a_temp=n_a;
+    end
+    if isstruct(n_z)
+        n_z_temp=n_z.(Names_i{ii});
+    else
+        n_z_temp=n_z;
+    end
+    if isstruct(N_j)
+        N_j_temp=N_j.(Names_i{ii});
+    else
+        N_j_temp=N_j;
+    end
+    if isstruct(d_grid)
+        d_grid_temp=d_grid.(Names_i{ii});
+    else
+        d_grid_temp=d_grid;
+    end
+    if isstruct(a_grid)
+        a_grid_temp=a_grid.(Names_i{ii});
+    else
+        a_grid_temp=a_grid;
+    end
+
+    %% Exogenous shocks
+    if isstruct(z_grid)
+        z_grid_temp=z_grid.(Names_i{ii});
+    else
+        nn=size(z_grid,ndims(z_grid));
+        if nn==N_i
+            otherdims = repmat({':'},1,ndims(z_grid)-1);
+            z_grid_temp=z_grid(otherdims{:},ii);
+        else
+            z_grid_temp=z_grid;
+        end
+    end
+    if isstruct(pi_z)
+        pi_z_temp=pi_z.(Names_i{ii});
+    else
+        nn=size(pi_z,ndims(pi_z));
+        if nn==N_i
+            otherdims = repmat({':'},1,ndims(pi_z)-1);
+            pi_z_temp=pi_z(otherdims{:},ii);
+        else
+            pi_z_temp=pi_z;
+        end
+    end
+
+    % e
+    if isfield(vfoptions_temp,'n_e')
+        % If vfoptions_temp.e_grid is a structure that was already dealt with by PType_Options() command
+        if ~isstruct(vfoptions.e_grid)
+            % So just need to check if last dimension is of length N_i
+            nn=size(vfoptions_temp.e_grid,ndims(vfoptions_temp.e_grid));
+            if nn==N_i
+                otherdims = repmat({':'},1,ndims(vfoptions_temp.e_grid)-1);
+                vfoptions_temp.e_grid=vfoptions_temp.e_grid(otherdims{:},ii);
+            end
+        end
+        % If vfoptions_temp.pi_semiz is a structure that was already dealt with by PType_Options() command
+        if ~isstruct(vfoptions.pi_e)
+            % So just need to check if last dimension is of length N_i
+            nn=size(vfoptions_temp.pi_e,ndims(vfoptions_temp.pi_e));
+            if nn==N_i
+                otherdims = repmat({':'},1,ndims(vfoptions_temp.pi_e)-1);
+                vfoptions_temp.pi_e=vfoptions_temp.pi_e(otherdims{:},ii);
+            end
+        end
+    end
+
+    % semiz
+    if isfield(vfoptions_temp,'n_semiz')
+        % If vfoptions_temp.semiz_grid is a structure that was already dealt with by PType_Options() command
+        if ~isstruct(vfoptions.semiz_grid)
+            % So just need to check if last dimension is of length N_i
+            nn=size(vfoptions_temp.semiz_grid,ndims(vfoptions_temp.semiz_grid));
+            if nn==N_i
+                otherdims = repmat({':'},1,ndims(vfoptions_temp.semiz_grid)-1);
+                vfoptions_temp.semiz_grid=vfoptions_temp.semiz_grid(otherdims{:},ii);
+            end
+        end
+        % Might use SemiExoShockFn or pi_semiz, if the later we need to deal with it
+        if isfield(vfoptions_temp,'pi_semiz')
+            % If vfoptions_temp.pi_semiz is a structure that was already dealt with by PType_Options() command
+            if ~isstruct(vfoptions.pi_semiz)
+                % So just need to check if last dimension is of length N_i
+                nn=size(vfoptions_temp.pi_semiz,ndims(vfoptions_temp.pi_semiz));
+                if nn==N_i
+                    otherdims = repmat({':'},1,ndims(vfoptions_temp.pi_semiz)-1);
+                    vfoptions_temp.pi_semiz=vfoptions_temp.pi_semiz(otherdims{:},ii);
+                end
+            end
+        end
+    end
+
+
+    %%
+    DiscountFactorParamNames_temp=DiscountFactorParamNames;
+    if isstruct(DiscountFactorParamNames)
+        names=fieldnames(DiscountFactorParamNames);
+        for jj=1:length(names)
+            if strcmp(names{jj},Names_i{ii})
+                DiscountFactorParamNames_temp=DiscountFactorParamNames.(names{jj});
+            end
+        end
+    end
+
+    if isstruct(ReturnFn)
+        ReturnFn_temp=ReturnFn.(Names_i{ii});
+    else
+        ReturnFn_temp=ReturnFn;
+    end
+    
+    %%
+    % Parameters are allowed to be given as structure, or as vector/matrix
+    % (in terms of their dependence on fixed type). So go through each of
+    % these in term.
+    Parameters_temp=Parameters;
+    FullParamNames=fieldnames(Parameters);
+    nFields=length(FullParamNames);
+    for kField=1:nFields
+        if isa(Parameters.(FullParamNames{kField}), 'struct') % Check for permanent type in structure form
+            names=fieldnames(Parameters.(FullParamNames{kField}));
+            for jj=1:length(names)
+                if strcmp(names{jj},Names_i{ii})
+                    Parameters_temp.(FullParamNames{kField})=Parameters.(FullParamNames{kField}).(names{jj});
+                end
+            end
+        elseif any(size(Parameters.(FullParamNames{kField}))==N_i) % Check for permanent type in vector/matrix form.
+            temp=Parameters.(FullParamNames{kField});
+            [~,ptypedim]=max(size(Parameters.(FullParamNames{kField}))==N_i); % Parameters as vector/matrix can be at most two dimensional, figure out which relates to PType.
+            if ptypedim==1
+                Parameters_temp.(FullParamNames{kField})=temp(ii,:);
+            elseif ptypedim==2
+                Parameters_temp.(FullParamNames{kField})=temp(:,ii);
+            end
+        end
+    end
+
+    % ReturnFnParamNames_temp=ReturnFnParamNamesFn(ReturnFn_temp,n_d_temp,n_a_temp,n_z_temp,vfoptions_temp,Parameters_temp);
+    
+    if vfoptions_temp.verboseparams==1
+        sprintf('Parameter values for the current permanent type')
+        Parameters_temp
+    end
+    
+    if isfinite(N_j_temp)
+        [V_ii, Policy_ii]=ValueFnIter_Case1_FHorz(n_d_temp,n_a_temp,n_z_temp,N_j_temp,d_grid_temp, a_grid_temp, z_grid_temp, pi_z_temp, ReturnFn_temp, Parameters_temp, DiscountFactorParamNames_temp, [], vfoptions_temp);
+    else % PType actually allows for infinite horizon as well
+        [V_ii, Policy_ii]=ValueFnIter_InfHorz(n_d_temp,n_a_temp,n_z_temp,d_grid_temp, a_grid_temp, z_grid_temp, pi_z_temp, ReturnFn_temp, Parameters_temp, DiscountFactorParamNames_temp, [], vfoptions_temp);
+    end
+
+    
+    if vfoptions_temp.ptypestorecpu==1
+        V.(Names_i{ii})=gather(V_ii); 
+        Policy.(Names_i{ii})=gather(Policy_ii);
+    else
+        V.(Names_i{ii})=V_ii;
+        Policy.(Names_i{ii})=Policy_ii;
+    end
+        
+    clear V_ii Policy_ii
+
+end
+
+
+end

--- a/ValueFnIter/TransPath/ValueFnOnTransPath_InfHorz.m
+++ b/ValueFnIter/TransPath/ValueFnOnTransPath_InfHorz.m
@@ -1,8 +1,8 @@
 function [VPath,PolicyPath]=ValueFnOnTransPath_InfHorz(PricePath, ParamPath, T, V_final, Policy_final, Parameters, n_d,n_a,n_z, d_grid,a_grid,z_grid, pi_z, DiscountFactorParamNames, ReturnFn, transpathoptions, vfoptions)
 % transpathoptions, vfoptions and simoptions are optional inputs
 
-if all(size(d_grid)==[prod(n_z),prod(n_z)])
-    error('Check input order: pi_z comes after z_grid') % Keep this error message until end of 2007, can remove after that
+if prod(n_z)>1 && all(size(d_grid)==[prod(n_z),prod(n_z)])
+    error('Check input order: pi_z comes after z_grid') % Keep this error message until end of 2027, can remove after that
 end
 
 %% Check which transpathoptions have been used, set all others to defaults 

--- a/ValueFnIter/TransPathMixHorz/ValueFnOnTransPath_Case1_MixHorz_PType.m
+++ b/ValueFnIter/TransPathMixHorz/ValueFnOnTransPath_Case1_MixHorz_PType.m
@@ -1,0 +1,215 @@
+function [VPath,PolicyPath]=ValueFnOnTransPath_Case1_MixHorz_PType(PricePath, ParamPath, T, V_final, Policy_final, Parameters, n_d, n_a, n_z, N_j, Names_i, d_grid, a_grid,z_grid, pi_z, DiscountFactorParamNames, ReturnFn, transpathoptions, vfoptions)
+
+VPath=struct();
+PolicyPath=struct();
+
+vfoptions.preEV=0; % =1 is used by 'Matched Expecations Path', for TPath we want =0 (this relates to details of fastOLG=1 value fn code)
+
+%%
+if iscell(Names_i)
+    N_i=length(Names_i);
+else
+    N_i=Names_i; % It is the number of PTypes (which have not been given names)
+    Names_i={'ptype001'};
+    for ii=2:N_i
+        if ii<10
+            Names_i{ii}=['ptype00',num2str(ii)];
+        elseif ii<100
+            Names_i{ii}=['ptype0',num2str(ii)];
+        elseif ii<1000
+            Names_i{ii}=['ptype',num2str(ii)];
+        end
+    end
+end
+
+%% Loop over permanent types
+for ii=1:N_i
+
+    % First set up transpathoptions
+    if exist('transpathoptions','var')
+        transpathoptions_temp=PType_Options(transpathoptions,Names_i,ii);
+        if ~isfield(transpathoptions_temp,'verbose')
+            transpathoptions_temp.verbose=0;
+        end
+        if ~isfield(transpathoptions_temp,'verboseparams')
+            transpathoptions_temp.verboseparams=0;
+        end
+    else
+        transpathoptions_temp.verbose=0;
+        transpathoptions_temp.verboseparams=0;
+    end
+
+    % First set up vfoptions
+    if exist('vfoptions','var')
+        vfoptions_temp=PType_Options(vfoptions,Names_i,ii);
+        if ~isfield(vfoptions_temp,'verbose')
+            vfoptions_temp.verbose=0;
+        end
+        if ~isfield(vfoptions_temp,'verboseparams')
+            vfoptions_temp.verboseparams=0;
+        end
+        if ~isfield(vfoptions_temp,'ptypestorecpu')
+            vfoptions_temp.ptypestorecpu=0; % GPU memory is limited, so switch solutions to the cpu
+        end
+    else
+        vfoptions_temp.verbose=0;
+        vfoptions_temp.verboseparams=0;
+        vfoptions_temp.ptypestorecpu=0; % GPU memory is limited, so switch solutions to the cpu
+    end 
+    
+    if vfoptions_temp.verbose==1
+        fprintf('Permanent type: %i of %i \n',ii, N_i)
+    end
+           
+    V_final_temp=V_final.(Names_i{ii});
+    Policy_final_temp=Policy_final.(Names_i{ii});
+    
+
+    % Go through everything which might be dependent on permanent type (PType)
+    % Notice that the way this is coded the grids (etc.) could be either
+    % fixed, or a function (that depends on age, and possibly on permanent
+    % type), or they could be a structure. Only in the case where they are
+    % a structure is there a need to take just a specific part and send
+    % only that to the 'non-PType' version of the command.
+    if isa(n_d,'struct')
+        n_d_temp=n_d.(Names_i{ii});
+    else
+        n_d_temp=n_d;
+    end
+    if isa(n_a,'struct')
+        n_a_temp=n_a.(Names_i{ii});
+    else
+        n_a_temp=n_a;
+    end
+    if isa(n_z,'struct')
+        n_z_temp=n_z.(Names_i{ii});
+    else
+        n_z_temp=n_z;
+    end
+    if isa(N_j,'struct')
+        N_j_temp=N_j.(Names_i{ii});
+    else
+        N_j_temp=N_j;
+    end
+    if isa(d_grid,'struct')
+        d_grid_temp=d_grid.(Names_i{ii});
+    else
+        d_grid_temp=d_grid;
+    end
+    if isa(a_grid,'struct')
+        a_grid_temp=a_grid.(Names_i{ii});
+    else
+        a_grid_temp=a_grid;
+    end
+    if isa(z_grid,'struct')
+        z_grid_temp=z_grid.(Names_i{ii});
+    else
+        z_grid_temp=z_grid;
+    end
+    if isa(pi_z,'struct')
+        pi_z_temp=pi_z.(Names_i{ii});
+    else
+        pi_z_temp=pi_z;
+    end
+    if isa(ReturnFn,'struct')
+        ReturnFn_temp=ReturnFn.(Names_i{ii});
+    else
+        ReturnFn_temp=ReturnFn;
+    end
+
+    % Parameters are allowed to be given as structure, or as vector/matrix
+    % (in terms of their dependence on fixed type). So go through each of
+    % these in term.
+    Parameters_temp=Parameters;
+    FullParamNames=fieldnames(Parameters);
+    nFields=length(FullParamNames);
+    for kField=1:nFields
+        if isa(Parameters.(FullParamNames{kField}), 'struct') % Check for permanent type in structure form
+            names=fieldnames(Parameters.(FullParamNames{kField}));
+            for jj=1:length(names)
+                if strcmp(names{jj},Names_i{ii})
+                    Parameters_temp.(FullParamNames{kField})=Parameters.(FullParamNames{kField}).(names{jj});
+                end
+            end
+        elseif any(size(Parameters.(FullParamNames{kField}))==N_i) % Check for permanent type in vector/matrix form.
+            temp=Parameters.(FullParamNames{kField});
+            [~,ptypedim]=max(size(Parameters.(FullParamNames{kField}))==N_i); % Parameters as vector/matrix can be at most two dimensional, figure out which relates to PType.
+            if ptypedim==1
+                Parameters_temp.(FullParamNames{kField})=temp(ii,:);
+            elseif ptypedim==2
+                Parameters_temp.(FullParamNames{kField})=temp(:,ii);
+            end
+        end
+    end
+    DiscountFactorParamNames_temp=DiscountFactorParamNames;
+    if isa(DiscountFactorParamNames,'struct')
+        names=fieldnames(DiscountFactorParamNames);
+        for jj=1:length(names)
+            if strcmp(names{jj},Names_i{ii})
+                DiscountFactorParamNames_temp=DiscountFactorParamNames.(names{jj});
+            end
+        end
+    end
+    
+    if vfoptions_temp.verboseparams==1
+        sprintf('Parameter values for the current permanent type')
+        Parameters_temp
+    end
+    
+    % PricePath can include parameters that differ by ptype
+    PricePath_temp=PricePath;
+    PricePathNames=fieldnames(PricePath);
+    for nn=1:length(PricePathNames)
+        if isstruct(PricePath_temp.(PricePathNames{nn}))
+            PricePath_temp.(PricePathNames{nn})=PricePath.(PricePathNames{nn}).(Names_i{ii});
+        elseif any(size(PricePath_temp.(PricePathNames{nn}))==N_i)
+            if size(PricePath_temp.(PricePathNames{nn}),1)==N_i
+                temp=PricePath_temp.(PricePathNames{nn});
+                PricePath_temp.(PricePathNames{nn})=temp(ii,:);
+            elseif size(PricePath_temp.(PricePathNames{nn}),2)==N_i
+                temp=PricePath_temp.(PricePathNames{nn});
+                PricePath_temp.(PricePathNames{nn})=temp(:,ii);
+            end
+        end
+    end
+
+    % ParamPath can include parameters that differ by ptype
+    ParamPath_temp=ParamPath;
+    ParamPathNames=fieldnames(ParamPath);
+    for nn=1:length(ParamPathNames)
+        if isstruct(ParamPath_temp.(ParamPathNames{nn}))
+            ParamPath_temp.(ParamPathNames{nn})=ParamPath.(ParamPathNames{nn}).(Names_i{ii});
+        elseif any(size(ParamPath_temp.(ParamPathNames{nn}))==N_i)
+            if size(ParamPath_temp.(ParamPathNames{nn}),1)==N_i
+                temp=ParamPath_temp.(ParamPathNames{nn});
+                ParamPath_temp.(ParamPathNames{nn})=temp(ii,:);
+            elseif size(ParamPath_temp.(ParamPathNames{nn}),2)==N_i
+                temp=ParamPath_temp.(ParamPathNames{nn});
+                ParamPath_temp.(ParamPathNames{nn})=temp(:,ii);
+            end
+        end
+    end
+
+    if isfinite(N_j_temp)
+        [VPath_ii,PolicyPath_ii]=ValueFnOnTransPath_Case1_FHorz(PricePath_temp, ParamPath_temp, T, V_final_temp, Policy_final_temp, Parameters_temp, n_d_temp, n_a_temp, n_z_temp, N_j_temp, d_grid_temp, a_grid_temp,z_grid_temp,pi_z_temp, DiscountFactorParamNames_temp, ReturnFn_temp, transpathoptions_temp, vfoptions_temp);
+    else
+        [VPath_ii,PolicyPath_ii]=ValueFnOnTransPath_InfHorz(PricePath_temp, ParamPath_temp, T, V_final_temp, Policy_final_temp, Parameters_temp, n_d_temp, n_a_temp, n_z_temp, d_grid_temp, a_grid_temp,z_grid_temp, pi_z_temp, DiscountFactorParamNames_temp, ReturnFn_temp, transpathoptions_temp, vfoptions_temp);
+    end
+    % Note: T cannot depend on ptype, nor can PricePath depend on ptype
+
+    if vfoptions_temp.ptypestorecpu==1
+        VPath.(Names_i{ii})=gather(VPath_ii);
+        PolicyPath.(Names_i{ii})=gather(PolicyPath_ii);
+    else
+        VPath.(Names_i{ii})=VPath_ii;
+        PolicyPath.(Names_i{ii})=PolicyPath_ii;
+    end
+        
+    clear VPath_ii PolicyPath_ii
+
+end
+
+
+end
+
+


### PR DESCRIPTION
First draft of minimal MixHorz changes.

You may want to evaluate how literally I took the FHorz/MixHorz separate with respect to EvaluateFnOnAgentDist\FHorz\PType\EvalFnOnAgentDist_AggVars_FHorz_Case1_PType.m (by duplicating the whole file to avoid a single `isfinite` test).  If we keep the original pattern (which lets an FHorz PType function perform a MixHorz test), then we need to cleanup the _Case1 function call that presently escaped the InfHorz naming changes.  If not, it goes away by magic.

In a vice-versa sense, we could split EvaluateFnOnAgentDist\FHorz\PType\EvalFnOnAgentDist_AggVars_FHorz_Case1_PType.m into FHorz and MixHorz cases.

I did include a few bug fixes such as StationaryDist\TransPathFHorz\AgentDistOnTransPath_Case1_FHorz.m and TransitionPaths\Subcodes\PricePathParamPath_FHorz_StructToMatrix.m and ValueFnIter\TransPath\ValueFnOnTransPath_InfHorz.m but left most for later review.