### PR TITLE
Improve lowmemory==1 behavior

### DIFF
--- a/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_nod1_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_nod1_raw.m
@@ -7,7 +7,7 @@ N_a=N_a1*N_a2;
 N_z=prod(n_z);
 
 V=zeros(N_a,N_z,N_j,'gpuArray');
-Policy=zeros(N_a,N_z,N_j,'gpuArray'); %first dim indexes the optimal choice for d and a1prime rest of dimensions a,z
+Policy=zeros(N_a,N_z,N_j,'gpuArray'); %first dim indexes the optimal choice for d2 and a1prime rest of dimensions a,z
 
 %%
 a2_gridvals=CreateGridvals(n_a2,a2_grid,1);
@@ -71,12 +71,12 @@ else
     EV=squeeze(sum(EV,4)); % sum over zprime, leaving current z
 
     % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
-    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1);
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,n_a2, n_z, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1);
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
 
         %Calc the max and it's index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -130,7 +130,7 @@ for reverse_j=1:N_j-1
     skipinterp=(Vlower==Vupper);
     aprimeProbs(skipinterp)=0; % effectively skips interpolation
 
-    % Switch EV from being in terms of a2prime to being in terms of d and a2
+    % Switch EV from being in terms of a2prime to being in terms of d2 and a2
     EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
     EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
     EV=EV_l+EV_u; % (d2*a1prime,a2,z,zprime)

--- a/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_nod1_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAssetz/ValueFnIter_FHorz_ExpAssetz_nod1_raw.m
@@ -12,8 +12,10 @@ Policy=zeros(N_a,N_z,N_j,'gpuArray'); %first dim indexes the optimal choice for 
 %%
 a2_gridvals=CreateGridvals(n_a2,a2_grid,1);
 
-if vfoptions.lowmemory>0
+if vfoptions.lowmemory==1
     special_n_z=ones(1,length(n_z));
+elseif vfoptions.lowmemory==2
+    error("invalid vfoptions.lowmemory without e")
 end
 
 %% j=N_j
@@ -59,19 +61,22 @@ else
     aprimeProbs(skipinterp)=0; % effectively skips interpolation
 
     % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-    EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2*a1prime,a2,z,zprime)
+    EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+    EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+    EV=EV_l+EV_u; % (d2*a1prime,a2,z,zprime)
     % Already applied the probabilities from interpolating onto grid
 
     EV=EV.*shiftdim(pi_z_J(:,:,N_j),-2); % pi shaped [1,1,z,zprime] -- no transpose since current z is dim 3
     EV(isnan(EV))=0; %multiplications of -Inf with 0 gives NaN, this replaces them with zeros (as the zeros come from the transition probabilities)
     EV=squeeze(sum(EV,4)); % sum over zprime, leaving current z
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
+    % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,n_a2, n_z, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1);
 
         %Calc the max and it's index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -83,11 +88,10 @@ else
 
         for z_c=1:N_z
             z_val=z_gridvals_J(z_c,:,N_j);
-            DiscountedEV_z=DiscountedEV(:,:,z_c);
 
             ReturnMatrix_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,n_a2, special_n_z, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_z=ReturnMatrix_z+DiscountedEV_z;
+            entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*repelem(EV(:,:,z_c),1,N_a1);
 
             %Calc the max and it's index
             [Vtemp,maxindex]=max(entireRHS_z,[],1);
@@ -116,9 +120,9 @@ for reverse_j=1:N_j-1
     [a2primeIndex,a2primeProbs]=CreateExperienceAssetzFnMatrix(aprimeFn, n_d2, n_a2, n_z, d2_gridvals, a2_grid, z_gridvals_J(:,:,jj), aprimeFnParamsVec,2); % Note, is actually aprime_grid (but a_grid is anyway same for all ages)
     % Note: aprimeIndex is [N_d2,N_a2,N_z], whereas aprimeProbs is [N_d2,N_a2,N_z]   (N_z here is the current z)
 
-    aprimeIndex=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat((a2primeIndex-1),N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]
+    aprimeIndex=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat(a2primeIndex-1,N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]
     aprimeplus1Index=repelem((1:1:N_a1)',N_d2,N_a2,N_z)+N_a1*repmat(a2primeIndex,N_a1,1,1); % [N_d2*N_a1,N_a2,N_z]
-    aprimeProbs=repmat(a2primeProbs,N_a1,1,1,N_z);  % [N_d2*N_a1,N_a2,N_z]    (z dim already present, no repmat over z; but need to add zprime)
+    aprimeProbs=repmat(a2primeProbs,N_a1,1,1,N_z); % [N_d2*N_a1,N_a2,N_z]    (z dim already present, no repmat over z; but need to add zprime)
 
     Vlower=reshape(V(aprimeIndex(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]); % (d2*a1prime,a2,z,zprime)
     Vupper=reshape(V(aprimeplus1Index(:),:,jj+1),[N_d2*N_a1,N_a2,N_z,N_z]);
@@ -126,20 +130,23 @@ for reverse_j=1:N_j-1
     skipinterp=(Vlower==Vupper);
     aprimeProbs(skipinterp)=0; % effectively skips interpolation
 
-    % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-    EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2*a1prime,a2,z,zprime)
+    % Switch EV from being in terms of a2prime to being in terms of d and a2
+    EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+    EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+    EV=EV_l+EV_u; % (d2*a1prime,a2,z,zprime)
     % Already applied the probabilities from interpolating onto grid
 
     EV=EV.*shiftdim(pi_z_J(:,:,jj),-2); % pi shaped [1,1,z,zprime] -- no transpose since current z is dim 3
     EV(isnan(EV))=0; %multiplications of -Inf with 0 gives NaN, this replaces them with zeros (as the zeros come from the transition probabilities)
     EV=squeeze(sum(EV,4)); % sum over zprime, leaving current z
+    % EV is over (d2*a1prime,a2,z)
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,n_a2, n_z, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,jj), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1,1);
 
         %Calc the max and it's index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -151,11 +158,10 @@ for reverse_j=1:N_j-1
 
         for z_c=1:N_z
             z_val=z_gridvals_J(z_c,:,jj);
-            DiscountedEV_z=DiscountedEV(:,:,z_c);
 
             ReturnMatrix_z=CreateReturnFnMatrix_ExpAsset_Disc(ReturnFn, 0, n_d2, n_a1, n_a1,n_a2, special_n_z, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_z=ReturnMatrix_z+DiscountedEV_z;
+            entireRHS_z=ReturnMatrix_z+DiscountFactorParamsVec*repelem(EV(:,:,z_c),1,N_a1);
 
             %Calc the max and it's index
             [Vtemp,maxindex]=max(entireRHS_z,[],1);

--- a/ValueFnIter/FHorz/ExperienceAssetze/ValueFnIter_FHorz_ExpAssetze_nod1_e_raw.m
+++ b/ValueFnIter/FHorz/ExperienceAssetze/ValueFnIter_FHorz_ExpAssetze_nod1_e_raw.m
@@ -13,10 +13,10 @@ Policy=zeros(N_a,N_z,N_e,N_j,'gpuArray'); %first dim indexes the optimal choice 
 %%
 a2_gridvals=CreateGridvals(n_a2,a2_grid,1);
 
-if vfoptions.lowmemory>=1
+if vfoptions.lowmemory==1
     special_n_e=ones(1,length(n_e));
-end
-if vfoptions.lowmemory==2
+elseif vfoptions.lowmemory==2
+    special_n_e=ones(1,length(n_e));
     special_n_z=ones(1,length(n_z));
 end
 
@@ -84,7 +84,9 @@ else
         aprimeProbs(skipinterp)=0; % effectively skips interpolation
 
         % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-        EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2*a1prime,a2,z_cur,e_cur,zprime)
+        EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+        EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+        EV=EV_l+EV_u; % (d2*a1prime,a2,z_cur,e_cur,zprime)
     else
         % l_a2==2: bilinear nested 2-corner interp with per-contribution NaN cleanup
         n_a2_1=n_a2(1);
@@ -124,13 +126,14 @@ else
     EV(isnan(EV))=0; % remove nan created where value fn is -Inf but probability is zero
     EV=reshape(sum(EV,5),[N_d2*N_a1,N_a2,N_z,N_e]); % sum zprime -> (d2*a1prime,a2,z_cur,e_cur)
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1,1);
+    % This creates a large matrix that defeats the lowmemory ideas, so build case-by-case
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1,1);
 
     if vfoptions.lowmemory==0
 
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, 0,n_d2,n_a1,n_a1,n_a2,n_z,n_e, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), e_gridvals_J(:,:,N_j), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1,1,1);
 
         %Calc the max and it's index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -144,7 +147,7 @@ else
             e_val=e_gridvals_J(e_c,:,N_j);
             ReturnMatrix_e=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, 0,n_d2,n_a1,n_a1,n_a2,n_z,special_n_e, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,N_j), e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_e=ReturnMatrix_e+DiscountedEV(:,:,:,e_c);
+            entireRHS_e=ReturnMatrix_e+DiscountFactorParamsVec*repelem(EV(:,:,:,e_c),1,N_a1,1,1);
 
             %Calc the max and it's index
             [Vtemp,maxindex]=max(entireRHS_e,[],1);
@@ -157,10 +160,9 @@ else
             z_val=z_gridvals_J(z_c,:,N_j);
             for e_c=1:N_e
                 e_val=e_gridvals_J(e_c,:,N_j);
-                DiscountedEV_ze=DiscountedEV(:,:,z_c,e_c); % DiscountedEV is 4D [N_d2*N_a1, N_a2, N_z, N_e]
                 ReturnMatrix_ze=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, 0,n_d2,n_a1,n_a1,n_a2,special_n_z,special_n_e, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-                entireRHS_ze=ReturnMatrix_ze+DiscountedEV_ze;
+                entireRHS_ze=ReturnMatrix_ze+DiscountFactorParamsVec*repelem(EV(:,:,z_c,e_c),1,N_a1,1,1); % EV is 4D [N_d2*N_a1, N_a2, N_z, N_e]
 
                 %Calc the max and it's index
                 [Vtemp,maxindex]=max(entireRHS_ze,[],1);
@@ -204,7 +206,9 @@ for reverse_j=1:N_j-1
         aprimeProbs(skipinterp)=0; % effectively skips interpolation
 
         % Switch EV from being in terms of a2prime to being in terms of d2 and a2
-        EV=aprimeProbs.*Vlower+(1-aprimeProbs).*Vupper; % (d2*a1prime,a2,z_cur,e_cur,zprime)
+        EV_l=aprimeProbs.*Vlower; EV_u=(1-aprimeProbs).*Vupper;
+        EV_l(isnan(EV_l))=0; EV_u(isnan(EV_u))=0;
+        EV=EV_l+EV_u; % (d2*a1prime,a2,z_cur,e_cur,zprime)
     else
         % l_a2==2: bilinear nested 2-corner interp with per-contribution NaN cleanup
         n_a2_1=n_a2(1);
@@ -244,12 +248,12 @@ for reverse_j=1:N_j-1
     EV(isnan(EV))=0; % remove nan created where value fn is -Inf but probability is zero
     EV=reshape(sum(EV,5),[N_d2*N_a1,N_a2,N_z,N_e]); % sum zprime -> (d2*a1prime,a2,z_cur,e_cur)
 
-    DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1,1);
+    % DiscountedEV=DiscountFactorParamsVec*repelem(EV,1,N_a1,1,1);
 
     if vfoptions.lowmemory==0
         ReturnMatrix=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, 0,n_d2,n_a1,n_a1,n_a2,n_z,n_e, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,jj), e_gridvals_J(:,:,jj), ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-        entireRHS=ReturnMatrix+DiscountedEV;
+        entireRHS=ReturnMatrix+DiscountFactorParamsVec*repelem(EV,1,N_a1,1,1);
 
         %Calc the max and it's index
         [Vtemp,maxindex]=max(entireRHS,[],1);
@@ -263,7 +267,7 @@ for reverse_j=1:N_j-1
             e_val=e_gridvals_J(e_c,:,jj);
             ReturnMatrix_e=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, 0,n_d2,n_a1,n_a1,n_a2,n_z,special_n_e, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_gridvals_J(:,:,jj), e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-            entireRHS_e=ReturnMatrix_e+DiscountedEV(:,:,:,e_c);
+            entireRHS_e=ReturnMatrix_e+DiscountFactorParamsVec*repelem(EV(:,:,:,e_c),1,N_a1,1,1);
 
             %Calc the max and it's index
             [Vtemp,maxindex]=max(entireRHS_e,[],1);
@@ -276,10 +280,9 @@ for reverse_j=1:N_j-1
             z_val=z_gridvals_J(z_c,:,jj);
             for e_c=1:N_e
                 e_val=e_gridvals_J(e_c,:,jj);
-                DiscountedEV_ze=DiscountedEV(:,:,z_c,e_c); % DiscountedEV is 4D [N_d2*N_a1, N_a2, N_z, N_e]
                 ReturnMatrix_ze=CreateReturnFnMatrix_ExpAsset_Disc_e(ReturnFn, 0,n_d2,n_a1,n_a1,n_a2,special_n_z,special_n_e, d2_gridvals, a1_gridvals, a1_gridvals, a2_gridvals, z_val, e_val, ReturnFnParamsVec,0,0); % Level=0, Refine=0
 
-                entireRHS_ze=ReturnMatrix_ze+DiscountedEV_ze;
+                entireRHS_ze=ReturnMatrix_ze+DiscountFactorParamsVec*repelem(EV(:,:,z_c,e_c),1,N_a1,1,1); % EV is 4D [N_d2*N_a1, N_a2, N_z, N_e]
 
                 %Calc the max and it's index
                 [Vtemp,maxindex]=max(entireRHS_ze,[],1);


### PR DESCRIPTION
These changes both fix the NaN problem with Vupper/Vlower, but also avoid overexpanding `EV` when `lowmemory==1`.

This pattern could be applied widely (and also with `lowmemory==2`), which also creates a full `EV` when we only use 1/z-th of that during the `z_c` iteration.  Note that in the `lowmemory==2` case we can lift the calculation of `EV_z` out of the `e_c` loop and just compute it once per `z_c` cycle.

I added the `lowmemory==2` error check because I am constantly getting burned by switching back and forth between models that do or don't enable `e` and I've wasted a lot of time chasing strange results that arise from the value function iteration silently returning garbage when passed a lowmemory value it chooses to ignore.