### PR TITLE
Improve infinite-horizon VFI max-iteration warnings

### DIFF
--- a/ValueFnIter/InfHorz/CPU/ValueFnIter_InfHorz_Par0_raw.m
+++ b/ValueFnIter/InfHorz/CPU/ValueFnIter_InfHorz_Par0_raw.m
@@ -60,8 +60,11 @@ Policy=zeros(2,N_a,N_z);
 Policy(1,:,:)=permute(PolicyIndexes1,[3,1,2]);
 Policy(2,:,:)=permute(PolicyIndexes2,[3,1,2]);
 
-if tempcounter>=maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 

--- a/ValueFnIter/InfHorz/CPU/ValueFnIter_InfHorz_Par1_raw.m
+++ b/ValueFnIter/InfHorz/CPU/ValueFnIter_InfHorz_Par1_raw.m
@@ -55,8 +55,11 @@ Policy=zeros(2,N_a,N_z);
 Policy(1,:,:)=shiftdim(rem(PolicyIndexes-1,N_d)+1,-1);
 Policy(2,:,:)=shiftdim(ceil(PolicyIndexes/N_d),-1);
 
-if tempcounter>=maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/CPU/ValueFnIter_InfHorz_nod_Par0_raw.m
+++ b/ValueFnIter/InfHorz/CPU/ValueFnIter_InfHorz_nod_Par0_raw.m
@@ -57,8 +57,11 @@ end
 Policy=reshape(PolicyIndexes,[1,N_a,N_z]);
 
 
-if tempcounter>=maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/CPU/ValueFnIter_InfHorz_nod_Par1_raw.m
+++ b/ValueFnIter/InfHorz/CPU/ValueFnIter_InfHorz_nod_Par1_raw.m
@@ -53,8 +53,11 @@ end
 Policy=reshape(Policy,[1,N_a,N_z]);
 
 
-if tempcounter>=maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/ExoticPrefs/QuasiHyperbolic/ValueFnIter_InfHorz_QuasiHyperbolicN_Refine_postGI_raw.m
+++ b/ValueFnIter/InfHorz/ExoticPrefs/QuasiHyperbolic/ValueFnIter_InfHorz_QuasiHyperbolicN_Refine_postGI_raw.m
@@ -266,8 +266,11 @@ Policy_QH_a=reshape(Policy_QH_a,[1,N_a,N_z]);
 Policy=local_extract_postGI_d(Policy_QH_a, dstar, aprimeshifter, n2short, vfoptions, N_a, N_z, N_aprime, ReturnMatrixfine, addindexforazfine);
 Policyalt=local_extract_postGI_d(Policy_std_a, dstar, aprimeshifter, n2short, vfoptions, N_a, N_z, N_aprime, ReturnMatrixfine, addindexforazfine);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/ExoticPrefs/QuasiHyperbolic/ValueFnIter_InfHorz_QuasiHyperbolicN_postGI_nod_raw.m
+++ b/ValueFnIter/InfHorz/ExoticPrefs/QuasiHyperbolic/ValueFnIter_InfHorz_QuasiHyperbolicN_postGI_nod_raw.m
@@ -215,8 +215,11 @@ Policy_QH_a=reshape(Policy_QH_a,[1,N_a,N_z]);
 Policy=local_extract_postGI(Policy_QH_a, aprimeshifter, n2short, vfoptions, N_a, N_z, N_aprime, ReturnMatrixfine, addindexforazfine);
 Policyalt=local_extract_postGI(Policy_std_a, aprimeshifter, n2short, vfoptions, N_a, N_z, N_aprime, ReturnMatrixfine, addindexforazfine);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/ExoticPrefs/QuasiHyperbolic/ValueFnIter_InfHorz_QuasiHyperbolicS_Refine_postGI_raw.m
+++ b/ValueFnIter/InfHorz/ExoticPrefs/QuasiHyperbolic/ValueFnIter_InfHorz_QuasiHyperbolicS_Refine_postGI_raw.m
@@ -218,8 +218,11 @@ Policy_a=reshape(Policy_a,[1,N_a,N_z]);
 Policy=local_extract_postGI_d(Policy_a, dstar, aprimeshifter, n2short, vfoptions, N_a, N_z, N_aprime, ReturnMatrixfine, addindexforazfine);
 Policyalt=[];
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/ExoticPrefs/QuasiHyperbolic/ValueFnIter_InfHorz_QuasiHyperbolicS_postGI_nod_raw.m
+++ b/ValueFnIter/InfHorz/ExoticPrefs/QuasiHyperbolic/ValueFnIter_InfHorz_QuasiHyperbolicS_postGI_nod_raw.m
@@ -164,8 +164,11 @@ Policy_a=reshape(Policy,[1,N_a,N_z]);
 Policy=local_extract_postGI(Policy_a, aprimeshifter, n2short, vfoptions, N_a, N_z, N_aprime, ReturnMatrixfine, addindexforazfine);
 Policyalt=[];
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/GI2A/ValueFnIter_InfHorz_Refine_postGI2A_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/GI2A/ValueFnIter_InfHorz_Refine_postGI2A_raw.m
@@ -357,8 +357,11 @@ isInfUpper = (ReturnMatrixfine(linidx_upper) == -Inf);
 inInterior = (L2 >= 2) & (L2 <= n2short+1);
 Policy(5,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper), [1,N_a,N_z]);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/GI2A/ValueFnIter_InfHorz_Refine_preGI2A_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/GI2A/ValueFnIter_InfHorz_Refine_preGI2A_raw.m
@@ -183,8 +183,11 @@ isInfUpper = (ReturnMatrixfine(linidx_upper) == -Inf);
 inInterior = (L2_flat >= 2) & (L2_flat <= n2short+1);
 Policy(5,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper), [1,N_a,N_z]);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 

--- a/ValueFnIter/InfHorz/GridInterpLayer/GI2A/ValueFnIter_InfHorz_postGI2A_nod_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/GI2A/ValueFnIter_InfHorz_postGI2A_nod_raw.m
@@ -275,8 +275,11 @@ isInfUpper = (ReturnMatrixfine(linidx_upper) == -Inf);
 inInterior = (L2 >= 2) & (L2 <= n2short+1);
 Policy(4,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper), [1,N_a,N_z]);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/GI2A/ValueFnIter_InfHorz_preGI2A_nod_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/GI2A/ValueFnIter_InfHorz_preGI2A_nod_raw.m
@@ -145,8 +145,11 @@ isInfUpper = (ReturnMatrixfine(linidx_upper) == -Inf);
 inInterior = (L2_flat >= 2) & (L2_flat <= n2short+1);
 Policy(4,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper), [1,N_a,N_z]);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_postGI_HowardGreedy_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_postGI_HowardGreedy_raw.m
@@ -193,8 +193,11 @@ Policy(4,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper
 if any(~isfinite(Ftemp))
     warning('Howards-greedy cannot be used for models where V contains values of -Inf. This model looks like it may be one where V takes a value of -Inf at some points in the state-space. Consider checking solution against that with vfoptions.howardsgreedy=0')
 end
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_postGI_HowardMix2_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_postGI_HowardMix2_raw.m
@@ -190,8 +190,11 @@ Policy(4,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper
 if any(~isfinite(Ftemp))
     warning('Howards-greedy cannot be used for models where V contains values of -Inf. This model looks like it may be one where V takes a value of -Inf at some points in the state-space. Consider checking solution against that with vfoptions.howardsgreedy=0')
 end
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_postGI_HowardMix_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_postGI_HowardMix_raw.m
@@ -188,8 +188,11 @@ isInfUpper = (ReturnMatrixfine(linidx_upper(:)) == -Inf);
 inInterior = (L2 >= 2) & (L2 <= n2short+1);
 Policy(4,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper), [1,N_a,N_z]);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_postGI_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_postGI_raw.m
@@ -331,8 +331,11 @@ isInfUpper = (ReturnMatrixfine(linidx_upper(:)) == -Inf);
 inInterior = (L2 >= 2) & (L2 <= n2short+1);
 Policy(4,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper), [1,N_a,N_z]);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_preGI_HowardGreedy_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_preGI_HowardGreedy_raw.m
@@ -177,8 +177,11 @@ Policy(4,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper
 if any(~isfinite(Ftemp))
     warning('Howards-greedy cannot be used for models where V contains values of -Inf. This model looks like it may be one where V takes a value of -Inf at some points in the state-space. Consider checking solution against that with vfoptions.howardsgreedy=0')
 end
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_preGI_HowardMix_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_preGI_HowardMix_raw.m
@@ -179,8 +179,11 @@ inInterior = (L2 >= 2) & (L2 <= n2short+1);
 Policy(4,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper), [1,N_a,N_z]);
 
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_preGI_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_Refine_preGI_raw.m
@@ -167,8 +167,11 @@ inInterior = (L2 >= 2) & (L2 <= n2short+1);
 Policy(4,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper), [1,N_a,N_z]);
 
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_postGI_HowardGreedy_nod_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_postGI_HowardGreedy_nod_raw.m
@@ -173,8 +173,11 @@ Policy(3,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper
 if any(~isfinite(Ftemp))
     warning('Howards-greedy cannot be used for models where V contains values of -Inf. This model looks like it may be one where V takes a value of -Inf at some points in the state-space. Consider checking solution against that with vfoptions.howardsgreedy=0')
 end
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_postGI_HowardMix2_nod_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_postGI_HowardMix2_nod_raw.m
@@ -171,8 +171,11 @@ Policy(3,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper
 if any(~isfinite(Ftemp))
     warning('Howards-greedy cannot be used for models where V contains values of -Inf. This model looks like it may be one where V takes a value of -Inf at some points in the state-space. Consider checking solution against that with vfoptions.howardsgreedy=0')
 end
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_postGI_HowardMix_nod_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_postGI_HowardMix_nod_raw.m
@@ -169,8 +169,11 @@ isInfUpper = (ReturnMatrixfine(linidx_upper(:)) == -Inf);
 inInterior = (L2 >= 2) & (L2 <= n2short+1);
 Policy(3,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper), [1,N_a,N_z]);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_postGI_nod_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_postGI_nod_raw.m
@@ -255,8 +255,11 @@ isInfUpper = (ReturnMatrixfine(linidx_upper(:)) == -Inf);
 inInterior = (L2 >= 2) & (L2 <= n2short+1);
 Policy(3,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper), [1,N_a,N_z]);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_postGI_sparse_nod_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_postGI_sparse_nod_raw.m
@@ -171,8 +171,11 @@ Policy(2,:,:)=adjust.*Policy(2,:,:)+(1-adjust).*(Policy(2,:,:)-n2short-1); % fro
 Policy(3,:,:) = PolicyL2flag_3d;
 
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_postGI_sparse_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_postGI_sparse_raw.m
@@ -184,8 +184,11 @@ Policy(4,:,:) = PolicyL2flag_3d;
 
 %Policy=Policy(1,:,:)+N_d*(Policy(2,:,:)-1)+N_d*N_a*(Policy(3,:,:)-1);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_preGI_HowardGreedy_nod_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_preGI_HowardGreedy_nod_raw.m
@@ -134,8 +134,11 @@ Policy(3,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper
 if any(~isfinite(Ftemp))
     warning('Howards-greedy cannot be used for models where V contains values of -Inf. This model looks like it may be one where V takes a value of -Inf at some points in the state-space. Consider checking solution against that with vfoptions.howardsgreedy=0')
 end
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_preGI_HowardMix_nod_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_preGI_HowardMix_nod_raw.m
@@ -140,8 +140,11 @@ isInfUpper = (ReturnMatrixfine(linidx_upper(:)) == -Inf);
 inInterior = (L2 >= 2) & (L2 <= n2short+1);
 Policy(3,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper), [1,N_a,N_z]);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_preGI_nod_raw.m
+++ b/ValueFnIter/InfHorz/GridInterpLayer/ValueFnIter_InfHorz_preGI_nod_raw.m
@@ -126,8 +126,11 @@ isInfUpper = (ReturnMatrixfine(linidx_upper(:)) == -Inf);
 inInterior = (L2 >= 2) & (L2 <= n2short+1);
 Policy(3,:,:) = reshape(2 + (inInterior & isInfLower) - (inInterior & isInfUpper), [1,N_a,N_z]);
 
-if tempcounter>=vfoptions.maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 

--- a/ValueFnIter/InfHorz/LowMemory/ValueFnIter_InfHorz_LowMem_nod_raw.m
+++ b/ValueFnIter/InfHorz/LowMemory/ValueFnIter_InfHorz_LowMem_nod_raw.m
@@ -58,8 +58,11 @@ end
 
 Policy=reshape(Policy,[1,N_a,N_z]);
 
-if tempcounter>=maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 

--- a/ValueFnIter/InfHorz/LowMemory/ValueFnIter_InfHorz_LowMem_raw.m
+++ b/ValueFnIter/InfHorz/LowMemory/ValueFnIter_InfHorz_LowMem_raw.m
@@ -63,8 +63,11 @@ Policy=zeros(2,N_a,N_z,'gpuArray'); %NOTE: this is not actually in Kron form
 Policy(1,:,:)=shiftdim(rem(PolicyIndexes-1,N_d)+1,-1);
 Policy(2,:,:)=shiftdim(ceil(PolicyIndexes/N_d),-1);
 
-if tempcounter>=maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/LowMemory/ValueFnIter_InfHorz_LowMem_sparse_nod_raw.m
+++ b/ValueFnIter/InfHorz/LowMemory/ValueFnIter_InfHorz_LowMem_sparse_nod_raw.m
@@ -71,8 +71,11 @@ end
 
 Policy=reshape(Policy,[1,N_a,N_z]);
 
-if tempcounter>=maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 

--- a/ValueFnIter/InfHorz/ValueFnIter_InfHorz_HowardGreedy_nod_raw.m
+++ b/ValueFnIter/InfHorz/ValueFnIter_InfHorz_HowardGreedy_nod_raw.m
@@ -52,12 +52,18 @@ end
 
 Policy=reshape(Policy,[1,N_a,N_z]);
 
-if tempcounter>=maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
-if tempcounter>=maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 

--- a/ValueFnIter/InfHorz/ValueFnIter_InfHorz_nod_raw.m
+++ b/ValueFnIter/InfHorz/ValueFnIter_InfHorz_nod_raw.m
@@ -48,8 +48,11 @@ end
 
 Policy=reshape(Policy,[1,N_a,N_z]);
 
-if tempcounter>=maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 

--- a/ValueFnIter/InfHorz/ValueFnIter_InfHorz_raw.m
+++ b/ValueFnIter/InfHorz/ValueFnIter_InfHorz_raw.m
@@ -61,8 +61,11 @@ Policy=zeros(2,N_a,N_z,'gpuArray'); %NOTE: this is not actually in Kron form
 Policy(1,:,:)=shiftdim(rem(PolicyIndexes-1,N_d)+1,-1);
 Policy(2,:,:)=shiftdim(ceil(PolicyIndexes/N_d),-1);
 
-if tempcounter>=maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end

--- a/ValueFnIter/InfHorz/ValueFnIter_InfHorz_sparse_nod_raw.m
+++ b/ValueFnIter/InfHorz/ValueFnIter_InfHorz_sparse_nod_raw.m
@@ -59,8 +59,11 @@ end %end while loop
 
 Policy=reshape(Policy,[1,N_a,N_z]);
 
-if tempcounter>=maxiter
-    warning('Value fn iteration has stopped due to reaching the maximum number of iterations (not due to convergence); can be set by vfoptions.maxiter.')
+if currdist > Tolerance
+    warning(['Value fn iteration has stopped due to reaching the maximum number of iterations ', ...
+             '(not due to convergence); can be set by vfoptions.maxiter. ', ...
+             'Last currdist = %.16g; tolerance = %.16g.'], ...
+             currdist, Tolerance)
 end
 
 end


### PR DESCRIPTION
Updates infinite-horizon value-function iteration routines so max-iteration warnings include the final convergence distance and tolerance.\n\nPreviously these warnings only reported that vfoptions.maxiter had been reached. The new message reports Last currdist and tolerance, making non-convergence diagnostics more informative.\n\nThis is limited to infinite-horizon VFI routines where convergence is checked; finite-horizon backward-iteration code is unchanged.