### PR TITLE
Degauss nprobs

### DIFF
--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
@@ -12,7 +12,7 @@ PolicyProbs=gather(PolicyProbs);
 StationaryDist=zeros(N_a,N_j,'gpuArray');
 StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(gather(jequaloneDistKron)); % sparse() creates a matrix of zeros
-epsilon=5e-4; % A suitably small value
+epsilon=1e-4; % A suitably small value; SD probabilities sum to 1
 
 % Precompute
 II2=repmat((1:1:N_a)',1,N_probs); % Note the N_probs-copies
@@ -27,7 +27,7 @@ for jj=1:(N_j-1)
     % Clean up Gaussian diffusion from Gamma step
     nnz_gamma=nnz(StationaryDist_jj);
     if nnz_gamma>6
-        [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj), nnz_gamma-6);
+        [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj), nnz_gamma-4);
         e_idx=e_idx(epsilons<epsilon);
         epsilons=epsilons(epsilons<epsilon);
         if nnz(epsilons)>0
@@ -36,9 +36,12 @@ for jj=1:(N_j-1)
             StationaryDist_jj(nonzero_idx(e_idx))=0;
             keep_nonzero=true(size(nonzero_idx));
             keep_nonzero(e_idx)=false;
-            % redistribute values zeroed out equally among remaining nonzero terms
-            % QUESTION: should we redistribute pro-rata instead of equally?
-            StationaryDist_jj(nonzero_idx(keep_nonzero))=StationaryDist_jj(nonzero_idx(keep_nonzero))+sum(epsilons)/(nnz_gamma-length(epsilons));
+            % Redistribute values zeroed out equally among remaining nonzero terms
+            % By subtracting the largest zeroed epsilon, we return some
+            % weight from the edges to the center of the distribution
+            % By multiplying by epsilon, we limit drift in our normalized averages
+            newdist_jj=StationaryDist_jj(nonzero_idx(keep_nonzero))-epsilons(end);
+            StationaryDist_jj(nonzero_idx(keep_nonzero))=epsilon*newdist_jj./sum(newdist_jj);
         end
     end
     StationaryDist(:,jj+1)=gather(full(StationaryDist_jj));

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
@@ -12,6 +12,7 @@ PolicyProbs=gather(PolicyProbs);
 StationaryDist=zeros(N_a,N_j,'gpuArray');
 StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(gather(jequaloneDistKron)); % sparse() creates a matrix of zeros
+epsilon=5e-4; % A suitably small value
 
 % Precompute
 II2=repmat((1:1:N_a)',1,N_probs); % Note the N_probs-copies
@@ -25,10 +26,10 @@ for jj=1:(N_j-1)
 
     % Clean up Gaussian diffusion from Gamma step
     nnz_gamma=nnz(StationaryDist_jj);
-    if nnz_gamma>4
-        [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj), nnz_gamma-4);
-        e_idx=e_idx(epsilons<2e-4);
-        epsilons=epsilons(epsilons<2e-4);
+    if nnz_gamma>6
+        [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj), nnz_gamma-6);
+        e_idx=e_idx(epsilons<epsilon);
+        epsilons=epsilons(epsilons<epsilon);
         if nnz(epsilons)>0
             nonzero_idx=find(StationaryDist_jj);
             % zero out likely error artifacts

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
@@ -12,7 +12,7 @@ PolicyProbs=gather(PolicyProbs);
 StationaryDist=zeros(N_a,N_j,'gpuArray');
 StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(gather(jequaloneDistKron)); % sparse() creates a matrix of zeros
-epsilon=1e-4; % A suitably small value; SD probabilities sum to 1
+epsilon=2e-5; % A suitably small value; SD probabilities sum to 1
 
 % Precompute
 II2=repmat((1:1:N_a)',1,N_probs); % Note the N_probs-copies
@@ -26,23 +26,26 @@ for jj=1:(N_j-1)
 
     % Clean up Gaussian diffusion from Gamma step
     nnz_gamma=nnz(StationaryDist_jj);
-    if nnz_gamma>6
+    while nnz_gamma>8
         [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj), nnz_gamma-4);
         e_idx=e_idx(epsilons<epsilon);
         epsilons=epsilons(epsilons<epsilon);
-        if nnz(epsilons)>0
-            nonzero_idx=find(StationaryDist_jj);
-            % zero out likely error artifacts
-            StationaryDist_jj(nonzero_idx(e_idx))=0;
-            keep_nonzero=true(size(nonzero_idx));
-            keep_nonzero(e_idx)=false;
-            % Redistribute values zeroed out equally among remaining nonzero terms
-            % By subtracting the largest zeroed epsilon, we return some
-            % weight from the edges to the center of the distribution
-            % By multiplying by epsilon, we limit drift in our normalized averages
-            newdist_jj=StationaryDist_jj(nonzero_idx(keep_nonzero))-epsilons(end);
-            StationaryDist_jj(nonzero_idx(keep_nonzero))=epsilon*newdist_jj./sum(newdist_jj);
+        if nnz(epsilons)==0
+            break
         end
+        nonzero_idx=find(StationaryDist_jj);
+        % zero out likely error artifacts
+        StationaryDist_jj(nonzero_idx(e_idx))=0;
+        keep_nonzero=true(size(nonzero_idx));
+        keep_nonzero(e_idx)=false;
+        % Redistribute values zeroed out equally among remaining nonzero terms
+        % By subtracting the largest zeroed epsilon, we return some
+        % weight from the edges to the center of the distribution
+        newdist_jj=StationaryDist_jj(nonzero_idx(keep_nonzero))-epsilons(end);
+        StationaryDist_jj(nonzero_idx(keep_nonzero))=epsilon*newdist_jj./sum(newdist_jj);
+        % Slicing out the epsilons and reallocating their probs may
+        % expose other marginal probs that can be trimmed
+        nnz_gamma=sum(StationaryDist_jj~=0,1);
     end
     StationaryDist(:,jj+1)=gather(full(StationaryDist_jj));
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
@@ -23,6 +23,23 @@ for jj=1:(N_j-1)
     % No z, so just a single step
     StationaryDist_jj=Gammatranspose*StationaryDist_jj;
 
+    % Clean up Gaussian diffusion from Gamma step
+    nnz_gamma=nnz(StationaryDist_jj);
+    if nnz_gamma>4
+        [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj), nnz_gamma-4);
+        e_idx=e_idx(epsilons<2e-4);
+        epsilons=epsilons(epsilons<2e-4);
+        if nnz(epsilons)>0
+            nonzero_idx=find(StationaryDist_jj);
+            % zero out likely error artifacts
+            StationaryDist_jj(nonzero_idx(e_idx))=0;
+            keep_nonzero=true(size(nonzero_idx));
+            keep_nonzero(e_idx)=false;
+            % redistribute values zeroed out equally among remaining nonzero terms
+            % QUESTION: should we redistribute pro-rata instead of equally?
+            StationaryDist_jj(nonzero_idx(keep_nonzero))=StationaryDist_jj(nonzero_idx(keep_nonzero))+sum(epsilons)/(nnz_gamma-length(epsilons));
+        end
+    end
     StationaryDist(:,jj+1)=gather(full(StationaryDist_jj));
 end
 

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -25,6 +25,26 @@ for jj=1:(N_j-1)
     % First step of Tan improvement
     StationaryDist_jj=reshape(Gammatranspose*StationaryDist_jj,[N_a,N_z]);
 
+    % Clean up Gaussian diffusion from Gamma step
+    nnz_gamma=sum(StationaryDist_jj~=0,1);
+    for z_c=1:length(nnz_gamma)
+        if nnz_gamma(z_c)>4
+            [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj(:,z_c)), nnz_gamma(z_c)-4);
+            e_idx=e_idx(epsilons<2e-4);
+            epsilons=epsilons(epsilons<2e-4);
+            if nnz(epsilons)>0
+                nonzero_idx=find(StationaryDist_jj(:,z_c));
+                % zero out likely error artifacts
+                StationaryDist_jj(nonzero_idx(e_idx),z_c)=0;
+                keep_nonzero=true(size(nonzero_idx));
+                keep_nonzero(e_idx)=false;
+                % redistribute values zeroed out equally among remaining nonzero terms
+                % QUESTION: should we redistribute pro-rata instead of equally?
+                StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)=StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)+sum(epsilons)/(nnz_gamma(z_c)-length(epsilons));
+            end
+        end
+    end
+
     % Second step of Tan improvement
     pi_z=sparse(gather(pi_z_J(:,:,jj)));
     StationaryDist_jj=reshape(StationaryDist_jj*pi_z,[N_a*N_z,1]);

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -13,7 +13,7 @@ PolicyProbs=gather(reshape(PolicyProbs,[N_a*N_z,N_probs,N_j])); % sparse() requi
 StationaryDist=zeros(N_a*N_z,N_j,'gpuArray');
 StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(gather(jequaloneDistKron)); % use sparse matrix
-epsilon=1e-4;  % A suitably small value...that may be scaled by the probability sum of each z slice
+epsilon=2e-5;  % A suitably small value...that may be scaled by the probability sum of each z slice
 
 % Precompute
 II2=repmat((1:1:N_a*N_z)',1,N_probs); %  Index for this period (a,z), note the N_probs-copies
@@ -28,23 +28,27 @@ for jj=1:(N_j-1)
     % Clean up Gaussian diffusion from Gamma step
     nnz_gamma=full(sum(StationaryDist_jj~=0,1));
     for z_c=1:length(nnz_gamma)
-        if nnz_gamma(z_c)>8
+        while nnz_gamma(z_c)>8
             epsilon_z=sum(StationaryDist_jj(:,z_c),1); % The sum of the z probs evolve as pi_z moves things around
             [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj(:,z_c)), nnz_gamma(z_c)-4);
             e_idx=e_idx(epsilons<epsilon*epsilon_z);
             epsilons=epsilons(epsilons<epsilon*epsilon_z);
-            if nnz(epsilons)>0
-                nonzero_idx=find(StationaryDist_jj(:,z_c));
-                % zero out likely error artifacts
-                StationaryDist_jj(nonzero_idx(e_idx),z_c)=0;
-                keep_nonzero=true(size(nonzero_idx));
-                keep_nonzero(e_idx)=false;
-                % Redistribute values zeroed out equally among remaining nonzero terms
-                % By subtracting the largest zeroed epsilon, we return some
-                % weight from the edges to the center of the distribution
-                newdist_jj=StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)-epsilons(end);
-                StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)=epsilon_z*newdist_jj./sum(newdist_jj);
+            if nnz(epsilons)==0
+                break
             end
+            nonzero_idx=find(StationaryDist_jj(:,z_c));
+            % zero out likely error artifacts
+            StationaryDist_jj(nonzero_idx(e_idx),z_c)=0;
+            keep_nonzero=true(size(nonzero_idx));
+            keep_nonzero(e_idx)=false;
+            % Redistribute values zeroed out equally among remaining nonzero terms
+            % By subtracting the largest zeroed epsilon, we return some
+            % weight from the edges to the center of the distribution
+            newdist_jj=StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)-epsilons(end);
+            StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)=epsilon_z*newdist_jj./sum(newdist_jj);
+            % Slicing out the epsilons and reallocating their probs may
+            % expose other marginal probs that can be trimmed
+            nnz_gamma(z_c)=sum(StationaryDist_jj(:,z_c)~=0,1);
         end
     end
 

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -13,6 +13,7 @@ PolicyProbs=gather(reshape(PolicyProbs,[N_a*N_z,N_probs,N_j])); % sparse() requi
 StationaryDist=zeros(N_a*N_z,N_j,'gpuArray');
 StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(gather(jequaloneDistKron)); % use sparse matrix
+epsilon_z=1e-3*full(sum(reshape(StationaryDist_jj,[N_a,N_z]),1)); % A suitably small value, scaled by the probability sum of this z slice
 
 % Precompute
 II2=repmat((1:1:N_a*N_z)',1,N_probs); %  Index for this period (a,z), note the N_probs-copies
@@ -28,10 +29,10 @@ for jj=1:(N_j-1)
     % Clean up Gaussian diffusion from Gamma step
     nnz_gamma=sum(StationaryDist_jj~=0,1);
     for z_c=1:length(nnz_gamma)
-        if nnz_gamma(z_c)>4
-            [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj(:,z_c)), nnz_gamma(z_c)-4);
-            e_idx=e_idx(epsilons<2e-4);
-            epsilons=epsilons(epsilons<2e-4);
+        if nnz_gamma(z_c)>6
+            [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj(:,z_c)), nnz_gamma(z_c)-6);
+            e_idx=e_idx(epsilons<epsilon_z(z_c));
+            epsilons=epsilons(epsilons<epsilon_z(z_c));
             if nnz(epsilons)>0
                 nonzero_idx=find(StationaryDist_jj(:,z_c));
                 % zero out likely error artifacts

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -13,7 +13,8 @@ PolicyProbs=gather(reshape(PolicyProbs,[N_a*N_z,N_probs,N_j])); % sparse() requi
 StationaryDist=zeros(N_a*N_z,N_j,'gpuArray');
 StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(gather(jequaloneDistKron)); % use sparse matrix
-epsilon_z=1e-3*full(sum(reshape(StationaryDist_jj,[N_a,N_z]),1)); % A suitably small value, scaled by the probability sum of this z slice
+epsilon=1e-4;  % A suitably small value...
+epsilon_z=full(sum(reshape(StationaryDist_jj,[N_a,N_z]),1)); % ...that may be scaled by the probability sum of this z slice
 
 % Precompute
 II2=repmat((1:1:N_a*N_z)',1,N_probs); %  Index for this period (a,z), note the N_probs-copies
@@ -30,18 +31,21 @@ for jj=1:(N_j-1)
     nnz_gamma=sum(StationaryDist_jj~=0,1);
     for z_c=1:length(nnz_gamma)
         if nnz_gamma(z_c)>6
-            [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj(:,z_c)), nnz_gamma(z_c)-6);
-            e_idx=e_idx(epsilons<epsilon_z(z_c));
-            epsilons=epsilons(epsilons<epsilon_z(z_c));
+            [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj(:,z_c)), nnz_gamma(z_c)-4);
+            e_idx=e_idx(epsilons<epsilon*epsilon_z(z_c));
+            epsilons=epsilons(epsilons<epsilon*epsilon_z(z_c));
             if nnz(epsilons)>0
                 nonzero_idx=find(StationaryDist_jj(:,z_c));
                 % zero out likely error artifacts
                 StationaryDist_jj(nonzero_idx(e_idx),z_c)=0;
                 keep_nonzero=true(size(nonzero_idx));
                 keep_nonzero(e_idx)=false;
-                % redistribute values zeroed out equally among remaining nonzero terms
-                % QUESTION: should we redistribute pro-rata instead of equally?
-                StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)=StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)+sum(epsilons)/(nnz_gamma(z_c)-length(epsilons));
+                % Redistribute values zeroed out equally among remaining nonzero terms
+                % By subtracting the largest zeroed epsilon, we return some
+                % weight from the edges to the center of the distribution
+                % By multiplying by epsilon_z(z_c), we limit drift in our normalized averages
+                newdist_jj=StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)-epsilons(end);
+                StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)=epsilon_z(z_c)*newdist_jj./sum(newdist_jj);
             end
         end
     end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -19,6 +19,7 @@ epsilon=2e-5;  % A suitably small value...that may be scaled by the probability 
 II2=repmat((1:1:N_a*N_z)',1,N_probs); %  Index for this period (a,z), note the N_probs-copies
 
 for jj=1:(N_j-1)
+
     % First, get Gamma
     Gammatranspose=sparse(Policy_aprimez(:,:,jj),II2,PolicyProbs(:,:,jj),N_a*N_z,N_a*N_z); % Note: sparse() will accumulate at repeated indices
 

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -13,14 +13,12 @@ PolicyProbs=gather(reshape(PolicyProbs,[N_a*N_z,N_probs,N_j])); % sparse() requi
 StationaryDist=zeros(N_a*N_z,N_j,'gpuArray');
 StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(gather(jequaloneDistKron)); % use sparse matrix
-epsilon=1e-4;  % A suitably small value...
-epsilon_z=full(sum(reshape(StationaryDist_jj,[N_a,N_z]),1)); % ...that may be scaled by the probability sum of this z slice
+epsilon=1e-4;  % A suitably small value...that may be scaled by the probability sum of each z slice
 
 % Precompute
 II2=repmat((1:1:N_a*N_z)',1,N_probs); %  Index for this period (a,z), note the N_probs-copies
 
 for jj=1:(N_j-1)
-
     % First, get Gamma
     Gammatranspose=sparse(Policy_aprimez(:,:,jj),II2,PolicyProbs(:,:,jj),N_a*N_z,N_a*N_z); % Note: sparse() will accumulate at repeated indices
 
@@ -28,12 +26,13 @@ for jj=1:(N_j-1)
     StationaryDist_jj=reshape(Gammatranspose*StationaryDist_jj,[N_a,N_z]);
 
     % Clean up Gaussian diffusion from Gamma step
-    nnz_gamma=sum(StationaryDist_jj~=0,1);
+    nnz_gamma=full(sum(StationaryDist_jj~=0,1));
     for z_c=1:length(nnz_gamma)
-        if nnz_gamma(z_c)>6
+        if nnz_gamma(z_c)>8
+            epsilon_z=sum(StationaryDist_jj(:,z_c),1); % The sum of the z probs evolve as pi_z moves things around
             [epsilons, e_idx] = mink(nonzeros(StationaryDist_jj(:,z_c)), nnz_gamma(z_c)-4);
-            e_idx=e_idx(epsilons<epsilon*epsilon_z(z_c));
-            epsilons=epsilons(epsilons<epsilon*epsilon_z(z_c));
+            e_idx=e_idx(epsilons<epsilon*epsilon_z);
+            epsilons=epsilons(epsilons<epsilon*epsilon_z);
             if nnz(epsilons)>0
                 nonzero_idx=find(StationaryDist_jj(:,z_c));
                 % zero out likely error artifacts
@@ -43,9 +42,8 @@ for jj=1:(N_j-1)
                 % Redistribute values zeroed out equally among remaining nonzero terms
                 % By subtracting the largest zeroed epsilon, we return some
                 % weight from the edges to the center of the distribution
-                % By multiplying by epsilon_z(z_c), we limit drift in our normalized averages
                 newdist_jj=StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)-epsilons(end);
-                StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)=epsilon_z(z_c)*newdist_jj./sum(newdist_jj);
+                StationaryDist_jj(nonzero_idx(keep_nonzero),z_c)=epsilon_z*newdist_jj./sum(newdist_jj);
             end
         end
     end


### PR DESCRIPTION
The Gamma transpose step can diffuse values that don't fit on the grid into adjacent grid cells (with low probabilities attached).  This code finds these newly created low-probability cases and redistributes them back to the remaining higher-probability gridpoints.

The effect can be seen by graphing the evolution of experience assets over time and looking at the Maximum and Minimum graphs.  These graphs wander much further beyond the Means and Quantiles than they should due to Gaussian diffusion.  These changes keep such wandering in check.