### PR TITLE
Fix grid interpolation policy unpacking with discrete choices

### DIFF
--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_GridInterpLayer.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_GridInterpLayer.m
@@ -216,7 +216,7 @@ V=reshape(V,[n_a,n_z]);
 if N_d==0
     Policy=UnKronPolicyIndexes1_z(Policy, n_a, n_a, n_z, vfoptions);
 else
-    Policy=UnKronPolicyIndexes1_z(Policy, [n_d,n_a], n_a, n_z, vfoptions);
+    Policy=UnKronPolicyIndexes2_z(Policy, n_d, n_a, n_a, n_z, vfoptions);
 end
 
 


### PR DESCRIPTION
Summary:
- Fixes the infinite-horizon grid interpolation wrapper for models with a discrete d choice and one endogenous asset.
- The GI raw solver already returns separate d, a', L2, and L2flag channels, so the final unpacking should use UnKronPolicyIndexes2_z rather than treating d and a' as one combined Kronecker index.
- Without this, the asset-policy channel is corrupted before stationary distribution and moment evaluation.

Verification:
- Reproduced in a Pijoan-Mas (2006) replication with n_d > 0, n_a = 600, n_z = 7, vfoptions.gridinterplayer = 1, simoptions.gridinterplayer = 1.
- After the fix, the stationary distribution has no negative mass and the GI moments line up with the non-GI solution; correlation evaluation also runs cleanly.