### PR TITLE
Restore lowmemory=3 for a few examples in ValueFnIter and TPaths

### DIFF
--- a/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAsset.m
+++ b/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAsset.m
@@ -74,7 +74,7 @@ Policy=reshape(Policy,[size(Policy,1),N_a,N_ze,N_j]);
 % Policy is currently about d and a1prime. Convert it to being about aprime
 % as that is what we need for simulation, and we can then just send it to standard Case1 commands.
 Policy_aprime=zeros(N_a,N_ze,2,N_j,'gpuArray'); % the lower grid point
-PolicyProbs=zeros(N_a,N_ze,2,N_j,'gpuArray'); % The fourth dimension is lower/upper grid point
+PolicyProbs=zeros(N_a,N_ze,2,N_j,'gpuArray'); % The third dimension is lower/upper grid point
 whichisdforexpasset=length(n_d)-simoptions.l_dexperienceasset+1:length(n_d);  % is just saying which is the decision variable that influences the experience asset (it is the 'last' decision variable)
 for jj=1:N_j
     aprimeFnParamsVec=CreateVectorFromParams(Parameters, aprimeFnParamNames,jj);

--- a/TransitionPaths/FHorz/subcodes/ValueFnSingleStep/ExpAsset/slowOLG/ValueFnIter_FHorz_TPath_SingleStep_ExpAsset_e_raw.m
+++ b/TransitionPaths/FHorz/subcodes/ValueFnSingleStep/ExpAsset/slowOLG/ValueFnIter_FHorz_TPath_SingleStep_ExpAsset_e_raw.m
@@ -18,6 +18,10 @@ if vfoptions.lowmemory==1
 elseif vfoptions.lowmemory==2
     special_n_e=ones(1,length(n_e));
     special_n_z=ones(1,length(n_z));
+elseif vfoptions.lowmemory==3
+    special_n_e=ones(1,length(n_e));
+    special_n_z=ones(1,length(n_z));
+    special_n_ea=ones(1,length(n_a2));
 end
 
 %% j=N_j
@@ -53,6 +57,21 @@ elseif vfoptions.lowmemory==2
             [Vtemp,maxindex]=max(ReturnMatrix_ze);
             V(:,z_c,e_c,N_j)=Vtemp;
             Policy(:,z_c,e_c,N_j)=maxindex;
+        end
+    end
+elseif vfoptions.lowmemory==3
+    for ea_c=1:N_a2
+        ea_val=a2_gridvals(ea_c);
+        for z_c=1:N_z
+            z_val=z_gridvals_J(z_c,:,N_j);
+            for e_c=1:N_e
+                e_val=e_gridvals_J(e_c,:,N_j);
+                ReturnMatrix_ea_ze=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1, special_n_ea, special_n_z, special_n_e, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+                % Calc the max and its index
+                [Vtemp,maxindex]=max(ReturnMatrix_ea_ze);
+                V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,e_c,N_j)=Vtemp;
+                Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,e_c,N_j)=maxindex;
+            end
         end
     end
 end
@@ -99,13 +118,14 @@ for reverse_j=1:N_j-1
     EV=squeeze(sum(EV,3));
     % EV is over (d2,a1prime,a2,z)
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
+    % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
 
     if vfoptions.lowmemory==0
 
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1,n_a2,n_z,n_e, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,jj), e_gridvals_J(:,:,jj), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountedEV; % should autofill e dimension
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1); % should autofill e dimension
 
         % Calc the max and its index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -119,7 +139,7 @@ for reverse_j=1:N_j-1
             e_val=e_gridvals_J(e_c,:,jj);
             ReturnMatrix_e=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1,n_a2,n_z,special_n_e, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,jj), e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS=ReturnMatrix_e+DiscountedEV;
+            entireRHS=ReturnMatrix_e+DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
 
             % Calc the max and its index
             [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -130,19 +150,38 @@ for reverse_j=1:N_j-1
     elseif vfoptions.lowmemory==2
         for z_c=1:N_z
             z_val=z_gridvals_J(z_c,:,jj);
-            DiscountedEV_z=DiscountFactorParamsVec*repelem(EV(:,:,z_c),N_d1,N_a1);
             for e_c=1:N_e
                 e_val=e_gridvals_J(e_c,:,jj);
 
                 ReturnMatrix_ze=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1,n_a2,special_n_z,special_n_e, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-                entireRHS=ReturnMatrix_ze+DiscountedEV_z;
+                entireRHS=ReturnMatrix_ze+DiscountFactorParamsVec*repelem(EV(:,:,z_c),N_d1,N_a1);
 
                 %Calc the max and its index
                 [Vtemp,maxindex]=max(entireRHS,[],1);
 
                 V(:,z_c,e_c,jj)=shiftdim(Vtemp,1);
                 Policy(:,z_c,e_c,jj)=shiftdim(maxindex,1);
+            end
+        end
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,jj);
+                for e_c=1:N_e
+                    e_val=e_gridvals_J(e_c,:,jj);
+
+                    ReturnMatrix_ea_ze=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1,special_n_ea,special_n_z,special_n_e, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+
+                    entireRHS_ea_z=ReturnMatrix_ea_ze+DiscountFactorParamsVec*repelem(EV(:,ea_c,z_c),N_d1,N_a1);
+
+                    %Calc the max and its index
+                    [Vtemp,maxindex]=max(entireRHS_ea_z,[],1);
+
+                    V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,e_c,jj)=shiftdim(Vtemp,1);
+                    Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,e_c,jj)=shiftdim(maxindex,1);
+                end
             end
         end
     end

--- a/TransitionPaths/FHorz/subcodes/ValueFnSingleStep/ExpAsset/slowOLG/ValueFnIter_FHorz_TPath_SingleStep_ExpAsset_raw.m
+++ b/TransitionPaths/FHorz/subcodes/ValueFnSingleStep/ExpAsset/slowOLG/ValueFnIter_FHorz_TPath_SingleStep_ExpAsset_raw.m
@@ -14,6 +14,9 @@ a2_gridvals=CreateGridvals(n_a2,a2_grid,1);
 
 if vfoptions.lowmemory==1
     special_n_z=ones(1,length(n_z));
+elseif vfoptions.lowmemory==3
+    special_n_z=ones(1,length(n_z));
+    special_n_ea=ones(1,length(n_a2));
 end
 
 %% j=N_j
@@ -38,6 +41,18 @@ elseif vfoptions.lowmemory==1
         [Vtemp,maxindex]=max(ReturnMatrix_z,[],1);
         V(:,z_c,N_j)=Vtemp;
         Policy(:,z_c,N_j)=maxindex;
+    end
+elseif vfoptions.lowmemory==3
+    for ea_c=1:N_a2
+        ea_val=a2_gridvals(ea_c);
+        for z_c=1:N_z
+            z_val=z_gridvals_J(z_c,:,N_j);
+            ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2,n_a1,n_a1, special_n_ea, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+            % Calc the max and its index
+            [Vtemp,maxindex]=max(ReturnMatrix_ea_z);
+            V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=Vtemp;
+            Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=maxindex;
+        end
     end
 end
 
@@ -82,13 +97,14 @@ for reverse_j=1:N_j-1
     EV=squeeze(sum(EV,3));
     % EV is over (d2,a1prime,a2,z)
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
+    % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2, n_a1, n_a1,n_a2,n_z, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals,z_gridvals_J(:,:,jj), ReturnFnParamsVec,0,0); % Level=0, Refine=0
         % (d,aprime,a,z)
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
 
         %Calc the max and its index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -99,16 +115,33 @@ for reverse_j=1:N_j-1
     elseif vfoptions.lowmemory==1
         for z_c=1:N_z
             z_val=z_gridvals_J(z_c,:,jj);
-            DiscountedEV_z=DiscountedEV(:,:,z_c);
 
             ReturnMatrix_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2, n_a1, n_a1,n_a2, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_z=ReturnMatrix_z+DiscountedEV_z;
+            entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*repelem(EV(:,:,z_c),N_d1,N_a1);
 
             %Calc the max and its index
             [Vtemp,maxindex]=max(entireRHS_z,[],1);
             V(:,z_c,jj)=Vtemp;
             Policy(:,z_c,jj)=maxindex;
+        end
+
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,jj);
+
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2,n_a1,n_a1,special_n_ea,special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+
+                entireRHS_ea_z=ReturnMatrix_ea_z+DiscountFactorParamsVec*repelem(EV(:,ea_c,z_c),N_d1,N_a1);
+
+                %Calc the max and its index
+                [Vtemp,maxindex]=max(entireRHS_ea_z,[],1);
+
+                V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,jj)=shiftdim(Vtemp,1);
+                Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,jj)=shiftdim(maxindex,1);
+            end
         end
     end
 end

--- a/ValueFnIter/FHorz/ExperienceAsset/ValueFnIter_FHorz_ExpAsset_e_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAsset/ValueFnIter_FHorz_ExpAsset_e_raw.m
@@ -19,6 +19,10 @@ if vfoptions.lowmemory==1
 elseif vfoptions.lowmemory==2
     special_n_e=ones(1,length(n_e));
     special_n_z=ones(1,length(n_z));
+elseif vfoptions.lowmemory==3
+    special_n_e=ones(1,length(n_e));
+    special_n_z=ones(1,length(n_z));
+    special_n_ea=ones(1,length(n_a2));
 end
 
 %% j=N_j
@@ -54,6 +58,21 @@ if ~isfield(vfoptions,'V_Jplus1')
                 Policy(:,z_c,e_c,N_j)=maxindex;
             end
         end
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,N_j);
+                for e_c=1:N_e
+                    e_val=e_gridvals_J(e_c,:,N_j);
+                    ReturnMatrix_ea_ze=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1, special_n_ea, special_n_z, special_n_e, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+                    % Calc the max and its index
+                    [Vtemp,maxindex]=max(ReturnMatrix_ea_ze);
+                    V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,e_c,N_j)=Vtemp;
+                    Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,e_c,N_j)=maxindex;
+                end
+            end
+        end
     end
 else
     DiscountFactorParamsVec=CreateVectorFromParams(Parameters, DiscountFactorParamNames,N_j);
@@ -84,13 +103,14 @@ else
     EV=squeeze(sum(EV,3));
     % EV is over (d2,a1prime,a2,z)
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
+    % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
 
     if vfoptions.lowmemory==0
 
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1,n_a2,n_z,n_e, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), e_gridvals_J(:,:,N_j), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountedEV; % should autofill e dimension
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1); % should autofill e dimension
 
         %Calc the max and its index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -104,7 +124,7 @@ else
             e_val=e_gridvals_J(e_c,:,N_j);
             ReturnMatrix_e=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1,n_a2,n_z,special_n_e, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS=ReturnMatrix_e+DiscountedEV;
+            entireRHS=ReturnMatrix_e+DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
 
             % Calc the max and its index
             [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -127,6 +147,26 @@ else
 
                 V(:,z_c,e_c,N_j)=shiftdim(Vtemp,1);
                 Policy(:,z_c,e_c,N_j)=shiftdim(maxindex,1);
+            end
+        end
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,N_j);
+                DiscountedEV_ea_z=DiscountFactorParamsVec*repelem(EV(:,ea_c,z_c),N_d1,N_a1);
+                for e_c=1:N_e
+                    e_val=e_gridvals_J(e_c,:,N_j);
+                    ReturnMatrix_ea_ze=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1,special_n_ea,special_n_z,special_n_e, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+
+                    entireRHS_ea_z=ReturnMatrix_ea_ze+DiscountedEV_ea_z;
+
+                    % Calc the max and its index
+                    [Vtemp,maxindex]=max(entireRHS_ea_z,[],1);
+
+                    V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,e_c,N_j)=shiftdim(Vtemp,1);
+                    Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,e_c,N_j)=shiftdim(maxindex,1);
+                end
             end
         end
     end
@@ -171,13 +211,13 @@ for reverse_j=1:N_j-1
     EV=squeeze(sum(EV,3));
     % EV is over (d2,a1prime,a2,z)
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
 
     if vfoptions.lowmemory==0
 
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1,n_a2,n_z,n_e, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,jj), e_gridvals_J(:,:,jj), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountedEV; % should autofill e dimension
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1); % should autofill e dimension
 
         % Calc the max and its index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -191,7 +231,7 @@ for reverse_j=1:N_j-1
             e_val=e_gridvals_J(e_c,:,jj);
             ReturnMatrix_e=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1,n_a2,n_z,special_n_e, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,jj), e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS=ReturnMatrix_e+DiscountedEV;
+            entireRHS=ReturnMatrix_e+DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
 
             % Calc the max and its index
             [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -215,6 +255,27 @@ for reverse_j=1:N_j-1
 
                 V(:,z_c,e_c,jj)=shiftdim(Vtemp,1);
                 Policy(:,z_c,e_c,jj)=shiftdim(maxindex,1);
+            end
+        end
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,jj);
+                DiscountedEV_ea_z=DiscountFactorParamsVec*repelem(EV(:,ea_c,z_c),N_d1,N_a1);
+                for e_c=1:N_e
+                    e_val=e_gridvals_J(e_c,:,jj);
+
+                    ReturnMatrix_ea_ze=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1,special_n_ea,special_n_z,special_n_e, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+
+                    entireRHS_ea_z=ReturnMatrix_ea_ze+DiscountedEV_ea_z;
+
+                    %Calc the max and its index
+                    [Vtemp,maxindex]=max(entireRHS_ea_z,[],1);
+
+                    V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,e_c,jj)=shiftdim(Vtemp,1);
+                    Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,e_c,jj)=shiftdim(maxindex,1);
+                end
             end
         end
     end

--- a/ValueFnIter/FHorz/ExperienceAsset/ValueFnIter_FHorz_ExpAsset_e_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAsset/ValueFnIter_FHorz_ExpAsset_e_raw.m
@@ -122,11 +122,12 @@ else
 
     elseif vfoptions.lowmemory==1
 
+        DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
         for e_c=1:N_e
             e_val=e_gridvals_J(e_c,:,N_j);
             ReturnMatrix_e=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1,n_a2,n_z,special_n_e, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS=ReturnMatrix_e+DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
+            entireRHS=ReturnMatrix_e+DiscountedEV;
 
             % Calc the max and its index
             [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -233,11 +234,12 @@ for reverse_j=1:N_j-1
 
     elseif vfoptions.lowmemory==1
 
+        DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
         for e_c=1:N_e
             e_val=e_gridvals_J(e_c,:,jj);
             ReturnMatrix_e=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1,n_a2,n_z,special_n_e, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,jj), e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS=ReturnMatrix_e+DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
+            entireRHS=ReturnMatrix_e+DiscountedEV;
 
             % Calc the max and its index
             [Vtemp,maxindex]=max(entireRHS,[],1);

--- a/ValueFnIter/FHorz/ExperienceAsset/ValueFnIter_FHorz_ExpAsset_e_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAsset/ValueFnIter_FHorz_ExpAsset_e_raw.m
@@ -9,7 +9,7 @@ N_z=prod(n_z);
 N_e=prod(n_e);
 
 V=zeros(N_a,N_z,N_e,N_j,'gpuArray');
-Policy=zeros(N_a,N_z,N_e,N_j,'gpuArray'); %first dim indexes the optimal choice for d and a1prime rest of dimensions a,z
+Policy=zeros(N_a,N_z,N_e,N_j,'gpuArray'); %first dim (added at the very end) indexes the optimal choice for d and a1prime rest of dimensions a,z
 
 %%
 a2_gridvals=CreateGridvals(n_a2,a2_grid,1);
@@ -95,7 +95,9 @@ else
     aprimeProbs(skipinterp)=0; % effectively skips interpolation
 
     % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-    EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2,a1prime,a2,u,zprime)
+    EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+    EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+    EV=EV_l+EV_u; % (d2*a1prime,a2,zprime)
     % Already applied the probabilities from interpolating onto grid
 
     EV=EV.*shiftdim(pi_z_J(:,:,N_j)',-2);
@@ -190,26 +192,30 @@ for reverse_j=1:N_j-1
     [a2primeIndex,a2primeProbs]=CreateExperienceAssetFnMatrix(aprimeFn, n_d2, n_a2, d2_gridvals, a2_grid, aprimeFnParamsVec,2); % Note, is actually aprime_grid (but a_grid is anyway same for all ages)
     % Note: aprimeIndex is [N_d2,N_a2], whereas aprimeProbs is [N_d2,N_a2]
 
-    aprimeIndex=repelem((1:1:N_a1)',N_d2,N_a2)+N_a1*repmat(a2primeIndex-1,N_a1,1,1); % [N_d2*N_a1,N_a2]
-    aprimeplus1Index=repelem((1:1:N_a1)',N_d2,N_a2)+N_a1*repmat(a2primeIndex,N_a1,1,1); % [N_d2*N_a1,N_a2]
-    aprimeProbs=repmat(a2primeProbs,N_a1,1,N_z); % [N_d2*N_a1,N_a2,N_z]
+    if vfoptions.lowmemory<3
+        aprimeIndex=repelem((1:1:N_a1)',N_d2,N_a2)+N_a1*repmat(a2primeIndex-1,N_a1,1,1); % [N_d2*N_a1,N_a2]
+        aprimeplus1Index=repelem((1:1:N_a1)',N_d2,N_a2)+N_a1*repmat(a2primeIndex,N_a1,1,1); % [N_d2*N_a1,N_a2]
+        aprimeProbs=repmat(a2primeProbs,N_a1,1,N_z); % [N_d2*N_a1,N_a2,N_z]
 
-    EVpre=sum(shiftdim(pi_e_J(:,jj),-2).*V(:,:,:,jj+1),3); % First, switch V_Jplus1 into Kron form
+        EVpre=sum(shiftdim(pi_e_J(:,jj),-2).*V(:,:,:,jj+1),3); % Resolve `e` effects on V_Jplus1
 
-    Vlower=reshape(EVpre(aprimeIndex(:),:),[N_d2*N_a1,N_a2,N_z]);
-    Vupper=reshape(EVpre(aprimeplus1Index(:),:),[N_d2*N_a1,N_a2,N_z]);
-    % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
-    skipinterp=(Vlower==Vupper);
-    aprimeProbs(skipinterp)=0; % effectively skips interpolation
-
-    % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-    EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2,a1prime,a2,u,zprime)
-    % Already applied the probabilities from interpolating onto grid
-
-    EV=EV.*shiftdim(pi_z_J(:,:,jj)',-2);
-    EV(isnan(EV))=0; % remove nan created where value fn is -Inf but probability is zero
-    EV=squeeze(sum(EV,3));
-    % EV is over (d2,a1prime,a2,z)
+        Vlower=reshape(EVpre(aprimeIndex(:),:),[N_d2*N_a1,N_a2,N_z]);
+        Vupper=reshape(EVpre(aprimeplus1Index(:),:),[N_d2*N_a1,N_a2,N_z]);
+        % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
+        skipinterp=(Vlower==Vupper);
+        aprimeProbs(skipinterp)=0; % effectively skips interpolation
+    
+        % Switch EV from being in terms of a2prime to being in terms of d2 and a2
+        EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+        EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+        EV=EV_l+EV_u; % (d2*a1prime,a2,zprime)
+        % Already applied the probabilities from interpolating onto grid
+    
+        EV=EV.*shiftdim(pi_z_J(:,:,jj)',-2);
+        EV(isnan(EV))=0; % remove nan created where value fn is -Inf but probability is zero
+        EV=squeeze(sum(EV,3));
+        % EV is over (d2,a1prime,a2,z)
+    end
 
     % DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1,1);
 
@@ -259,10 +265,31 @@ for reverse_j=1:N_j-1
         end
     elseif vfoptions.lowmemory==3
         for ea_c=1:N_a2
+            aprimeIndex_ea=repelem((1:1:N_a1)',N_d2,1)+N_a1*repmat(squeeze(a2primeIndex(:,ea_c))-1,N_a1,1,1); % [N_d2*N_a1,1]
+            aprimeplus1Index_ea=repelem((1:1:N_a1)',N_d2)+N_a1*repmat(squeeze(a2primeIndex(:,ea_c)),N_a1,1,1); % [N_d2*N_a1,1]
+            aprimeProbs_ea=repmat(squeeze(a2primeProbs(:,ea_c)),N_a1,1,N_z); % [N_d2*N_a1,1,N_z]
+
+            Vlower_ea=reshape(V(aprimeIndex_ea(:),:,jj+1),[N_d2*N_a1,1,N_z]); % (d*a1prime,1,z)
+            Vupper_ea=reshape(V(aprimeplus1Index_ea(:),:,jj+1),[N_d2*N_a1,1,N_z]);
+            % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
+            skipinterp_ea=(Vlower_ea==Vupper_ea);
+            aprimeProbs_ea(skipinterp_ea)=0; % effectively skips interpolation
+
+            % Switch EV from being in terms of a2prime to being in terms of d (and the present ea_c, from a2)
+            EV_ea_l=aprimeProbs_ea.*Vlower_ea; EV_ea_u=(1-aprimeProbs_ea).*Vupper_ea;
+            EV_ea_l(isnan(EV_ea_l))=0; EV_ea_u(isnan(EV_ea_u))=0;
+            EV_ea=EV_ea_l+EV_ea_u; % (d2*a1prime,1,z)
+            % Already applied the probabilities from interpolating onto grid
+
+            EV_ea=EV_ea.*shiftdim(pi_z_J(:,:,jj),-1); % shifted pi_z shaped [1,z,zprime] -- no transpose since current z is dim 3
+            EV_ea(isnan(EV_ea))=0; % remove nan created where value fn is -Inf but probability is zero
+            EV_ea=squeeze(sum(EV_ea,3));
+            % EV is over (d2*a1prime,z)
+
             ea_val=a2_gridvals(ea_c);
             for z_c=1:N_z
                 z_val=z_gridvals_J(z_c,:,jj);
-                DiscountedEV_ea_z=DiscountFactorParamsVec*repelem(EV(:,ea_c,z_c),N_d1,N_a1);
+                DiscountedEV_ea_z=DiscountFactorParamsVec*repelem(EV_ea(:,z_c),N_d1,N_a1);
                 for e_c=1:N_e
                     e_val=e_gridvals_J(e_c,:,jj);
 

--- a/ValueFnIter/FHorz/ExperienceAsset/ValueFnIter_FHorz_ExpAsset_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAsset/ValueFnIter_FHorz_ExpAsset_raw.m
@@ -15,6 +15,9 @@ a2_gridvals=CreateGridvals(n_a2,a2_grid,1);
 
 if vfoptions.lowmemory==1
     special_n_z=ones(1,length(n_z));
+elseif vfoptions.lowmemory==3
+    special_n_z=ones(1,length(n_z));
+    special_n_ea=ones(1,length(n_a2));
 end
 
 %% j=N_j
@@ -37,6 +40,18 @@ if ~isfield(vfoptions,'V_Jplus1')
             [Vtemp,maxindex]=max(ReturnMatrix_z,[],1);
             V(:,z_c,N_j)=Vtemp;
             Policy(:,z_c,N_j)=maxindex;
+        end
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,N_j);
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1, special_n_ea, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+                % Calc the max and its index
+                [Vtemp,maxindex]=max(ReturnMatrix_ea_z);
+                V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=Vtemp;
+                Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=maxindex;
+            end
         end
     end
 else
@@ -68,13 +83,14 @@ else
     EV=squeeze(sum(EV,3));
     % EV is over (d2,a1prime,a2,z)
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
+    % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2, n_a1, n_a1,n_a2,n_z, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), ReturnFnParamsVec,0,0); % Level=0, Refine=0
         % (d,a1prime,a)
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
 
         %Calc the max and its index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -85,11 +101,10 @@ else
     elseif vfoptions.lowmemory==1
         for z_c=1:N_z
             z_val=z_gridvals_J(z_c,:,N_j);
-            DiscountedEV_z=DiscountedEV(:,:,z_c);
 
             ReturnMatrix_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2, n_a1, n_a1,n_a2, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_z=ReturnMatrix_z+DiscountedEV_z;
+            entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*repelem(EV(:,:,z_c),N_d1,N_a1);
 
             %Calc the max and its index
             [Vtemp,maxindex]=max(entireRHS_z,[],1);
@@ -97,6 +112,22 @@ else
             Policy(:,z_c,N_j)=maxindex;
         end
 
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,N_j);
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2,n_a1,n_a1,special_n_ea,special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+
+                entireRHS_ea_z=ReturnMatrix_ea_z+DiscountFactorParamsVec*repelem(EV(:,ea_c,z_c),N_d1,N_a1);
+
+                % Calc the max and its index
+                [Vtemp,maxindex]=max(entireRHS_ea_z,[],1);
+
+                V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=shiftdim(Vtemp,1);
+                Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=shiftdim(maxindex,1);
+            end
+        end
     end
 end
 
@@ -138,13 +169,13 @@ for reverse_j=1:N_j-1
     EV=squeeze(sum(EV,3));
     % EV is over (d2,a1prime,a2,z)
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2, n_a1, n_a1,n_a2,n_z, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals,z_gridvals_J(:,:,jj), ReturnFnParamsVec,0,0); % Level=0, Refine=0
         % (d,aprime,a,z)
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
 
         %Calc the max and its index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -155,16 +186,33 @@ for reverse_j=1:N_j-1
     elseif vfoptions.lowmemory==1
         for z_c=1:N_z
             z_val=z_gridvals_J(z_c,:,jj);
-            DiscountedEV_z=DiscountedEV(:,:,z_c);
 
             ReturnMatrix_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2, n_a1, n_a1,n_a2, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_z=ReturnMatrix_z+DiscountedEV_z;
+            entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*repelem(EV(:,:,z_c),N_d1,N_a1);
 
             %Calc the max and its index
             [Vtemp,maxindex]=max(entireRHS_z,[],1);
             V(:,z_c,jj)=Vtemp;
             Policy(:,z_c,jj)=maxindex;
+        end
+
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,jj);
+
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2,n_a1,n_a1,special_n_ea,special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+
+                entireRHS_ea_z=ReturnMatrix_ea_z+DiscountFactorParamsVec*repelem(EV(:,ea_c,z_c),N_d1,N_a1);
+
+                %Calc the max and its index
+                [Vtemp,maxindex]=max(entireRHS_ea_z,[],1);
+
+                V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,jj)=shiftdim(Vtemp,1);
+                Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,jj)=shiftdim(maxindex,1);
+            end
         end
     end
 end

--- a/ValueFnIter/FHorz/ExperienceAsset/ValueFnIter_FHorz_ExpAsset_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAsset/ValueFnIter_FHorz_ExpAsset_raw.m
@@ -15,6 +15,8 @@ a2_gridvals=CreateGridvals(n_a2,a2_grid,1);
 
 if vfoptions.lowmemory==1
     special_n_z=ones(1,length(n_z));
+elseif vfoptions.lowmemory==2
+    error("invalid vfoptions.lowmemory without e");
 elseif vfoptions.lowmemory==3
     special_n_z=ones(1,length(n_z));
     special_n_ea=ones(1,length(n_a2));

--- a/ValueFnIter/FHorz/ExperienceAsset/ValueFnIter_FHorz_ExpAsset_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAsset/ValueFnIter_FHorz_ExpAsset_raw.m
@@ -46,9 +46,9 @@ if ~isfield(vfoptions,'V_Jplus1')
             ea_val=a2_gridvals(ea_c);
             for z_c=1:N_z
                 z_val=z_gridvals_J(z_c,:,N_j);
-                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, n_d1,n_d2,n_a1,n_a1, special_n_ea, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2,n_a1,n_a1, special_n_ea, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
                 % Calc the max and its index
-                [Vtemp,maxindex]=max(ReturnMatrix_ea_z);
+                [Vtemp,maxindex]=max(ReturnMatrix_ea_z,[],1);
                 V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=Vtemp;
                 Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=maxindex;
             end
@@ -75,7 +75,9 @@ else
     aprimeProbs(skipinterp)=0; % effectively skips interpolation
 
     % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-    EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2,a1prime,a2,u,zprime)
+    EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+    EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+    EV=EV_l+EV_u; % (d2*a1prime,a2,zprime)
     % Already applied the probabilities from interpolating onto grid
 
     EV=EV.*shiftdim(pi_z_J(:,:,N_j)',-2);
@@ -149,25 +151,31 @@ for reverse_j=1:N_j-1
     [a2primeIndex,a2primeProbs]=CreateExperienceAssetFnMatrix(aprimeFn, n_d2, n_a2, d2_gridvals, a2_grid, aprimeFnParamsVec,2); % Note, is actually aprime_grid (but a_grid is anyway same for all ages)
     % Note: aprimeIndex is [N_d2,N_a2], whereas aprimeProbs is [N_d2,N_a2]
 
-    aprimeIndex=repelem((1:1:N_a1)',N_d2,N_a2)+N_a1*repmat(a2primeIndex-1,N_a1,1,1); % [N_d2*N_a1,N_a2]
-    aprimeplus1Index=repelem((1:1:N_a1)',N_d2,N_a2)+N_a1*repmat(a2primeIndex,N_a1,1,1); % [N_d2*N_a1,N_a2]
-    aprimeProbs=repmat(a2primeProbs,N_a1,1,N_z); % [N_d2*N_a1,N_a2,N_z]
-
-    Vlower=reshape(V(aprimeIndex(:),:,jj+1),[N_d2*N_a1,N_a2,N_z]);
-    Vupper=reshape(V(aprimeplus1Index(:),:,jj+1),[N_d2*N_a1,N_a2,N_z]);
-    % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
-    skipinterp=(Vlower==Vupper);
-    aprimeProbs(skipinterp)=0; % effectively skips interpolation
-
-    % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-    EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2,a1prime,a2,zprime)
-    % Already applied the probabilities from interpolating onto grid
-
-    % EV is over (d2,a1prime,a2,zprime)
-    EV=EV.*shiftdim(pi_z_J(:,:,jj)',-2);
-    EV(isnan(EV))=0; % remove nan created where value fn is -Inf but probability is zero
-    EV=squeeze(sum(EV,3));
-    % EV is over (d2,a1prime,a2,z)
+    if vfoptions.lowmemory<3
+        aprimeIndex=repelem((1:1:N_a1)',N_d2,N_a2)+N_a1*repmat(a2primeIndex-1,N_a1,1); % [N_d2*N_a1,N_a2]
+        aprimeplus1Index=repelem((1:1:N_a1)',N_d2,N_a2)+N_a1*repmat(a2primeIndex,N_a1,1); % [N_d2*N_a1,N_a2]
+        aprimeProbs=repmat(a2primeProbs,N_a1,1,N_z); % [N_d2*N_a1,N_a2,N_z]
+    
+        Vlower=reshape(V(aprimeIndex(:),:,jj+1),[N_d2*N_a1,N_a2,N_z]);
+        Vupper=reshape(V(aprimeplus1Index(:),:,jj+1),[N_d2*N_a1,N_a2,N_z]);
+        % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
+        skipinterp=(Vlower==Vupper);
+        aprimeProbs(skipinterp)=0; % effectively skips interpolation
+    
+        % Switch EV from being in terms of a2prime to being in terms of d2 and a2
+        EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+        EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+        EV=EV_l+EV_u; % (d2*a1prime,a2,zprime)
+        % Already applied the probabilities from interpolating onto grid
+    
+        % EV is over (d2,a1prime,a2,zprime)
+        EV=EV.*shiftdim(pi_z_J(:,:,jj)',-2);
+        EV(isnan(EV))=0; % remove nan created where value fn is -Inf but probability is zero
+        EV=squeeze(sum(EV,3));
+        % EV is over (d2,a1prime,a2,z)
+    else
+        % We will compute EV piece by piece
+    end
 
     % DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
 
@@ -199,13 +207,34 @@ for reverse_j=1:N_j-1
 
     elseif vfoptions.lowmemory==3
         for ea_c=1:N_a2
+            aprimeIndex_ea=repelem((1:1:N_a1)',N_d2,1)+N_a1*repmat(squeeze(a2primeIndex(:,ea_c))-1,N_a1,1); % [N_d2*N_a1,1]
+            aprimeplus1Index_ea=repelem((1:1:N_a1)',N_d2)+N_a1*repmat(squeeze(a2primeIndex(:,ea_c)),N_a1,1); % [N_d2*N_a1,1]
+            aprimeProbs_ea=repmat(squeeze(a2primeProbs(:,ea_c)),N_a1,1,N_z); % [N_d2*N_a1,1,N_z]
+
+            Vlower_ea=reshape(V(aprimeIndex_ea(:),:,jj+1),[N_d2*N_a1,1,N_z]); % (d2*a1prime,1,z)
+            Vupper_ea=reshape(V(aprimeplus1Index_ea(:),:,jj+1),[N_d2*N_a1,1,N_z]);
+            % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
+            skipinterp_ea=(Vlower_ea==Vupper_ea);
+            aprimeProbs_ea(skipinterp_ea)=0; % effectively skips interpolation
+
+            % Switch EV from being in terms of a2prime to being in terms of d (and the present ea_c, from a2)
+            EV_ea_l=aprimeProbs_ea.*Vlower_ea; EV_ea_u=(1-aprimeProbs_ea).*Vupper_ea;
+            EV_ea_l(isnan(EV_ea_l))=0; EV_ea_u(isnan(EV_ea_u))=0;
+            EV_ea=EV_ea_l+EV_ea_u; % (d2*a1prime,1,z)
+            % Already applied the probabilities from interpolating onto grid
+
+            EV_ea=EV_ea.*shiftdim(pi_z_J(:,:,jj),-1); % shifted pi_z shaped [1,z,zprime] -- no transpose since current z is dim 3
+            EV_ea(isnan(EV_ea))=0; % remove nan created where value fn is -Inf but probability is zero
+            EV_ea=squeeze(sum(EV_ea,3));
+            % EV is over (d2*a1prime,z)
+
             ea_val=a2_gridvals(ea_c);
             for z_c=1:N_z
                 z_val=z_gridvals_J(z_c,:,jj);
 
                 ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2,n_a1,n_a1,special_n_ea,special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-                entireRHS_ea_z=ReturnMatrix_ea_z+DiscountFactorParamsVec*repelem(EV(:,ea_c,z_c),N_d1,N_a1);
+                entireRHS_ea_z=ReturnMatrix_ea_z+DiscountFactorParamsVec*repelem(EV_ea(:,z_c),N_d1,N_a1);
 
                 %Calc the max and its index
                 [Vtemp,maxindex]=max(entireRHS_ea_z,[],1);

--- a/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_nod1_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_nod1_raw.m
@@ -134,12 +134,13 @@ for reverse_j=1:N_j-1
     EV(isnan(EV))=0; %multiplications of -Inf with 0 gives NaN, this replaces them with zeros (as the zeros come from the transition probabilities)
     EV=squeeze(sum(EV,4)); % sum over zprime, leaving current z
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
+    % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,n_a2, n_z, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,jj), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
 
         %Calc the max and it's index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -151,11 +152,10 @@ for reverse_j=1:N_j-1
 
         for z_c=1:N_z
             z_val=z_gridvals_J(z_c,:,jj);
-            DiscountedEV_z=DiscountedEV(:,:,z_c);
 
             ReturnMatrix_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,n_a2, special_n_z, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_z=ReturnMatrix_z+DiscountedEV_z;
+            entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*repelem(EV(:,:,z_c),1,N_a1);
 
             %Calc the max and it's index
             [Vtemp,maxindex]=max(entireRHS_z,[],1);

--- a/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_nod1_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_nod1_raw.m
@@ -12,8 +12,13 @@ Policy=zeros(N_a,N_z,N_j,'gpuArray'); %first dim indexes the optimal choice for 
 %%
 a2_gridvals=CreateGridvals(n_a2,a2_grid,1);
 
-if vfoptions.lowmemory>0
+if vfoptions.lowmemory==1
     special_n_z=ones(1,length(n_z));
+elseif vfoptions.lowmemory==2
+    error("invalid vfoptions.lowmemory without e")
+elseif vfoptions.lowmemory==3
+    special_n_z=ones(1,length(n_z));
+    special_n_ea=ones(1,length(n_a2));
 end
 
 %% j=N_j
@@ -37,6 +42,18 @@ if ~isfield(vfoptions,'V_Jplus1')
             V(:,z_c,N_j)=Vtemp;
             Policy(:,z_c,N_j)=maxindex;
         end
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,N_j);
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,special_n_ea, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+                %Calc the max and its index
+                [Vtemp,maxindex]=max(ReturnMatrix_ea_z);
+                V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=Vtemp;
+                Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=maxindex;
+            end
+        end
     end
 else
     DiscountFactorParamsVec=CreateVectorFromParams(Parameters, DiscountFactorParamNames,N_j);
@@ -59,19 +76,22 @@ else
     aprimeProbs(skipinterp)=0; % effectively skips interpolation
 
     % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-    EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2*a1prime,a2,z,zprime)
+    EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+    EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+    EV=EV_l+EV_u; % (d2*a1prime,a2,z,zprime)
     % Already applied the probabilities from interpolating onto grid
 
     EV=EV.*shiftdim(pi_z_J(:,:,N_j),-2); % pi shaped [1,1,z,zprime] -- no transpose since current z is dim 3
     EV(isnan(EV))=0; %multiplications of -Inf with 0 gives NaN, this replaces them with zeros (as the zeros come from the transition probabilities)
     EV=squeeze(sum(EV,4)); % sum over zprime, leaving current z
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
+    % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,n_a2, n_z, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1);
 
         %Calc the max and it's index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -83,16 +103,32 @@ else
 
         for z_c=1:N_z
             z_val=z_gridvals_J(z_c,:,N_j);
-            DiscountedEV_z=DiscountedEV(:,:,z_c);
 
             ReturnMatrix_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,n_a2, special_n_z, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_z=ReturnMatrix_z+DiscountedEV_z;
+            entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*repelem(EV(:,:,z_c),1,N_a1);
 
             %Calc the max and it's index
             [Vtemp,maxindex]=max(entireRHS_z,[],1);
             V(:,z_c,N_j)=Vtemp;
             Policy(:,z_c,N_j)=maxindex;
+        end
+
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,N_j);
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0,n_d2,n_a1,n_a1,special_n_ea,special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+
+                entireRHS_ea_z=ReturnMatrix_ea_z+DiscountFactorParamsVec*repelem(EV(:,ea_c,z_c),1,N_a1);
+
+                % Calc the max and its index
+                [Vtemp,maxindex]=max(entireRHS_ea_z,[],1);
+
+                V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=shiftdim(Vtemp,1);
+                Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=shiftdim(maxindex,1);
+            end
         end
     end
 end
@@ -116,25 +152,31 @@ for reverse_j=1:N_j-1
     [a2primeIndex,a2primeProbs]=CreateExperienceAssetzFnMatrix(aprimeFn, n_d2, n_a2, n_z, d2_gridvals, a2_grid, z_gridvals_J(:,:,jj), aprimeFnParamsVec,2); % Note, is actually aprime_grid (but a_grid is anyway same for all ages)
     % Note: aprimeIndex is [N_d2,N_a2,N_z], whereas aprimeProbs is [N_d2,N_a2,N_z]   (N_z here is the current z)
 
-    aprimeIndex=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat((a2primeIndex-1),N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]
-    aprimeplus1Index=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat(a2primeIndex,N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]
-    aprimeProbs=repmat(a2primeProbs,N_a1,1,1,N_z);  % [N_d2*N_a1,N_a2,N_z]    (z dim already present, no repmat over z; but need to add zprime)
+    if vfoptions.lowmemory<3
+        aprimeIndex=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat(a2primeIndex-1,N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]
+        aprimeplus1Index=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat(a2primeIndex,N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]
+        aprimeProbs=repmat(a2primeProbs,N_a1,1,1,N_z); % [N_d2*N_a1,N_a2,N_z]    (z dim already present, no repmat over z; but need to add zprime)
+    
+        Vlower=reshape(V(aprimeIndex(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]); % (d*a1prime,a2,z,zprime)
+        Vupper=reshape(V(aprimeplus1Index(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]);
+        % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
+        skipinterp=(Vlower==Vupper);
+        aprimeProbs(skipinterp)=0; % effectively skips interpolation
+    
+        % Switch EV from being in terms of a2prime to being in terms of d and a2
+        EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+        EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+        EV=EV_l+EV_u; % (d2*a1prime,a2,z,zprime)
+        % Already applied the probabilities from interpolating onto grid
+    
+        EV=EV.*shiftdim(pi_z_J(:,:,jj),-2); % pi shaped [1,1,z,zprime] -- no transpose since current z is dim 3
+        EV(isnan(EV))=0; % remove nan created where value fn is -Inf but probability is zero
+        EV=squeeze(sum(EV,4));
+        % EV is over (d2*a1prime,a2,z)
+    else
+        % We will compute EV piece by piece
+    end
 
-    Vlower=reshape(V(aprimeIndex(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]); % (d2*a1prime,a2,z,zprime)
-    Vupper=reshape(V(aprimeplus1Index(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]);
-    % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
-    skipinterp=(Vlower==Vupper);
-    aprimeProbs(skipinterp)=0; % effectively skips interpolation
-
-    % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-    EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2*a1prime,a2,z,zprime)
-    % Already applied the probabilities from interpolating onto grid
-
-    EV=EV.*shiftdim(pi_z_J(:,:,jj),-2); % pi shaped [1,1,z,zprime] -- no transpose since current z is dim 3
-    EV(isnan(EV))=0; %multiplications of -Inf with 0 gives NaN, this replaces them with zeros (as the zeros come from the transition probabilities)
-    EV=squeeze(sum(EV,4)); % sum over zprime, leaving current z
-
-    % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
     % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1);
 
     if vfoptions.lowmemory==0
@@ -161,6 +203,45 @@ for reverse_j=1:N_j-1
             [Vtemp,maxindex]=max(entireRHS_z,[],1);
             V(:,z_c,jj)=Vtemp;
             Policy(:,z_c,jj)=maxindex;
+        end
+
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            aprimeIndex_ea=repelem((1:1:N_a1)',N_d2,N_z)+N_a1*repmat(squeeze(a2primeIndex(:,ea_c,:))-1,N_a1,1); % [N_d2*N_a1,N_z]
+            aprimeplus1Index_ea=repelem((1:1:N_a1)',N_d2,N_z)+N_a1*repmat(squeeze(a2primeIndex(:,ea_c,:)),N_a1,1); % [N_d2*N_a1,N_z]
+            aprimeProbs_ea=repmat(squeeze(a2primeProbs(:,ea_c,:)),N_a1,1,N_z); % [N_d2*N_a1,N_z]    (z dim already present, no repmat over z; but need to add zprime)
+
+            Vlower_ea=reshape(V(aprimeIndex_ea(:),:,jj+1),[N_d2*N_a1,N_z,N_z]); % (d*a1prime,z,zprime)
+            Vupper_ea=reshape(V(aprimeplus1Index_ea(:),:,jj+1),[N_d2*N_a1,N_z,N_z]);
+            % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
+            skipinterp_ea=(Vlower_ea==Vupper_ea);
+            aprimeProbs_ea(skipinterp_ea)=0; % effectively skips interpolation
+
+            % Switch EV from being in terms of a2prime to being in terms of d2 (and the present ea_c, from a2)
+            EV_ea_l=aprimeProbs_ea.*Vlower_ea; EV_ea_u=(1-aprimeProbs_ea).*Vupper_ea;
+            EV_ea_l(isnan(EV_ea_l))=0; EV_ea_u(isnan(EV_ea_u))=0;
+            EV_ea=EV_ea_l+EV_ea_u; % (d2*a1prime,a2,z,zprime)
+            % Already applied the probabilities from interpolating onto grid
+
+            EV_ea=EV_ea.*shiftdim(pi_z_J(:,:,jj),-1); % pi shaped [1,z,zprime] -- no transpose since current z is dim 3
+            EV_ea(isnan(EV_ea))=0; % remove nan created where value fn is -Inf but probability is zero
+            EV_ea=squeeze(sum(EV_ea,3));
+            % EV is over (d*a1prime,z)
+
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,jj);
+
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0,n_d2, n_a1, n_a1,special_n_ea, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+
+                entireRHS_ea_z=ReturnMatrix_ea_z+DiscountFactorParamsVec*EV_ea(:,z_c); % auto-fill on a1
+
+                %Calc the max and its index
+                [Vtemp,maxindex]=max(entireRHS_ea_z,[],1);
+
+                V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,jj)=shiftdim(Vtemp,1);
+                Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,jj)=shiftdim(maxindex,1);
+            end
         end
     end
 end

--- a/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_nod1_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_nod1_raw.m
@@ -47,7 +47,7 @@ if ~isfield(vfoptions,'V_Jplus1')
             ea_val=a2_gridvals(ea_c);
             for z_c=1:N_z
                 z_val=z_gridvals_J(z_c,:,N_j);
-                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,special_n_ea, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,special_n_ea, special_n_z, d2_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
                 %Calc the max and its index
                 [Vtemp,maxindex]=max(ReturnMatrix_ea_z);
                 V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=Vtemp;
@@ -119,7 +119,7 @@ else
             ea_val=a2_gridvals(ea_c);
             for z_c=1:N_z
                 z_val=z_gridvals_J(z_c,:,N_j);
-                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0,n_d2,n_a1,n_a1,special_n_ea,special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0,n_d2,n_a1,n_a1,special_n_ea,special_n_z, d2_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
                 entireRHS_ea_z=ReturnMatrix_ea_z+DiscountFactorParamsVec*repelem(EV(:,ea_c,z_c),1,N_a1);
 
@@ -232,7 +232,7 @@ for reverse_j=1:N_j-1
             for z_c=1:N_z
                 z_val=z_gridvals_J(z_c,:,jj);
 
-                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0,n_d2, n_a1, n_a1,special_n_ea, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0,n_d2, n_a1, n_a1,special_n_ea, special_n_z, d2_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
                 entireRHS_ea_z=ReturnMatrix_ea_z+DiscountFactorParamsVec*EV_ea(:,z_c); % auto-fill on a1
 

--- a/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_nod1_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_nod1_raw.m
@@ -7,7 +7,7 @@ N_a=N_a1*N_a2;
 N_z=prod(n_z);
 
 V=zeros(N_a,N_z,N_j,'gpuArray');
-Policy=zeros(N_a,N_z,N_j,'gpuArray'); %first dim indexes the optimal choice for d and a1prime rest of dimensions a,z
+Policy=zeros(N_a,N_z,N_j,'gpuArray'); %first dim indexes the optimal choice for d2 and a1prime rest of dimensions a,z
 
 %%
 a2_gridvals=CreateGridvals(n_a2,a2_grid,1);
@@ -86,12 +86,12 @@ else
     EV=squeeze(sum(EV,4)); % sum over zprime, leaving current z
 
     % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
-    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1);
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,n_a2, n_z, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1);
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
 
         %Calc the max and it's index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -157,13 +157,13 @@ for reverse_j=1:N_j-1
         aprimeplus1Index=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat(a2primeIndex,N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]
         aprimeProbs=repmat(a2primeProbs,N_a1,1,1,N_z); % [N_d2*N_a1,N_a2,N_z]    (z dim already present, no repmat over z; but need to add zprime)
     
-        Vlower=reshape(V(aprimeIndex(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]); % (d*a1prime,a2,z,zprime)
+        Vlower=reshape(V(aprimeIndex(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]); % (d2*a1prime,a2,z,zprime)
         Vupper=reshape(V(aprimeplus1Index(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]);
         % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
         skipinterp=(Vlower==Vupper);
         aprimeProbs(skipinterp)=0; % effectively skips interpolation
     
-        % Switch EV from being in terms of a2prime to being in terms of d and a2
+        % Switch EV from being in terms of a2prime to being in terms of d2 and a2
         EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
         EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
         EV=EV_l+EV_u; % (d2*a1prime,a2,z,zprime)
@@ -177,7 +177,7 @@ for reverse_j=1:N_j-1
         % We will compute EV piece by piece
     end
 
-    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1);
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,n_a2, n_z, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,jj), ReturnFnParamsVec,0,0); % Level=0, Refine=0

--- a/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_raw.m
@@ -15,6 +15,9 @@ a2_gridvals=CreateGridvals(n_a2,a2_grid,1);
 
 if vfoptions.lowmemory==1
     special_n_z=ones(1,length(n_z));
+elseif vfoptions.lowmemory==3
+    special_n_z=ones(1,length(n_z));
+    special_n_ea=ones(1,length(n_a2));
 end
 
 %% j=N_j
@@ -38,6 +41,18 @@ if ~isfield(vfoptions,'V_Jplus1')
             V(:,z_c,N_j)=Vtemp;
             Policy(:,z_c,N_j)=maxindex;
         end
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,N_j);
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1, n_d2, n_a1, n_a1,special_n_ea, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+                %Calc the max and its index
+                [Vtemp,maxindex]=max(ReturnMatrix_ea_z);
+                V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=Vtemp;
+                Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=maxindex;
+            end
+        end
     end
 else
     DiscountFactorParamsVec=CreateVectorFromParams(Parameters, DiscountFactorParamNames,N_j);
@@ -60,7 +75,9 @@ else
     aprimeProbs(skipinterp)=0; % effectively skips interpolation
 
     % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-    EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2*a1prime,a2,z,zprime)
+    EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+    EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+    EV=EV_l+EV_u; % (d2*a1prime,a2,z,zprime)
     % Already applied the probabilities from interpolating onto grid
 
     EV=EV.*shiftdim(pi_z_J(:,:,N_j),-2); % pi shaped [1,1,z,zprime] -- no transpose since current z is dim 3
@@ -68,13 +85,14 @@ else
     EV=squeeze(sum(EV,4));
     % EV is over (d2*a1prime,a2,z)
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
+    % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2, n_a1, n_a1,n_a2,n_z, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), ReturnFnParamsVec,0,0); % Level=0, Refine=0
         % (d,a1prime,a)
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
 
         %Calc the max and its index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -85,11 +103,10 @@ else
     elseif vfoptions.lowmemory==1
         for z_c=1:N_z
             z_val=z_gridvals_J(z_c,:,N_j);
-            DiscountedEV_z=DiscountedEV(:,:,z_c);
 
             ReturnMatrix_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2, n_a1, n_a1,n_a2, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_z=ReturnMatrix_z+DiscountedEV_z;
+            entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*repelem(EV(:,:,z_c),N_d1,N_a1);
 
             %Calc the max and its index
             [Vtemp,maxindex]=max(entireRHS_z,[],1);
@@ -97,6 +114,22 @@ else
             Policy(:,z_c,N_j)=maxindex;
         end
 
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,N_j);
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2,n_a1,n_a1,special_n_ea,special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+
+                entireRHS_ea_z=ReturnMatrix_ea_z+DiscountFactorParamsVec*repelem(EV(:,ea_c,z_c),N_d1,N_a1);
+
+                % Calc the max and its index
+                [Vtemp,maxindex]=max(entireRHS_ea_z,[],1);
+
+                V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=shiftdim(Vtemp,1);
+                Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,N_j)=shiftdim(maxindex,1);
+            end
+        end
     end
 end
 
@@ -118,32 +151,39 @@ for reverse_j=1:N_j-1
     [a2primeIndex,a2primeProbs]=CreateExperienceAssetzFnMatrix(aprimeFn, n_d2, n_a2, n_z, d2_gridvals, a2_grid, z_gridvals_J(:,:,jj), aprimeFnParamsVec,2); % Note, is actually aprime_grid (but a_grid is anyway same for all ages)
     % Note: aprimeIndex is [N_d2,N_a2,N_z], whereas aprimeProbs is [N_d2,N_a2,N_z]   (N_z here is the current z)
 
-    aprimeIndex=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat(a2primeIndex-1,N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]
-    aprimeplus1Index=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat(a2primeIndex,N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]
-    aprimeProbs=repmat(a2primeProbs,N_a1,1,1,N_z); % [N_d2*N_a1,N_a2,N_z]    (z dim already present, no repmat over z; but need to add zprime)
 
-    Vlower=reshape(V(aprimeIndex(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]); % (d2*a1prime,a2,z,zprime)
-    Vupper=reshape(V(aprimeplus1Index(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]);
-    % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
-    skipinterp=(Vlower==Vupper);
-    aprimeProbs(skipinterp)=0; % effectively skips interpolation
+    if vfoptions.lowmemory<3
+        aprimeIndex=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat(a2primeIndex-1,N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]
+        aprimeplus1Index=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat(a2primeIndex,N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]
+        aprimeProbs=repmat(a2primeProbs,N_a1,1,1,N_z); % [N_d2*N_a1,N_a2,N_z]    (z dim already present, no repmat over z; but need to add zprime)
+    
+        Vlower=reshape(V(aprimeIndex(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]); % (d*a1prime,a2,z,zprime)
+        Vupper=reshape(V(aprimeplus1Index(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]);
+        % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
+        skipinterp=(Vlower==Vupper);
+        aprimeProbs(skipinterp)=0; % effectively skips interpolation
+    
+        % Switch EV from being in terms of a2prime to being in terms of d and a2
+        EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+        EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+        EV=EV_l+EV_u; % (d2*a1prime,a2,z,zprime)
+        % Already applied the probabilities from interpolating onto grid
+    
+        EV=EV.*shiftdim(pi_z_J(:,:,jj),-2); % pi shaped [1,1,z,zprime] -- no transpose since current z is dim 3
+        EV(isnan(EV))=0; % remove nan created where value fn is -Inf but probability is zero
+        EV=squeeze(sum(EV,4));
+        % EV is over (d2*a1prime,a2,z)
+    else
+        % We will compute EV piece by piece
+    end
 
-    % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-    EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2*a1prime,a2,z,zprime)
-    % Already applied the probabilities from interpolating onto grid
-
-    EV=EV.*shiftdim(pi_z_J(:,:,jj),-2); % pi shaped [1,1,z,zprime] -- no transpose since current z is dim 3
-    EV(isnan(EV))=0; % remove nan created where value fn is -Inf but probability is zero
-    EV=squeeze(sum(EV,4));
-    % EV is over (d2*a1prime,a2,z)
-
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,N_d1,N_a1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2, n_a1, n_a1,n_a2,n_z, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals,z_gridvals_J(:,:,jj), ReturnFnParamsVec,0,0); % Level=0, Refine=0
         % (d,aprime,a,z)
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
 
         %Calc the max and its index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -154,16 +194,54 @@ for reverse_j=1:N_j-1
     elseif vfoptions.lowmemory==1
         for z_c=1:N_z
             z_val=z_gridvals_J(z_c,:,jj);
-            DiscountedEV_z=DiscountedEV(:,:,z_c);
 
             ReturnMatrix_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2, n_a1, n_a1,n_a2, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_z=ReturnMatrix_z+DiscountedEV_z;
+            entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*repelem(EV(:,:,z_c),1,N_a1);
 
             %Calc the max and its index
             [Vtemp,maxindex]=max(entireRHS_z,[],1);
             V(:,z_c,jj)=Vtemp;
             Policy(:,z_c,jj)=maxindex;
+        end
+
+    elseif vfoptions.lowmemory==3
+        for ea_c=1:N_a2
+            aprimeIndex_ea=repelem((1:1:N_a1)',N_d2,N_z)+N_a1*repmat(squeeze(a2primeIndex(:,ea_c,:))-1,N_a1,1); % [N_d2*N_a1,N_z]
+            aprimeplus1Index_ea=repelem((1:1:N_a1)',N_d2,N_z)+N_a1*repmat(squeeze(a2primeIndex(:,ea_c,:)),N_a1,1); % [N_d2*N_a1,N_z]
+            aprimeProbs_ea=repmat(squeeze(a2primeProbs(:,ea_c,:)),N_a1,1,N_z); % [N_d2*N_a1,N_z]    (z dim already present, no repmat over z; but need to add zprime)
+
+            Vlower_ea=reshape(V(aprimeIndex_ea(:),:,jj+1),[N_d2*N_a1,N_z,N_z]); % (d*a1prime,z,zprime)
+            Vupper_ea=reshape(V(aprimeplus1Index_ea(:),:,jj+1),[N_d2*N_a1,N_z,N_z]);
+            % Skip interpolation when upper and lower are equal (otherwise can cause numerical rounding errors)
+            skipinterp_ea=(Vlower_ea==Vupper_ea);
+            aprimeProbs_ea(skipinterp_ea)=0; % effectively skips interpolation
+
+            % Switch EV from being in terms of a2prime to being in terms of d2 (and the present ea_c, from a2)
+            EV_ea_l=aprimeProbs_ea.*Vlower_ea; EV_ea_u=(1-aprimeProbs_ea).*Vupper_ea;
+            EV_ea_l(isnan(EV_ea_l))=0; EV_ea_u(isnan(EV_ea_u))=0;
+            EV_ea=EV_ea_l+EV_ea_u; % (d2*a1prime,a2,z,zprime)
+            % Already applied the probabilities from interpolating onto grid
+
+            EV_ea=EV_ea.*shiftdim(pi_z_J(:,:,jj),-1); % pi shaped [1,z,zprime] -- no transpose since current z is dim 3
+            EV_ea(isnan(EV_ea))=0; % remove nan created where value fn is -Inf but probability is zero
+            EV_ea=squeeze(sum(EV_ea,3));
+            % EV is over (d*a1prime,z)
+
+            ea_val=a2_gridvals(ea_c);
+            for z_c=1:N_z
+                z_val=z_gridvals_J(z_c,:,jj);
+
+                ReturnMatrix_ea_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, n_d1,n_d2, n_a1, n_a1,special_n_ea, special_n_z, d_gridvals, a1_gridvals, a1_gridvals, ea_val, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
+    
+                entireRHS_ea_z=ReturnMatrix_ea_z+DiscountFactorParamsVec*EV_ea(:,z_c); % auto-fill on a1
+    
+                %Calc the max and its index
+                [Vtemp,maxindex]=max(entireRHS_ea_z,[],1);
+
+                V(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,jj)=shiftdim(Vtemp,1);
+                Policy(1+(ea_c-1)*N_a1:ea_c*N_a1,z_c,jj)=shiftdim(maxindex,1);
+            end
         end
     end
 end

--- a/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_raw.m
@@ -15,6 +15,8 @@ a2_gridvals=CreateGridvals(n_a2,a2_grid,1);
 
 if vfoptions.lowmemory==1
     special_n_z=ones(1,length(n_z));
+elseif vfoptions.lowmemory==2
+    error("invalid vfoptions.lowmemory without e")
 elseif vfoptions.lowmemory==3
     special_n_z=ones(1,length(n_z));
     special_n_ea=ones(1,length(n_a2));
@@ -150,7 +152,6 @@ for reverse_j=1:N_j-1
     aprimeFnParamsVec=CreateVectorFromParams(Parameters, aprimeFnParamNames,jj);
     [a2primeIndex,a2primeProbs]=CreateExperienceAssetzFnMatrix(aprimeFn, n_d2, n_a2, n_z, d2_gridvals, a2_grid, z_gridvals_J(:,:,jj), aprimeFnParamsVec,2); % Note, is actually aprime_grid (but a_grid is anyway same for all ages)
     % Note: aprimeIndex is [N_d2,N_a2,N_z], whereas aprimeProbs is [N_d2,N_a2,N_z]   (N_z here is the current z)
-
 
     if vfoptions.lowmemory<3
         aprimeIndex=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat(a2primeIndex-1,N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]

--- a/ValueFnIter/FHorz/ExperienceAssetze/ValueFnIter_FHorz_ExpAssetze_nod1_e_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAssetze/ValueFnIter_FHorz_ExpAssetze_nod1_e_raw.m
@@ -13,10 +13,10 @@ Policy=zeros(N_a,N_z,N_e,N_j,'gpuArray'); %first dim indexes the optimal choice 
 %%
 a2_gridvals=CreateGridvals(n_a2,a2_grid,1);
 
-if vfoptions.lowmemory>=1
+if vfoptions.lowmemory==1
     special_n_e=ones(1,length(n_e));
-end
-if vfoptions.lowmemory==2
+elseif vfoptions.lowmemory==2
+    special_n_e=ones(1,length(n_e));
     special_n_z=ones(1,length(n_z));
 end
 
@@ -84,7 +84,9 @@ else
         aprimeProbs(skipinterp)=0; % effectively skips interpolation
 
         % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-        EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2*a1prime,a2,z_cur,e_cur,zprime)
+        EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+        EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+        EV=EV_l+EV_u; % (d2*a1prime,a2,z_cur,e_cur,zprime)
     else
         % l_a2==2: bilinear nested 2-corner interp with per-contribution NaN cleanup
         n_a2_1=n_a2(1);
@@ -124,13 +126,14 @@ else
     EV(isnan(EV))=0; % remove nan created where value fn is -Inf but probability is zero
     EV=reshape(sum(EV,5),[N_d2*N_a1,N_a2,N_z,N_e]); % sum zprime -> (d2*a1prime,a2,z_cur,e_cur)
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1,1);
+    % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1,1);
 
     if vfoptions.lowmemory==0
 
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, 0,n_d2,n_a1,n_a1,n_a2,n_z,n_e, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), e_gridvals_J(:,:,N_j), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1,1,1);
 
         %Calc the max and it's index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -144,7 +147,7 @@ else
             e_val=e_gridvals_J(e_c,:,N_j);
             ReturnMatrix_e=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, 0,n_d2,n_a1,n_a1,n_a2,n_z,special_n_e, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_e=ReturnMatrix_e+DiscountedEV(:,:,:,e_c);
+            entireRHS_e=ReturnMatrix_e+DiscountFactorParamsVec*repelem(EV(:,:,:,e_c),1,N_a1,1,1);
 
             %Calc the max and it's index
             [Vtemp,maxindex]=max(entireRHS_e,[],1);
@@ -157,10 +160,9 @@ else
             z_val=z_gridvals_J(z_c,:,N_j);
             for e_c=1:N_e
                 e_val=e_gridvals_J(e_c,:,N_j);
-                DiscountedEV_ze=DiscountedEV(:,:,z_c,e_c); % DiscountedEV is 4D [N_d2*N_a1, N_a2, N_z, N_e]
                 ReturnMatrix_ze=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, 0,n_d2,n_a1,n_a1,n_a2,special_n_z,special_n_e, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-                entireRHS_ze=ReturnMatrix_ze+DiscountedEV_ze;
+                entireRHS_ze=ReturnMatrix_ze+DiscountFactorParamsVec*repelem(EV(:,:,z_c,e_c),1,N_a1,1,1); % EV is 4D [N_d2*N_a1, N_a2, N_z, N_e]
 
                 %Calc the max and it's index
                 [Vtemp,maxindex]=max(entireRHS_ze,[],1);
@@ -204,7 +206,9 @@ for reverse_j=1:N_j-1
         aprimeProbs(skipinterp)=0; % effectively skips interpolation
 
         % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-        EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2*a1prime,a2,z_cur,e_cur,zprime)
+        EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+        EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+        EV=EV_l+EV_u; % (d2*a1prime,a2,z_cur,e_cur,zprime)
     else
         % l_a2==2: bilinear nested 2-corner interp with per-contribution NaN cleanup
         n_a2_1=n_a2(1);
@@ -244,12 +248,12 @@ for reverse_j=1:N_j-1
     EV(isnan(EV))=0; % remove nan created where value fn is -Inf but probability is zero
     EV=reshape(sum(EV,5),[N_d2*N_a1,N_a2,N_z,N_e]); % sum zprime -> (d2*a1prime,a2,z_cur,e_cur)
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1,1);
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1,1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, 0,n_d2,n_a1,n_a1,n_a2,n_z,n_e, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,jj), e_gridvals_J(:,:,jj), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1,1,1);
 
         %Calc the max and it's index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -263,7 +267,7 @@ for reverse_j=1:N_j-1
             e_val=e_gridvals_J(e_c,:,jj);
             ReturnMatrix_e=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, 0,n_d2,n_a1,n_a1,n_a2,n_z,special_n_e, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,jj), e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_e=ReturnMatrix_e+DiscountedEV(:,:,:,e_c);
+            entireRHS_e=ReturnMatrix_e+DiscountFactorParamsVec*repelem(EV(:,:,:,e_c),1,N_a1,1,1);
 
             %Calc the max and it's index
             [Vtemp,maxindex]=max(entireRHS_e,[],1);
@@ -276,10 +280,9 @@ for reverse_j=1:N_j-1
             z_val=z_gridvals_J(z_c,:,jj);
             for e_c=1:N_e
                 e_val=e_gridvals_J(e_c,:,jj);
-                DiscountedEV_ze=DiscountedEV(:,:,z_c,e_c); % DiscountedEV is 4D [N_d2*N_a1, N_a2, N_z, N_e]
                 ReturnMatrix_ze=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, 0,n_d2,n_a1,n_a1,n_a2,special_n_z,special_n_e, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-                entireRHS_ze=ReturnMatrix_ze+DiscountedEV_ze;
+                entireRHS_ze=ReturnMatrix_ze+DiscountFactorParamsVec*repelem(EV(:,:,z_c,e_c),1,N_a1,1,1); % EV is 4D [N_d2*N_a1, N_a2, N_z, N_e]
 
                 %Calc the max and it's index
                 [Vtemp,maxindex]=max(entireRHS_ze,[],1);

--- a/ValueFnIter/FHorz/ValueFnIter_FHorz_raw.m
+++ b/ValueFnIter/FHorz/ValueFnIter_FHorz_raw.m
@@ -103,14 +103,15 @@ for reverse_j=1:N_j-1
     EV(isnan(EV))=0; %multiplications of -Inf with 0 gives NaN, this replaces them with zeros (as the zeros come from the transition probabilities)
     EV=sum(EV,2); % sum over z', leaving a singular second dimension
 
-    entireEV=repelem(EV,N_d,1,1);
+    % Doing the replication here defeats our lowmemory optimizations
+    % entireEV=repelem(EV,N_d,1,1);
 
     if vfoptions.lowmemory==0
 
         ReturnMatrix=CreateReturnFnMatrix_Disc(ReturnFn, n_d, n_a, n_z, d_gridvals, a_grid, z_gridvals_J(:,:,jj), ReturnFnParamsVec,0);
         % (d,aprime,a,z)
 
-        entireRHS=ReturnMatrix+DiscountFactorParamsVec*entireEV; % autofill a for EV
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,N_d,1,1); % autofill a for EV
 
         % Calc the max and it's index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -122,12 +123,11 @@ for reverse_j=1:N_j-1
 
         for z_c=1:N_z
             z_val=z_gridvals_J(z_c,:,jj);
-            entireEV_z=entireEV(:,:,z_c);
 
             ReturnMatrix_z=CreateReturnFnMatrix_Disc(ReturnFn, n_d, n_a, special_n_z, d_gridvals, a_grid, z_val, ReturnFnParamsVec,0);
             % (d,aprime,a)
 
-            entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*entireEV_z; % autofill a for EV
+            entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*repelem(EV(:,:,z_c),N_d,1,1); % autofill a for EV
 
             % Calc the max and it's index
             [Vtemp,maxindex]=max(entireRHS_z,[],1);


### PR DESCRIPTION
These changes both restore the lowmemory==3 functions to iterate across an experienceasset.  They also allow lowmemory to trim the size of `DiscountedEV` in cases 2 and 3.

It would be nice if Claude could study this and apply it to the myriad ExpAsset codes that are now available.