### PR TITLE
Fix calculation of PolicyaprimejzPath when simoptions.fastOLG==1

### DIFF
--- a/TransitionPaths/FHorz/SubSteps/TransitionPath_FHorz_substeps_Step2_AdjustPolicy.m
+++ b/TransitionPaths/FHorz/SubSteps/TransitionPath_FHorz_substeps_Step2_AdjustPolicy.m
@@ -211,12 +211,17 @@ if transpathoptions.fastOLG==0
                 end
                 PolicyProbsPath=a2primeProbsPath;
             elseif simoptions.fastOLG==1
+                PolicyaprimejzPath=permute(repmat(PolicyaprimejzPath,[1,1,2]),[1,3,2]);
                 if simoptions.setup_experienceasset.N_a1==0
-                    PolicyaprimejzPath=repmat(PolicyaprimejzPath,1,2,1)+repelem(a2primeIndexesPath,1,2,1);
+                    PolicyaprimejzPath=PolicyaprimejzPath+a2primeIndexesPath;
                 else
-                    PolicyaprimejzPath=repmat(PolicyaprimejzPath,1,2,1)+repelem(simoptions.setup_experienceasset.N_a1*(a2primeIndexesPath-1),1,2,1);
+                    PolicyaprimejzPath=PolicyaprimejzPath+simoptions.setup_experienceasset.N_a1*(a2primeIndexesPath-1);
                 end
-                PolicyProbsPath=repmat(PolicyProbsPath,1,2,1).*repelem(a2primeProbsPath,1,2,1);
+                if exist('PolicyProbsPath','var')
+                    PolicyProbsPath=PolicyProbsPath.*a2primeProbsPath;
+                else
+                    PolicyProbsPath=a2primeProbsPath;
+                end
             end
         end
     elseif N_z==0 && N_e>0


### PR DESCRIPTION
When `PolicyaprimejzPath` is a 2D matrix, `repmat(PolicyaprimejzPath, 1,2,1)` does not preserve its first and last dimensions (as might be expected by the 1s in the new first and last dimensions) while creating a new middle dimension that is replicated 2x.  Instead, it merely replicates along the second dimension and adding a self-eliminating singleton in the 3rd dimension.

These changes create a shape that matches the shape of `a2primeIndexesPath`, for better or worse.

We also handle the case when `PolicyProbsPath` is not initially defined (because we got here via experienceasset, not gridinterp).

NOTE: because of the way the code is factored (common code replicated across both fastOLG==0 and fastOLG==1, as well as the three cases N_z>0 && N_e==0, N_z==0 && N_e>0, N_z>0 && N_e>0) there are eight places where code needs to be changed.  Additionally there are cases where N_z==0 and N_e==0 which also need to be changed, albeit slightly differently.  A refactorization of the logic (for example, using N_ze) would greatly reduce this duplication.