### PR TITLE
V_final missing reshape in fastOLG case

### DIFF
--- a/TransitionPaths/MixHorz/TransitionPath_Case1_MixHorz_PType.m
+++ b/TransitionPaths/MixHorz/TransitionPath_Case1_MixHorz_PType.m
@@ -606,11 +606,11 @@ for ii=1:PTypeStructure.N_i
     
     %% Organise V_final and AgentDist_initial
     % Reshape V_final
-    if ~isfinite(PTypeStructure.(iistr).N_j)
+    N_j_temp=PTypeStructure.(iistr).N_j;
+    if ~isfinite(N_j_temp)
         % If no z, then N_z=1 here
         V_final.(iistr)=reshape(V_final.(iistr),[N_a,N_z]);
-    elseif transpathoptions.fastOLG==0
-        N_j_temp=PTypeStructure.(iistr).N_j;
+    else
         if N_z==0
             if N_e==0
                 V_final.(iistr)=reshape(V_final.(iistr),[N_a,N_j_temp]);
@@ -624,19 +624,20 @@ for ii=1:PTypeStructure.N_i
                 V_final.(iistr)=reshape(V_final.(iistr),[N_a,N_z,N_e,N_j_temp]);
             end
         end
-    else % transpathoptions.fastOLG==1
-        N_j_temp=PTypeStructure.(iistr).N_j;
-        if N_z==0
-            if N_e==0
-                V_final.(iistr)=reshape(V_final.(iistr),[N_a,N_j_temp]);
+        if transpathoptions.fastOLG==1
+            if N_z==0
+                if N_e==0
+                    % Already reshaped
+                    % V_final.(iistr)=reshape(V_final.(iistr),[N_a,N_j_temp]);
+                else
+                    V_final.(iistr)=reshape(permute(V_final.(iistr),[1,3,2]),[N_a*N_j_temp,N_e]);
+                end
             else
-                V_final.(iistr)=reshape(permute(V_final.(iistr),[1,3,2]),[N_a*N_j_temp,N_e]);
-            end
-        else
-            if N_e==0
-                V_final.(iistr)=reshape(permute(V_final.(iistr),[1,3,2]),[N_a*N_j_temp,N_z]);
-            else
-                V_final.(iistr)=reshape(permute(V_final.(iistr),[1,4,2,3]),[N_a*N_j_temp,N_z,N_e]);
+                if N_e==0
+                    V_final.(iistr)=reshape(permute(V_final.(iistr),[1,3,2]),[N_a*N_j_temp,N_z]);
+                else
+                    V_final.(iistr)=reshape(permute(V_final.(iistr),[1,4,2,3]),[N_a*N_j_temp,N_z,N_e]);
+                end
             end
         end
     end


### PR DESCRIPTION
Somehow V_final was missing a reshape in the fastOLG==1 case.  These patches fix the problem by implementing a pattern recognizing that fastOLG or not, V_final needs to be reshaped so that the first dimension fully stacks all the n_a terms into an N_a term.  However, instead of doing this common reshaping on both branches of the fastOLG condition, we do it once, before the fastOLG test.  If we are doing fastOLG, we then further reshape V_final with an additional permute and reshape.

This pattern could be applied to the FHorz and FHorz_PType cases as well as the ValueFnOnTransPath_Case1_FHorz case, simplifying the code.  Indeed, in the latter case this has already been done for `Policy_final`; it just hasn't been done for `V_final`.  See this code at line 142:

```
        Policy_final=reshape(Policy_final,[size(Policy_final,1),N_a,N_z,N_j]);
        if transpathoptions.fastOLG==0
            V_final=reshape(V_final,[N_a,N_z,N_j]);
        else % vfoptions.fastOLG==1
            V_final=reshape(permute(reshape(V_final,[N_a,N_z,N_j]),[1,3,2]),[N_a*N_j,N_z]);
            Policy_final=reshape(permute(Policy_final,[1,2,4,3]),[size(Policy_final,1),N_a,N_j,N_z]);
        end
```