### PR TITLE
Optimization of nProbs (enhancing adaptive grids for ExpAssets)

### DIFF
--- a/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAsset.m
+++ b/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAsset.m
@@ -111,11 +111,11 @@ end
 if simoptions.gridinterplayer==0
     % Note: N_z=0 && N_e=0 is a different code
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
@@ -130,11 +130,11 @@ elseif simoptions.gridinterplayer==1
 
     % Note: N_z=0 && N_e=0 is a different code
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 end
 

--- a/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAsset.m
+++ b/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAsset.m
@@ -111,11 +111,11 @@ end
 if simoptions.gridinterplayer==0
     % Note: N_z=0 && N_e=0 is a different code
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
@@ -130,11 +130,11 @@ elseif simoptions.gridinterplayer==1
 
     % Note: N_z=0 && N_e=0 is a different code
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,N_a,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,N_a,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
     end
 end
 

--- a/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAssetSemiExo.m
+++ b/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAssetSemiExo.m
@@ -135,13 +135,13 @@ Policy_dsemiexo=shiftdim(Policy_dsemiexo,1);
 %%
 if simoptions.gridinterplayer==0
     if N_z==0 && N_e==0
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_j,pi_semiz_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_j,pi_semiz_J,Parameters,simoptions);
     elseif N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
@@ -155,13 +155,13 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,:,3:4,:)=PolicyProbs(:,:,3:4,:).*aprimeProbs_upper; % upper a1
 
     if N_z==0 && N_e==0
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_j,pi_semiz_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_j,pi_semiz_J,Parameters,simoptions);
     elseif N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 end
 

--- a/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAsset_noz.m
+++ b/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAsset_noz.m
@@ -91,7 +91,7 @@ end
 
 if simoptions.gridinterplayer==0
 
-    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,Kaprimepts,N_a,N_j,Parameters);
+    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,Kaprimepts,n_a1,n_a2,N_j,Parameters);
 
 elseif simoptions.gridinterplayer==1
     if l_a2>1
@@ -107,7 +107,7 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,1:2,:)=PolicyProbs(:,1:2,:).*(1-aprimeProbs_upper); % lower a1
     PolicyProbs(:,3:4,:)=PolicyProbs(:,3:4,:).*aprimeProbs_upper; % upper a1
 
-    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,N_a,N_j,Parameters);
+    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_j,Parameters);
 end
 
 

--- a/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAsset_noz.m
+++ b/StationaryDist/FHorz/ExpAsset/StationaryDist_FHorz_ExpAsset_noz.m
@@ -91,7 +91,7 @@ end
 
 if simoptions.gridinterplayer==0
 
-    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,Kaprimepts,n_a1,n_a2,N_j,Parameters);
+    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,Kaprimepts,n_a1,n_a2,N_j,Parameters,simoptions);
 
 elseif simoptions.gridinterplayer==1
     if l_a2>1
@@ -107,7 +107,7 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,1:2,:)=PolicyProbs(:,1:2,:).*(1-aprimeProbs_upper); % lower a1
     PolicyProbs(:,3:4,:)=PolicyProbs(:,3:4,:).*aprimeProbs_upper; % upper a1
 
-    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_j,Parameters);
+    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_j,Parameters,simoptions);
 end
 
 

--- a/StationaryDist/FHorz/ExpAssete/StationaryDist_FHorz_ExpAssete.m
+++ b/StationaryDist/FHorz/ExpAssete/StationaryDist_FHorz_ExpAssete.m
@@ -97,9 +97,9 @@ end
 %%
 if simoptions.gridinterplayer==0
     if N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
@@ -113,9 +113,9 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,:,3:4,:)=PolicyProbs(:,:,3:4,:).*aprimeProbs_upper; % upper a1
 
     if N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,N_a,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 end
 

--- a/StationaryDist/FHorz/ExpAssete/StationaryDist_FHorz_ExpAsseteSemiExo.m
+++ b/StationaryDist/FHorz/ExpAssete/StationaryDist_FHorz_ExpAsseteSemiExo.m
@@ -127,9 +127,9 @@ Policy_dsemiexo=shiftdim(Policy_dsemiexo,1);
 %%
 if simoptions.gridinterplayer==0
     if N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
@@ -143,9 +143,9 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,:,3:4,:)=PolicyProbs(:,:,3:4,:).*aprimeProbs_upper; % upper a1
 
     if N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 end
 

--- a/StationaryDist/FHorz/ExpAssetsemiz/StationaryDist_FHorz_ExpAssetsemiz.m
+++ b/StationaryDist/FHorz/ExpAssetsemiz/StationaryDist_FHorz_ExpAssetsemiz.m
@@ -148,13 +148,13 @@ Policy_dsemiexo=shiftdim(Policy_dsemiexo,1);
 %%
 if simoptions.gridinterplayer==0
     if N_z==0 && N_e==0 % just semiz
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_j,pi_semiz_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_j,pi_semiz_J,Parameters,simoptions);
     elseif N_e==0 % semiz and z
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % semiz and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters,simoptions);
     else % semiz, z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 elseif simoptions.gridinterplayer==1
     % (a,bothze,2,j)
@@ -168,13 +168,13 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,:,3:4,:)=PolicyProbs(:,:,3:4,:).*aprimeProbs_upper; % upper a1
 
     if N_z==0 && N_e==0 % just semiz
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_j,pi_semiz_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_j,pi_semiz_J,Parameters,simoptions);
     elseif N_e==0 % semiz and z
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % semiz and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters,simoptions);
     else % semiz, z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 end
 

--- a/StationaryDist/FHorz/ExpAssetu/StationaryDist_FHorz_ExpAssetu.m
+++ b/StationaryDist/FHorz/ExpAssetu/StationaryDist_FHorz_ExpAssetu.m
@@ -134,11 +134,11 @@ PolicyProbs=reshape(PolicyProbs,[N_a,N_ze,N_u*2,N_j]);
 if simoptions.gridinterplayer==0
     % Note: N_z=0 && N_e=0 is a different code
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,N_a,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,N_a,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
@@ -153,11 +153,11 @@ elseif simoptions.gridinterplayer==1
 
     % Note: N_z=0 && N_e=0 is a different code
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,N_a,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,N_a,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
     end
 end
 

--- a/StationaryDist/FHorz/ExpAssetu/StationaryDist_FHorz_ExpAssetu.m
+++ b/StationaryDist/FHorz/ExpAssetu/StationaryDist_FHorz_ExpAssetu.m
@@ -134,11 +134,11 @@ PolicyProbs=reshape(PolicyProbs,[N_a,N_ze,N_u*2,N_j]);
 if simoptions.gridinterplayer==0
     % Note: N_z=0 && N_e=0 is a different code
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
@@ -153,11 +153,11 @@ elseif simoptions.gridinterplayer==1
 
     % Note: N_z=0 && N_e=0 is a different code
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 end
 

--- a/StationaryDist/FHorz/ExpAssetu/StationaryDist_FHorz_ExpAssetuSemiExo.m
+++ b/StationaryDist/FHorz/ExpAssetu/StationaryDist_FHorz_ExpAssetuSemiExo.m
@@ -161,13 +161,13 @@ Policy_dsemiexo=shiftdim(Policy_dsemiexo,1);
 %%
 if simoptions.gridinterplayer==0
     if N_z==0 && N_e==0
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_u*2,N_dsemiz,N_a,N_semiz,N_j,pi_semiz_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_u*2,N_dsemiz,n_a1,n_a2,N_semiz,N_j,pi_semiz_J,Parameters,simoptions);
     elseif N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_u*2,N_dsemiz,N_a,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_u*2,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_u*2,N_dsemiz,N_a,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_u*2,N_dsemiz,n_a1,n_a2,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_u*2,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_u*2,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
@@ -181,13 +181,13 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,:,2*N_u+1:end,:)=PolicyProbs(:,:,2*N_u+1:end,:).*aprimeProbs_upper; % upper a1
 
     if N_z==0 && N_e==0
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2*N_u*2,N_dsemiz,N_a,N_semiz,N_j,pi_semiz_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2*N_u*2,N_dsemiz,n_a1,n_a2,N_semiz,N_j,pi_semiz_J,Parameters,simoptions);
     elseif N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2*N_u*2,N_dsemiz,N_a,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2*N_u*2,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2*N_u*2,N_dsemiz,N_a,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2*N_u*2,N_dsemiz,n_a1,n_a2,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2*N_u*2,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2*N_u*2,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 end
 

--- a/StationaryDist/FHorz/ExpAssetu/StationaryDist_FHorz_ExpAssetu_noz.m
+++ b/StationaryDist/FHorz/ExpAssetu/StationaryDist_FHorz_ExpAssetu_noz.m
@@ -70,7 +70,7 @@ PolicyProbs=reshape(PolicyProbs,[N_a,N_u*2,N_j]);
 %%
 
 if simoptions.gridinterplayer==0
-    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,N_a,N_j,Parameters);
+    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_j,Parameters,simoptions);
 
 elseif simoptions.gridinterplayer==1
     % (a,u,2,j)
@@ -83,7 +83,7 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,1:2*N_u,:)=PolicyProbs(:,1:2*N_u,:).*(1-aprimeProbs_upper); % lower a1
     PolicyProbs(:,2*N_u+1:end,:)=PolicyProbs(:,2*N_u+1:end,:).*aprimeProbs_upper; % upper a1
 
-    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,N_a,N_j,Parameters);
+    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_j,Parameters,simoptions);
 end
 
 

--- a/StationaryDist/FHorz/ExpAssetz/StationaryDist_FHorz_ExpAssetz.m
+++ b/StationaryDist/FHorz/ExpAssetz/StationaryDist_FHorz_ExpAssetz.m
@@ -97,9 +97,9 @@ end
 %%
 if simoptions.gridinterplayer==0
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
@@ -113,9 +113,9 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,:,3:4,:)=PolicyProbs(:,:,3:4,:).*aprimeProbs_upper; % upper a1
 
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,N_a,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
     end
 end
 

--- a/StationaryDist/FHorz/ExpAssetz/StationaryDist_FHorz_ExpAssetz.m
+++ b/StationaryDist/FHorz/ExpAssetz/StationaryDist_FHorz_ExpAssetz.m
@@ -97,9 +97,9 @@ end
 %%
 if simoptions.gridinterplayer==0
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
@@ -113,9 +113,9 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,:,3:4,:)=PolicyProbs(:,:,3:4,:).*aprimeProbs_upper; % upper a1
 
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,4,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 end
 

--- a/StationaryDist/FHorz/ExpAssetz/StationaryDist_FHorz_ExpAssetzSemiExo.m
+++ b/StationaryDist/FHorz/ExpAssetz/StationaryDist_FHorz_ExpAssetzSemiExo.m
@@ -127,9 +127,9 @@ Policy_dsemiexo=shiftdim(Policy_dsemiexo,1);
 %%
 if simoptions.gridinterplayer==0
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
@@ -143,9 +143,9 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,:,3:4,:)=PolicyProbs(:,:,3:4,:).*aprimeProbs_upper; % upper a1
 
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 end
 

--- a/StationaryDist/FHorz/ExpAssetze/StationaryDist_FHorz_ExpAssetze.m
+++ b/StationaryDist/FHorz/ExpAssetze/StationaryDist_FHorz_ExpAssetze.m
@@ -141,7 +141,7 @@ clear aprimeIndexes aprimeProbs
 %%
 if simoptions.gridinterplayer==0
     % Both z and e required for experienceassetze
-    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,gather(Policy_aprime),gather(PolicyProbs),Kaprimepts,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+    StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,gather(Policy_aprime),gather(PolicyProbs),Kaprimepts,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
 elseif simoptions.gridinterplayer==1
     % GI doubles the corner count: each EAZE corner -> (lower a1, upper a1) pair.
     % l_a2==1: Kaprimepts=2 -> Kaprimepts_GI=4 (legacy)
@@ -157,7 +157,7 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,:,1:Kaprimepts,:)                = PolicyProbs(:,:,1:Kaprimepts,:)                .*(1-aprimeProbs_upper); % lower a1
     PolicyProbs(:,:,Kaprimepts+1:Kaprimepts_GI,:)  = PolicyProbs(:,:,Kaprimepts+1:Kaprimepts_GI,:)  .*   aprimeProbs_upper;  % upper a1
 
-    StationaryDist = StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,gather(PolicyProbs),Kaprimepts_GI,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+    StationaryDist = StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,gather(PolicyProbs),Kaprimepts_GI,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
 end
 
 

--- a/StationaryDist/FHorz/ExpAssetze/StationaryDist_FHorz_ExpAssetzeSemiExo.m
+++ b/StationaryDist/FHorz/ExpAssetze/StationaryDist_FHorz_ExpAssetzeSemiExo.m
@@ -123,7 +123,7 @@ Policy_dsemiexo=shiftdim(Policy_dsemiexo,1);
 %%
 if simoptions.gridinterplayer==0
     % Both z and e required for experienceassetze
-    StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+    StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
     Policy_aprime=repmat(Policy_aprime,1,1,2,1);
@@ -135,7 +135,7 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,:,1:2,:)=PolicyProbs(:,:,1:2,:).*(1-aprimeProbs_upper); % lower a1
     PolicyProbs(:,:,3:4,:)=PolicyProbs(:,:,3:4,:).*aprimeProbs_upper; % upper a1
 
-    StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+    StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,4,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
 end
 
 

--- a/StationaryDist/FHorz/ResidAsset/StationaryDist_FHorz_ResidAsset.m
+++ b/StationaryDist/FHorz/ResidAsset/StationaryDist_FHorz_ResidAsset.m
@@ -96,11 +96,11 @@ Policy_arprime(:,:,2,:)=Policy_aprime+N_a*(Policy_rprime+1-1);
 if simoptions.gridinterplayer==0
     % Note: N_z=0 && N_e=0 is a different code
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_arprime,PolicyProbs,2,N_a*N_r,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_arprime,PolicyProbs,2,n_a,n_r,N_z,N_j,pi_z_J,Parameters);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_arprime,PolicyProbs,2,N_a*N_r,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_arprime,PolicyProbs,2,n_a,n_r,N_e,N_j,simoptions.pi_e_J,Parameters);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_arprime,PolicyProbs,2,N_a*N_r,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_arprime,PolicyProbs,2,n_a,n_r,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
     end
 elseif simoptions.gridinterplayer==1
     error('grid interpolation layer not yet implemented for residual assets (contact me)')

--- a/StationaryDist/FHorz/RiskyAsset/StationaryDist_FHorz_RiskyAsset.m
+++ b/StationaryDist/FHorz/RiskyAsset/StationaryDist_FHorz_RiskyAsset.m
@@ -142,11 +142,11 @@ PolicyProbs=reshape(PolicyProbs,[N_a,N_ze,N_u*2,N_j]);
 if simoptions.gridinterplayer==0
     % Note: N_z=0 && N_e=0 is a different code
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,N_a,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,N_a,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_u*2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,2,j)
@@ -161,11 +161,11 @@ elseif simoptions.gridinterplayer==1
 
     % Note: N_z=0 && N_e=0 is a different code
     if N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,N_a,N_z,N_j,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,N_a,N_e,N_j,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_e,N_j,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2*N_u*2,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 end
 

--- a/StationaryDist/FHorz/SemiExo/StationaryDist_FHorz_SemiExo.m
+++ b/StationaryDist/FHorz/SemiExo/StationaryDist_FHorz_SemiExo.m
@@ -71,13 +71,13 @@ Policy_dsemiexo=shiftdim(Policy_dsemiexo,1); % [N_a,N_bothze,N_j]
 %%
 if simoptions.gridinterplayer==0
     if N_z==0 && N_e==0
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,N_dsemiz,N_a,N_semiz,N_j,pi_semiz_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,N_dsemiz,N_a,N_semiz,N_j,pi_semiz_J,Parameters,simoptions);
     elseif N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,N_dsemiz,N_a,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,N_dsemiz,N_a,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,N_dsemiz,N_a,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,N_dsemiz,N_a,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 elseif simoptions.gridinterplayer==1
     % (a,z,1,j)
@@ -92,13 +92,13 @@ elseif simoptions.gridinterplayer==1
     PolicyProbs(:,:,2,:)=PolicyProbs(:,:,2,:).*aprimeProbs_upper; % upper a1
 
     if N_z==0 && N_e==0
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_j,pi_semiz_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a,0,N_semiz,N_j,pi_semiz_J,Parameters,simoptions);
     elseif N_e==0 % just z
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a,0,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters,simoptions);
     elseif N_z==0 % just e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a,0,N_semiz,N_e,N_j,pi_semiz_J,simoptions.pi_e_J,Parameters,simoptions);
     else % both z and e
-        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,2,N_dsemiz,n_a,0,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
     end
 end
 

--- a/StationaryDist/FHorz/StationaryDist_FHorz_Case1.m
+++ b/StationaryDist/FHorz/StationaryDist_FHorz_Case1.m
@@ -335,7 +335,7 @@ if N_z==0 && N_e==0
         PolicyProbs(:,1,:)=PolicyProbs(:,1,:).*(1-aprimeProbs_upper); % lower a1
         PolicyProbs(:,2,:)=PolicyProbs(:,2,:).*aprimeProbs_upper; % upper a1
 
-        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_j,Parameters);
+        StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a,0,N_j,Parameters,simoptions);
     end
 else
     if N_z==0
@@ -391,13 +391,13 @@ else
         PolicyProbs(:,:,2,:)=PolicyProbs(:,:,2,:).*aprimeProbs_upper; % upper a1
 
         if N_z==0 && N_e==0 % handled separately above
-            % StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_j,Parameters);
+            % StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a,0,N_j,Parameters,simoptions);
         elseif N_e==0 % just z
-            StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_z,N_j,pi_z_J,Parameters);
+            StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a,0,N_z,N_j,pi_z_J,Parameters,simoptions);
         elseif N_z==0 % just e
-            StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_e,N_j,simoptions.pi_e_J,Parameters);
+            StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a,0,N_e,N_j,simoptions.pi_e_J,Parameters,simoptions);
         else % both z and e
-            StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,N_a,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters);
+            StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDist,AgeWeightParamNames,Policy_aprime,PolicyProbs,2,n_a,0,N_z,N_e,N_j,pi_z_J,simoptions.pi_e_J,Parameters,simoptions);
         end
     end
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw.m
@@ -1,7 +1,35 @@
-function StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDistKron,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_probs,N_dsemiz,N_a,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,pi_e_J,Parameters)
+function StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_e_raw(jequaloneDistKron,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_probs,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_e,N_j,pi_semiz_J,pi_z_J,pi_e_J,Parameters,simoptions)
 % 'nProbs' refers to N_probs probabilities.
 % Policy_aprime has an additional dimension of length N_probs which is the N_probs points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these N_probs.
+
+if exist('simoptions','var')==0
+    simoptions=struct();
+    simoptions.optimize_nProbs=0;
+    simoptions.verbosed=0;
+else
+    if ~isfield(simoptions,'verbose')
+        simoptions.verbose=0;
+    end
+    if ~isfield(simoptions,'optimize_nProbs')
+        simoptions.optimize_nProbs=0;
+    end
+end
+
+epsilon=1e-7;
+total_zeros_created=0;
+jj_at_max_a2=Inf;
+
+N_a1=prod(n_a1);
+N_a2=prod(n_a2);
+if N_a2==0
+    N_a=N_a1;
+elseif N_a1==0
+    N_a1=1;
+    N_a=N_a2;
+else
+    N_a=N_a1*N_a2;
+end
 
 % When we use semiz, we need to use a different shape for Policy_aprime.
 % sparse() limits us to 2-D, and we need to get in a semiz' dimension. So I
@@ -60,6 +88,10 @@ for jj=1:(N_j-1)
     % Second step of Tan improvement
     StationaryDist_jj=reshape(StationaryDist_jj*pi_z_J(:,:,jj),[N_a*N_bothz,1]);
 
+    if simoptions.optimize_nProbs==1
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,n_a1,n_a2,N_bothz,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+    end
+
     % Now do e transitions
     pi_e=sparse(pi_e_J(:,jj));
     StationaryDist_jj=kron(pi_e,StationaryDist_jj);
@@ -80,5 +112,42 @@ end
 
 StationaryDist=StationaryDist.*AgeWeights;
 
+
+if isfinite(jj_at_max_a2)
+    if N_a2>0
+        warning("Max ExpAsset index %3d first reached at age %3d \n", N_a2, jj_at_max_a2);
+    else
+        warning("Max grid-interpolated asset index %3d first reached at age %3d \n", N_a1, jj_at_max_a2);
+    end
+end
+
+if simoptions.verbose
+    if total_zeros_created>0
+        fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+        if ~isfinite(jj_at_max_a2)
+            max_a=nan;
+            if N_a2==0
+                temp=reshape(StationaryDist,[N_a1,N_bothz*N_e,N_j]);
+                [a1,~,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a1);
+                jj_at_max_a2=min(age_j(a1==max_a));
+            else
+                if N_a1>0
+                    temp=reshape(StationaryDist,[N_a1,N_a2,N_bothz*N_e,N_j]);
+                else
+                    temp=reshape(StationaryDist,[1,N_a2,N_bothz*N_e,N_j]);
+                end
+                [~,a2,~,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a2);
+                jj_at_max_a2=min(age_j(a2==max_a));
+            end
+            if N_a2>0
+                fprintf("Max ExpAsset index reached: %3d (of %3d) at age %3d \n", max_a, N_a2, jj_at_max_a2);
+            else
+                fprintf("Max grid-interpolated asset index reached: %3d (of %3d) at age %3d \n", max_a, N_a1, jj_at_max_a2);
+            end
+        end
+    end
+end
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw.m
@@ -117,12 +117,12 @@ if simoptions.verbose
         if ~isfinite(jj_at_max_a2)
             max_a=nan;
             if N_a2==0
-                temp=reshape(StationaryDist,[N_a1,N_e,N_j]);
+                temp=reshape(StationaryDist,[N_a1,N_semiz*N_e,N_j]);
                 [a1,~,age_j]=ind2sub(size(temp),find(temp~=0));
                 max_a=max(a1);
                 jj_at_max_a2=min(age_j(a1==max_a));
             else
-                temp=reshape(StationaryDist,[N_a1,N_a2,N_e,N_j]);
+                temp=reshape(StationaryDist,[N_a1,N_a2,N_semiz*N_e,N_j]);
                 [~,a2,~,age_j]=ind2sub(size(temp),find(temp~=0));
                 max_a=max(a2);
                 jj_at_max_a2=min(age_j(a2==max_a));

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw.m
@@ -1,8 +1,35 @@
-function StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDistKron,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_probs,N_dsemiz,N_a,N_semiz,N_e,N_j,pi_semiz_J,pi_e_J,Parameters)
+function StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_e_raw(jequaloneDistKron,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_probs,N_dsemiz,n_a1,n_a2,N_semiz,N_e,N_j,pi_semiz_J,pi_e_J,Parameters,simoptions)
 % 'nProbs' refers to N_probs probabilities.
 % Policy_aprime has an additional dimension of length N_probs which is the N_probs points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these N_probs.
 
+if exist('simoptions','var')==0
+    simoptions=struct();
+    simoptions.optimize_nProbs=0;
+    simoptions.verbosed=0;
+else
+    if ~isfield(simoptions,'verbose')
+        simoptions.verbose=0;
+    end
+    if ~isfield(simoptions,'optimize_nProbs')
+        simoptions.optimize_nProbs=0;
+    end
+end
+
+epsilon=1e-7;
+total_zeros_created=0;
+jj_at_max_a2=Inf;
+
+N_a1=prod(n_a1);
+N_a2=prod(n_a2);
+if N_a2==0
+    N_a=N_a1;
+elseif N_a1==0
+    N_a1=1;
+    N_a=N_a2;
+else
+    N_a=N_a1*N_a2;
+end
 % When we use semiz, we need to use a different shape for Policy_aprime.
 % sparse() limits us to 2-D, and we need to get in a semiz' dimension. So I
 % put a&semiz&e together into the 1st dim, semiz'&nprobs into the 2nd dim.
@@ -53,6 +80,10 @@ for jj=1:(N_j-1)
     % No z, so just a simple iteration
     StationaryDist_jj=Gammatranspose*StationaryDist_jj;
 
+    if simoptions.optimize_nProbs==1
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,n_a1,n_a2,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+    end
+
     % Put e back into dist
     StationaryDist_jj=kron(pi_e_J(:,jj),StationaryDist_jj);
 
@@ -71,5 +102,38 @@ if size(AgeWeights,2)==1 % If it seems to be a column vector, then transpose it
 end
 
 StationaryDist=StationaryDist.*AgeWeights;
+
+if isfinite(jj_at_max_a2)
+    if N_a2>0
+        warning("Max ExpAsset index %3d first reached at age %3d \n", N_a2, jj_at_max_a2);
+    else
+        warning("Max grid-interpolated asset index %3d first reached at age %3d \n", N_a1, jj_at_max_a2);
+    end
+end
+
+if simoptions.verbose
+    if total_zeros_created>0
+        fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+        if ~isfinite(jj_at_max_a2)
+            max_a=nan;
+            if N_a2==0
+                temp=reshape(StationaryDist,[N_a1,N_e,N_j]);
+                [a1,~,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a1);
+                jj_at_max_a2=min(age_j(a1==max_a));
+            else
+                temp=reshape(StationaryDist,[N_a1,N_a2,N_e,N_j]);
+                [~,a2,~,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a2);
+                jj_at_max_a2=min(age_j(a2==max_a));
+            end
+            if N_a2>0
+                fprintf("Max ExpAsset index reached: %3d (of %3d) at age %3d \n", max_a, N_a2, jj_at_max_a2);
+            else
+                fprintf("Max grid-interpolated asset index reached: %3d (of %3d) at age %3d \n", max_a, N_a1, jj_at_max_a2);
+            end
+        end
+    end
+end
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw.m
@@ -3,6 +3,34 @@ function StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(je
 % Policy_aprime has an additional dimension of length 4 which is the four points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these four
 
+if exist('simoptions','var')==0
+    simoptions=struct();
+    simoptions.optimize_nProbs=0;
+    simoptions.verbosed=0;
+else
+    if ~isfield(simoptions,'verbose')
+        simoptions.verbose=0;
+    end
+    if ~isfield(simoptions,'optimize_nProbs')
+        simoptions.optimize_nProbs=0;
+    end
+end
+
+epsilon=1e-7;
+total_zeros_created=0;
+jj_at_max_a2=Inf;
+
+N_a1=prod(n_a1);
+N_a2=prod(n_a2);
+if N_a2==0
+    N_a=N_a1;
+elseif N_a1==0
+    N_a1=1;
+    N_a=N_a2;
+else
+    N_a=N_a1*N_a2;
+end
+
 % Note: Tried doing creation of semiztransitions, etc., in parallel over jj
 % before the loop. Having it in the loop massively reduces the memory-use which
 % was a bottleneck when parallel over jj, and the runtime is actually if
@@ -50,6 +78,10 @@ for jj=1:(N_j-1)
     % No z, so just a single iteration
     StationaryDist_jj=Gammatranspose*StationaryDist_jj;
 
+    if simoptions.optimize_nProbs==1
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,n_a1,n_a2,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+    end
+
     StationaryDist(:,jj+1)=gpuArray(full(StationaryDist_jj));
 end
 
@@ -66,5 +98,41 @@ end
 
 StationaryDist=StationaryDist.*AgeWeights;
 
+if isfinite(jj_at_max_a2)
+    if N_a2>0
+        warning("Max ExpAsset index %3d first reached at age %3d \n", N_a2, jj_at_max_a2);
+    else
+        warning("Max grid-interpolated asset index %3d first reached at age %3d \n", N_a1, jj_at_max_a2);
+    end
+end
+
+if simoptions.verbose
+    if total_zeros_created>0
+        fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+        if ~isfinite(jj_at_max_a2)
+            max_a=nan;
+            if N_a2==0
+                temp=reshape(StationaryDist,[N_a1,N_j]);
+                [a1,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a1);
+                jj_at_max_a2=min(age_j(a1==max_a));
+            else
+                if N_a1>0
+                    temp=reshape(StationaryDist,[N_a1,N_a2,N_j]);
+                else
+                    temp=reshape(StationaryDist,[1,N_a2,N_j]);
+                end
+                [~,a2,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a2);
+                jj_at_max_a2=min(age_j(a2==max_a));
+            end
+            if N_a2>0
+                fprintf("Max ExpAsset index reached: %3d (of %3d) at age %3d \n", max_a, N_a2, jj_at_max_a2);
+            else
+                fprintf("Max grid-interpolated asset index reached: %3d (of %3d) at age %3d \n", max_a, N_a1, jj_at_max_a2);
+            end
+        end
+    end
+end
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw.m
@@ -79,7 +79,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=Gammatranspose*StationaryDist_jj;
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,n_a1,n_a2,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,n_a1,n_a2,N_semiz,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     StationaryDist(:,jj+1)=gpuArray(full(StationaryDist_jj));
@@ -112,17 +112,17 @@ if simoptions.verbose
         if ~isfinite(jj_at_max_a2)
             max_a=nan;
             if N_a2==0
-                temp=reshape(StationaryDist,[N_a1,N_j]);
-                [a1,age_j]=ind2sub(size(temp),find(temp~=0));
+                temp=reshape(StationaryDist,[N_a1,N_semiz,N_j]);
+                [a1,~,age_j]=ind2sub(size(temp),find(temp~=0));
                 max_a=max(a1);
                 jj_at_max_a2=min(age_j(a1==max_a));
             else
                 if N_a1>0
-                    temp=reshape(StationaryDist,[N_a1,N_a2,N_j]);
+                    temp=reshape(StationaryDist,[N_a1,N_a2,N_semiz,N_j]);
                 else
-                    temp=reshape(StationaryDist,[1,N_a2,N_j]);
+                    temp=reshape(StationaryDist,[1,N_a2,N_semiz,N_j]);
                 end
-                [~,a2,age_j]=ind2sub(size(temp),find(temp~=0));
+                [~,a2,~,age_j]=ind2sub(size(temp),find(temp~=0));
                 max_a=max(a2);
                 jj_at_max_a2=min(age_j(a2==max_a));
             end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw.m
@@ -1,4 +1,4 @@
-function StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_probs,N_dsemiz,N_a,N_semiz,N_j,pi_semiz_J,Parameters)
+function StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_probs,N_dsemiz,n_a1,n_a2,N_semiz,N_j,pi_semiz_J,Parameters,simoptions)
 % 'nProbs' refers to four probabilities.
 % Policy_aprime has an additional dimension of length 4 which is the four points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these four

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw.m
@@ -1,7 +1,34 @@
-function StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDistKron,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_probs,N_dsemiz,N_a,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters)
+function StationaryDist=StationaryDist_FHorz_Iteration_SemiExo_nProbs_raw(jequaloneDistKron,AgeWeightParamNames,Policy_dsemiexo,Policy_aprime,PolicyProbs,N_probs,N_dsemiz,n_a1,n_a2,N_semiz,N_z,N_j,pi_semiz_J,pi_z_J,Parameters,simoptions)
 % 'nProbs' refers to N_probs probabilities.
 % Policy_aprime has an additional dimension of length N_probs which is the N_probs points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these N_probs.
+
+if exist('simoptions','var')==0
+    simoptions=struct();
+    simoptions.optimize_nProbs=0;
+    simoptions.verbosed=0;
+else
+    if ~isfield(simoptions,'verbose')
+        simoptions.verbose=0;
+    end
+    if ~isfield(simoptions,'optimize_nProbs')
+        simoptions.optimize_nProbs=0;
+    end
+end
+
+epsilon=1e-7;
+total_zeros_created=0;
+jj_at_max_a2=Inf;
+
+N_a1=prod(n_a1);
+N_a2=prod(n_a2);
+if N_a2==0
+    N_a=N_a1;
+elseif N_a1==0
+    N_a=N_a2;
+else
+    N_a=N_a1*N_a2;
+end
 
 % When we use semiz, we need to use a different shape for Policy_aprime.
 % sparse() limits us to 2-D, and we need to get in a semiz' dimension. So I
@@ -60,6 +87,10 @@ for jj=1:(N_j-1)
     % Second step of Tan improvement
     StationaryDist_jj=reshape(StationaryDist_jj*pi_z_J(:,:,jj),[N_a*N_bothz,1]);
 
+    if simoptions.optimize_nProbs==1
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,n_a1,n_a2,N_bothz,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+    end
+
     StationaryDist(:,jj+1)=gpuArray(full(StationaryDist_jj));
 end
 
@@ -75,5 +106,42 @@ if size(AgeWeights,2)==1 % If it seems to be a column vector, then transpose it
 end
 
 StationaryDist=StationaryDist.*AgeWeights;
+
+if isfinite(jj_at_max_a2)
+    if N_a2>0
+        warning("Max ExpAsset index %3d first reached at age %3d \n", N_a2, jj_at_max_a2);
+    else
+        warning("Max grid-interpolated asset index %3d first reached at age %3d \n", N_a1, jj_at_max_a2);
+    end
+end
+
+if simoptions.verbose
+    if total_zeros_created>0
+        fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+        if ~isfinite(jj_at_max_a2)
+            max_a=nan;
+            if N_a2==0
+                temp=reshape(StationaryDist,[N_a1,N_bothz,N_j]);
+                [a1,~,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a1);
+                jj_at_max_a2=min(age_j(a1==max_a));
+            else
+                if N_a1>0
+                    temp=reshape(StationaryDist,[N_a1,N_a2,N_bothz,N_j]);
+                else
+                    temp=reshape(StationaryDist,[1,N_a2,N_bothz,N_j]);
+                end
+                [~,a2,~,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a2);
+                jj_at_max_a2=min(age_j(a2==max_a));
+            end
+            if N_a2>0
+                fprintf("Max ExpAsset index reached: %3d (of %3d) at age %3d \n", max_a, N_a2, jj_at_max_a2);
+            else
+                fprintf("Max grid-interpolated asset index reached: %3d (of %3d) at age %3d \n", max_a, N_a1, jj_at_max_a2);
+            end
+        end
+    end
+end
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_e_raw.m
@@ -1,8 +1,29 @@
-function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_probs,N_a,N_z,N_e,N_j,pi_z_J,pi_e_J,Parameters)
+function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_probs,n_a1,n_a2,N_z,N_e,N_j,pi_z_J,pi_e_J,Parameters,simoptions)
 % 'nProbs' refers to N_probs probabilities.
 % Policy_aprime has an additional dimension of length N_probs which is the N_probs points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these N_probs.
 
+if exist('simpoptions','var')==0
+    simoptions=struct();
+    simoptions.optimize_nProbs=0;
+elseif ~isfield(simoptions,'optimize_nProbs')
+    simoptions.optimize_nProbs=0;
+end
+
+epsilon=1e-7;
+total_zeros_created=0;
+jj_at_max_a2=Inf;
+
+N_a1=prod(n_a1);
+N_a2=prod(n_a2);
+if N_a2==0
+    N_a=N_a1;
+elseif N_a1==0
+    N_a1=1;
+    N_a=N_a2;
+else
+    N_a=N_a1*N_a2;
+end
 % Policy_aprime and PolicyProbs are currently [N_a,N_z*N_e,N_probs,N_j]
 Policy_aprimez=Policy_aprime+repmat(N_a*(0:1:N_z-1),1,N_e);  % Note: add z' index following the z dimension [Tan improvement, z stays where it is]
 Policy_aprimez=gather(reshape(Policy_aprimez,[N_a*N_z*N_e,N_probs,N_j])); % sparse() requires inputs to be 2-D
@@ -29,6 +50,10 @@ for jj=1:(N_j-1)
     pi_z=sparse(gather(pi_z_J(:,:,jj)));
     StationaryDist_jj=reshape(StationaryDist_jj*pi_z,[N_a*N_z,1]);
 
+    if simoptions.optimize_nProbs==1
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2);
+    end
+
     % Put e back into dist
     pi_e=sparse(gather(pi_e_J(:,jj)));
     StationaryDist_jj=kron(pi_e,StationaryDist_jj);
@@ -48,5 +73,18 @@ if size(AgeWeights,2)==1 % If it seems to be a column vector, then transpose it
 end
 
 StationaryDist=StationaryDist.*AgeWeights;
+
+if total_zeros_created>0
+    fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+    if isfinite(jj_at_max_a2)
+        fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
+    else
+        temp=reshape(StationaryDist,[N_a1,N_a2,N_z*N_e,N_j]);
+        [a1,a2,ze_c,age_j]=ind2sub(size(temp),find(temp~=0));
+        max_a2=max(a2);
+        jj_at_max_a2=min(age_j(find(a2==max_a2)));
+        fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+    end
+end
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_e_raw.m
@@ -3,11 +3,17 @@ function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_e_raw(jequaloneDis
 % Policy_aprime has an additional dimension of length N_probs which is the N_probs points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these N_probs.
 
-if exist('simpoptions','var')==0
+if exist('simoptions','var')==0
     simoptions=struct();
     simoptions.optimize_nProbs=0;
-elseif ~isfield(simoptions,'optimize_nProbs')
-    simoptions.optimize_nProbs=0;
+    simoptions.verbosed=0;
+else
+    if ~isfield(simoptions,'verbose')
+        simoptions.verbose=0;
+    end
+    if ~isfield(simoptions,'optimize_nProbs')
+        simoptions.optimize_nProbs=0;
+    end
 end
 
 epsilon=1e-7;
@@ -51,7 +57,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=reshape(StationaryDist_jj*pi_z,[N_a*N_z,1]);
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     % Put e back into dist
@@ -74,16 +80,36 @@ end
 
 StationaryDist=StationaryDist.*AgeWeights;
 
-if total_zeros_created>0
-    fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
-    if isfinite(jj_at_max_a2)
-        fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
+if isfinite(jj_at_max_a2)
+    if N_a2>0
+        warning("Max ExpAsset index %3d first reached at age %3d \n", N_a2, jj_at_max_a2);
     else
-        temp=reshape(StationaryDist,[N_a1,N_a2,N_z*N_e,N_j]);
-        [a1,a2,ze_c,age_j]=ind2sub(size(temp),find(temp~=0));
-        max_a2=max(a2);
-        jj_at_max_a2=min(age_j(find(a2==max_a2)));
-        fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+        warning("Max grid-interpolated asset index %3d first reached at age %3d \n", N_a1, jj_at_max_a2);
+    end
+end
+
+if simoptions.verbose
+    if total_zeros_created>0
+        fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+        if ~isfinite(jj_at_max_a2)
+            max_a=nan;
+            if N_a2==0
+                temp=reshape(StationaryDist,[N_a1,N_z*N_e,N_j]);
+                [a1,~,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a1);
+                jj_at_max_a2=min(age_j(a1==max_a));
+            else
+                temp=reshape(StationaryDist,[N_a1,N_a2,N_z*N_e,N_j]);
+                [~,a2,~,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a2);
+                jj_at_max_a2=min(age_j(a2==max_a));
+            end
+            if N_a2>0
+                fprintf("Max ExpAsset index reached: %3d (of %3d) at age %3d \n", max_a, N_a2, jj_at_max_a2);
+            else
+                fprintf("Max grid-interpolated asset index reached: %3d (of %3d) at age %3d \n", max_a, N_a1, jj_at_max_a2);
+            end
+        end
     end
 end
 

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_e_raw.m
@@ -57,7 +57,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=reshape(StationaryDist_jj*pi_z,[N_a*N_z,1]);
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     % Put e back into dist

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_e_raw.m
@@ -99,7 +99,11 @@ if simoptions.verbose
                 max_a=max(a1);
                 jj_at_max_a2=min(age_j(a1==max_a));
             else
-                temp=reshape(StationaryDist,[N_a1,N_a2,N_z*N_e,N_j]);
+                if N_a1>0
+                    temp=reshape(StationaryDist,[N_a1,N_a2,N_z*N_e,N_j]);
+                else
+                    temp=reshape(StationaryDist,[1,N_a2,N_z*N_e,N_j]);
+                end
                 [~,a2,~,age_j]=ind2sub(size(temp),find(temp~=0));
                 max_a=max(a2);
                 jj_at_max_a2=min(age_j(a2==max_a));

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_e_raw.m
@@ -57,7 +57,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=reshape(StationaryDist_jj*pi_z,[N_a*N_z,1]);
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,n_a1,n_a2,N_z,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     % Put e back into dist

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_e_raw.m
@@ -52,7 +52,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=Gammatranspose*StationaryDist_jj;
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,0,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     % Put e back into dist

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_e_raw.m
@@ -3,11 +3,17 @@ function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequalon
 % Policy_aprime has an additional dimension of length N_probs which is the N_probs points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these N_probs.
 
-if exist('simpoptions','var')==0
+if exist('simoptions','var')==0
     simoptions=struct();
     simoptions.optimize_nProbs=0;
-elseif ~isfield(simoptions,'optimize_nProbs')
-    simoptions.optimize_nProbs=0;
+    simoptions.verbosed=0;
+else
+    if ~isfield(simoptions,'verbose')
+        simoptions.verbose=0;
+    end
+    if ~isfield(simoptions,'optimize_nProbs')
+        simoptions.optimize_nProbs=0;
+    end
 end
 
 epsilon=1e-7;
@@ -46,7 +52,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=Gammatranspose*StationaryDist_jj;
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,0,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,0,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     % Put e back into dist
@@ -69,16 +75,36 @@ end
 
 StationaryDist=StationaryDist.*AgeWeights;
 
-if total_zeros_created>0
-    fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
-    if isfinite(jj_at_max_a2)
-        fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
+if isfinite(jj_at_max_a2)
+    if N_a2>0
+        warning("Max ExpAsset index %3d first reached at age %3d \n", N_a2, jj_at_max_a2);
     else
-        temp=reshape(StationaryDist,[N_a1,N_a2,N_e,N_j]);
-        [a1,a2,e_c,age_j]=ind2sub(size(temp),find(temp~=0));
-        max_a2=max(a2);
-        jj_at_max_a2=min(age_j(find(a2==max_a2)));
-        fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+        warning("Max grid-interpolated asset index %3d first reached at age %3d \n", N_a1, jj_at_max_a2);
+    end
+end
+
+if simoptions.verbose
+    if total_zeros_created>0
+        fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+        if ~isfinite(jj_at_max_a2)
+            max_a=nan;
+            if N_a2==0
+                temp=reshape(StationaryDist,[N_a1,N_e,N_j]);
+                [a1,~,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a1);
+                jj_at_max_a2=min(age_j(a1==max_a));
+            else
+                temp=reshape(StationaryDist,[N_a1,N_a2,N_e,N_j]);
+                [~,a2,~,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a2);
+                jj_at_max_a2=min(age_j(a2==max_a));
+            end
+            if N_a2>0
+                fprintf("Max ExpAsset index reached: %3d (of %3d) at age %3d \n", max_a, N_a2, jj_at_max_a2);
+            else
+                fprintf("Max grid-interpolated asset index reached: %3d (of %3d) at age %3d \n", max_a, N_a1, jj_at_max_a2);
+            end
+        end
     end
 end
 

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_e_raw.m
@@ -1,8 +1,29 @@
-function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_probs,N_a,N_e,N_j,pi_e_J,Parameters)
+function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_e_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_probs,n_a1,n_a2,N_e,N_j,pi_e_J,Parameters,simoptions)
 % 'nProbs' refers to N_probs probabilities.
 % Policy_aprime has an additional dimension of length N_probs which is the N_probs points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these N_probs.
 
+if exist('simpoptions','var')==0
+    simoptions=struct();
+    simoptions.optimize_nProbs=0;
+elseif ~isfield(simoptions,'optimize_nProbs')
+    simoptions.optimize_nProbs=0;
+end
+
+epsilon=1e-7;
+total_zeros_created=0;
+jj_at_max_a2=Inf;
+
+N_a1=prod(n_a1);
+N_a2=prod(n_a2);
+if N_a2==0
+    N_a=N_a1;
+elseif N_a1==0
+    N_a1=1;
+    N_a=N_a2;
+else
+    N_a=N_a1*N_a2;
+end
 % Policy_aprime and PolicyProbs are currently [N_a,N_e,N_probs,N_j]
 Policy_aprime=gather(reshape(Policy_aprime,[N_a*N_e,N_probs,N_j])); % sparse() requires inputs to be 2-D
 PolicyProbs=gather(reshape(PolicyProbs,[N_a*N_e,N_probs,N_j])); % sparse() requires inputs to be 2-D
@@ -24,6 +45,10 @@ for jj=1:(N_j-1)
     % No z, so just a simple iteration
     StationaryDist_jj=Gammatranspose*StationaryDist_jj;
 
+    if simoptions.optimize_nProbs==1
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,0,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2);
+    end
+
     % Put e back into dist
     pi_e=sparse(gather(pi_e_J(:,jj)));
     StationaryDist_jj=kron(pi_e,StationaryDist_jj);
@@ -43,5 +68,18 @@ if size(AgeWeights,2)==1 % If it seems to be a column vector, then transpose it
 end
 
 StationaryDist=StationaryDist.*AgeWeights;
+
+if total_zeros_created>0
+    fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+    if isfinite(jj_at_max_a2)
+        fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
+    else
+        temp=reshape(StationaryDist,[N_a1,N_a2,N_e,N_j]);
+        [a1,a2,e_c,age_j]=ind2sub(size(temp),find(temp~=0));
+        max_a2=max(a2);
+        jj_at_max_a2=min(age_j(find(a2==max_a2)));
+        fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+    end
+end
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_e_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_e_raw.m
@@ -52,7 +52,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=Gammatranspose*StationaryDist_jj;
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,n_a1,n_a2,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     % Put e back into dist

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
@@ -1,7 +1,14 @@
-function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_probs,n_a1,n_a2,N_j,Parameters)
+function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_probs,n_a1,n_a2,N_j,Parameters,simoptions)
 % 'nProbs' refers to four probabilities.
 % Policy_aprime has an additional dimension of length 4 which is the four points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these four
+
+if exist('simpoptions','var')==0
+    simoptions=struct();
+    simoptions.optimize_nProbs=0;
+elseif ~isfield(simoptions,'optimize_nProbs')
+    simoptions.optimize_nProbs=0;
+end
 
 epsilon=1e-7;
 total_zeros_created=0;
@@ -46,7 +53,9 @@ for jj=1:(N_j-1)
     StationaryDist_upper_jj=Gammatranspose_upper*StationaryDist_jj;
     StationaryDist_jj=Gammatranspose*StationaryDist_jj; % =StationaryDist_lower_jj+StationaryDist_upper_jj;
 
-    [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,StationaryDist_lower_jj,StationaryDist_upper_jj, N_a1,N_a2,0,jj, epsilon,total_zeros_created,jj_at_max_a2);
+    if simoptions.optimize_nProbs==1
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,StationaryDist_lower_jj,StationaryDist_upper_jj, N_a1,N_a2,0,0,jj, epsilon,total_zeros_created,jj_at_max_a2);
+    end
 
     StationaryDist(:,jj+1)=gather(full(StationaryDist_jj));
 end
@@ -66,15 +75,17 @@ end
 
 StationaryDist=StationaryDist.*AgeWeights;
 
-fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
-if isfinite(jj_at_max_a2)
-    fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
-else
-    temp=reshape(StationaryDist,[N_a1,N_a2,N_j]);
-    [a1,a2,age_j]=ind2sub(size(temp),find(temp~=0));
-    max_a2=max(a2);
-    jj_at_max_a2=min(age_j(find(a2==max_a2)));
-    fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+if total_zeros_created>0
+    fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+    if isfinite(jj_at_max_a2)
+        fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
+    else
+        temp=reshape(StationaryDist,[N_a1,N_a2,N_j]);
+        [a1,a2,age_j]=ind2sub(size(temp),find(temp~=0));
+        max_a2=max(a2);
+        jj_at_max_a2=min(age_j(find(a2==max_a2)));
+        fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+    end
 end
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
@@ -55,7 +55,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=Gammatranspose*StationaryDist_jj;
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,0,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     StationaryDist(:,jj+1)=gather(full(StationaryDist_jj));

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
@@ -45,22 +45,17 @@ StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(gather(jequaloneDistKron)); % sparse() creates a matrix of zeros
 
 % Precompute
-II1=(1:1:N_a)';
 II2=repmat((1:1:N_a)',1,N_probs); % Note the N_probs-copies
 
 for jj=1:(N_j-1)
     % First, get Gamma
     Gammatranspose=sparse(Policy_aprime(:,:,jj),II2,PolicyProbs(:,:,jj),N_a,N_a);  % Note: sparse() will accumulate at repeated indices
-    Gammatranspose_lower=sparse(Policy_aprime(:,1,jj),II1,PolicyProbs(:,1,jj),N_a,N_a);
-    Gammatranspose_upper=sparse(Policy_aprime(:,2,jj),II1,PolicyProbs(:,2,jj),N_a,N_a);
 
     % No z, so just a single step
-    StationaryDist_lower_jj=Gammatranspose_lower*StationaryDist_jj;
-    StationaryDist_upper_jj=Gammatranspose_upper*StationaryDist_jj;
-    StationaryDist_jj=Gammatranspose*StationaryDist_jj; % =StationaryDist_lower_jj+StationaryDist_upper_jj;
+    StationaryDist_jj=Gammatranspose*StationaryDist_jj;
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,StationaryDist_lower_jj,StationaryDist_upper_jj, N_a1,N_a2,0,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,0,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     StationaryDist(:,jj+1)=gather(full(StationaryDist_jj));

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
@@ -1,10 +1,28 @@
-function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_probs,N_a,N_j,Parameters)
+function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_probs,n_a1,n_a2,N_j,Parameters)
 % 'nProbs' refers to four probabilities.
 % Policy_aprime has an additional dimension of length 4 which is the four points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these four
 
+epsilon=1e-7;
+total_zeros_created=0;
+jj_at_max_a2=Inf;
+
 % Policy_aprime and PolicyProbs are currently [N_a,N_probs,N_j]
+N_a1=prod(n_a1);
+N_a2=prod(n_a2);
+if N_a2==0
+    N_a=N_a1;
+elseif N_a1==0
+    N_a1=1;
+    N_a=N_a2;
+else
+    N_a=N_a1*N_a2;
+end
 Policy_aprime=gather(Policy_aprime);
+needs_rounding=(PolicyProbs<epsilon | PolicyProbs>1-epsilon);
+needs_rounding(PolicyProbs==0)=0;
+needs_rounding(PolicyProbs==1)=0;
+PolicyProbs(needs_rounding)=round(PolicyProbs(needs_rounding));
 PolicyProbs=gather(PolicyProbs);
 
 %% Use Tan improvement
@@ -14,14 +32,21 @@ StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(gather(jequaloneDistKron)); % sparse() creates a matrix of zeros
 
 % Precompute
+II1=(1:1:N_a)';
 II2=repmat((1:1:N_a)',1,N_probs); % Note the N_probs-copies
 
 for jj=1:(N_j-1)
     % First, get Gamma
     Gammatranspose=sparse(Policy_aprime(:,:,jj),II2,PolicyProbs(:,:,jj),N_a,N_a);  % Note: sparse() will accumulate at repeated indices
+    Gammatranspose_lower=sparse(Policy_aprime(:,1,jj),II1,PolicyProbs(:,1,jj),N_a,N_a);
+    Gammatranspose_upper=sparse(Policy_aprime(:,2,jj),II1,PolicyProbs(:,2,jj),N_a,N_a);
 
     % No z, so just a single step
-    StationaryDist_jj=Gammatranspose*StationaryDist_jj;
+    StationaryDist_lower_jj=Gammatranspose_lower*StationaryDist_jj;
+    StationaryDist_upper_jj=Gammatranspose_upper*StationaryDist_jj;
+    StationaryDist_jj=Gammatranspose*StationaryDist_jj; % =StationaryDist_lower_jj+StationaryDist_upper_jj;
+
+    [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,StationaryDist_lower_jj,StationaryDist_upper_jj, N_a1,N_a2,0,jj, epsilon,total_zeros_created,jj_at_max_a2);
 
     StationaryDist(:,jj+1)=gather(full(StationaryDist_jj));
 end
@@ -40,5 +65,16 @@ if size(AgeWeights,2)==1 % If it seems to be a column vector, then transpose it
 end
 
 StationaryDist=StationaryDist.*AgeWeights;
+
+fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+if isfinite(jj_at_max_a2)
+    fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
+else
+    temp=reshape(StationaryDist,[N_a1,N_a2,N_j]);
+    [a1,a2,age_j]=ind2sub(size(temp),find(temp~=0));
+    max_a2=max(a2);
+    jj_at_max_a2=min(age_j(find(a2==max_a2)));
+    fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+end
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
@@ -3,11 +3,17 @@ function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_noz_raw(jequaloneD
 % Policy_aprime has an additional dimension of length 4 which is the four points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these four
 
-if exist('simpoptions','var')==0
+if exist('simoptions','var')==0
     simoptions=struct();
     simoptions.optimize_nProbs=0;
-elseif ~isfield(simoptions,'optimize_nProbs')
-    simoptions.optimize_nProbs=0;
+    simoptions.verbosed=0;
+else
+    if ~isfield(simoptions,'verbose')
+        simoptions.verbose=0;
+    end
+    if ~isfield(simoptions,'optimize_nProbs')
+        simoptions.optimize_nProbs=0;
+    end
 end
 
 epsilon=1e-7;
@@ -54,7 +60,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=Gammatranspose*StationaryDist_jj; % =StationaryDist_lower_jj+StationaryDist_upper_jj;
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,StationaryDist_lower_jj,StationaryDist_upper_jj, N_a1,N_a2,0,0,jj, epsilon,total_zeros_created,jj_at_max_a2);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,StationaryDist_lower_jj,StationaryDist_upper_jj, N_a1,N_a2,0,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     StationaryDist(:,jj+1)=gather(full(StationaryDist_jj));
@@ -75,16 +81,36 @@ end
 
 StationaryDist=StationaryDist.*AgeWeights;
 
-if total_zeros_created>0
-    fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
-    if isfinite(jj_at_max_a2)
-        fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
+if isfinite(jj_at_max_a2)
+    if N_a2>0
+        warning("Max ExpAsset index %3d first reached at age %3d \n", N_a2, jj_at_max_a2);
     else
-        temp=reshape(StationaryDist,[N_a1,N_a2,N_j]);
-        [a1,a2,age_j]=ind2sub(size(temp),find(temp~=0));
-        max_a2=max(a2);
-        jj_at_max_a2=min(age_j(find(a2==max_a2)));
-        fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+        warning("Max grid-interpolated asset index %3d first reached at age %3d \n", N_a1, jj_at_max_a2);
+    end
+end
+
+if simoptions.verbose
+    if total_zeros_created>0
+        fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+        if ~isfinite(jj_at_max_a2)
+            max_a=nan;
+            if N_a2==0
+                temp=reshape(StationaryDist,[N_a1,N_j]);
+                [a1,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a1);
+                jj_at_max_a2=min(age_j(a1==max_a));
+            else
+                temp=reshape(StationaryDist,[N_a1,N_a2,N_j]);
+                [~,a2,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a2);
+                jj_at_max_a2=min(age_j(a2==max_a));
+            end
+            if N_a2>0
+                fprintf("Max ExpAsset index reached: %3d (of %3d) at age %3d \n", max_a, N_a2, jj_at_max_a2);
+            else
+                fprintf("Max grid-interpolated asset index reached: %3d (of %3d) at age %3d \n", max_a, N_a1, jj_at_max_a2);
+            end
+        end
     end
 end
 

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
@@ -55,7 +55,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=Gammatranspose*StationaryDist_jj;
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,n_a1,n_a2,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     StationaryDist(:,jj+1)=gather(full(StationaryDist_jj));

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_noz_raw.m
@@ -20,7 +20,6 @@ epsilon=1e-7;
 total_zeros_created=0;
 jj_at_max_a2=Inf;
 
-% Policy_aprime and PolicyProbs are currently [N_a,N_probs,N_j]
 N_a1=prod(n_a1);
 N_a2=prod(n_a2);
 if N_a2==0
@@ -31,6 +30,7 @@ elseif N_a1==0
 else
     N_a=N_a1*N_a2;
 end
+% Policy_aprime and PolicyProbs are currently [N_a,N_probs,N_j]
 Policy_aprime=gather(Policy_aprime);
 needs_rounding=(PolicyProbs<epsilon | PolicyProbs>1-epsilon);
 needs_rounding(PolicyProbs==0)=0;

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -1,7 +1,14 @@
-function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_probs,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters)
+function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_probs,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters,simoptions)
 % 'nProbs' refers to N_probs probabilities.
 % Policy_aprime has an additional dimension of length N_probs which is the N_probs points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these N_probs.
+
+if exist('simoptions','var')==0
+    simoptions=struct();
+    simoptions.optimize_nProbs=0;
+elseif ~isfield(simoptions,'optimize_nProbs')
+    simoptions.optimize_nProbs=0;
+end
 
 epsilon=1e-7;
 total_zeros_created=0;
@@ -54,7 +61,9 @@ for jj=1:(N_j-1)
     pi_z=sparse(gather(pi_z_J(:,:,jj)));
     StationaryDist_jj=StationaryDist_jj*pi_z;
 
-    [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,jj, epsilon,total_zeros_created,jj_at_max_a2);
+    if simoptions.optimize_nProbs==1
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,0,jj, epsilon,total_zeros_created,jj_at_max_a2);
+    end
 
     StationaryDist_jj=reshape(StationaryDist_jj,[N_a*N_z,1]);
     assert(all(StationaryDist_jj>=0));
@@ -76,15 +85,17 @@ end
 
 StationaryDist=StationaryDist.*AgeWeights;
 
-fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
-if isfinite(jj_at_max_a2)
-    fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
-else
-    temp=reshape(StationaryDist,[N_a1,N_a2,N_z,N_j]);
-    [a1,a2,z_c,age_j]=ind2sub(size(temp),find(temp~=0));
-    max_a2=max(a2);
-    jj_at_max_a2=min(age_j(find(a2==max_a2)));
-    fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+if total_zeros_created>0
+    fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+    if isfinite(jj_at_max_a2)
+        fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
+    else
+        temp=reshape(StationaryDist,[N_a1,N_a2,N_z,N_j]);
+        [a1,a2,z_c,age_j]=ind2sub(size(temp),find(temp~=0));
+        max_a2=max(a2);
+        jj_at_max_a2=min(age_j(find(a2==max_a2)));
+        fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+    end
 end
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -90,11 +90,19 @@ if total_zeros_created>0
     if isfinite(jj_at_max_a2)
         fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
     else
-        temp=reshape(StationaryDist,[N_a1,N_a2,N_z,N_j]);
-        [a1,a2,z_c,age_j]=ind2sub(size(temp),find(temp~=0));
-        max_a2=max(a2);
-        jj_at_max_a2=min(age_j(find(a2==max_a2)));
-        fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+        if N_a2==0
+            temp=reshape(StationaryDist,[N_a1,N_z,N_j]);
+            [a1,z_c,age_j]=ind2sub(size(temp),find(temp~=0));
+            max_a1=max(a1);
+            jj_at_max_a2=min(age_j(find(a1==max_a1)));
+            fprintf("Max (interpolated) Asset index reached = %3d (of %3d) at age %3d \n", max_a1, N_a1, jj_at_max_a2);
+        else
+            temp=reshape(StationaryDist,[N_a1,N_a2,N_z,N_j]);
+            [a1,a2,z_c,age_j]=ind2sub(size(temp),find(temp~=0));
+            max_a2=max(a2);
+            jj_at_max_a2=min(age_j(find(a2==max_a2)));
+            fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+        end
     end
 end
 

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -22,7 +22,9 @@ Policy_aprimez=gather(reshape(Policy_aprimez,[N_a*N_z,N_probs,N_j])); % sparse()
 needs_rounding=(PolicyProbs<epsilon | PolicyProbs>1-epsilon);
 needs_rounding(PolicyProbs==0)=0;
 needs_rounding(PolicyProbs==1)=0;
-PolicyProbs(needs_rounding)=round(PolicyProbs(needs_rounding));
+if false
+    PolicyProbs(needs_rounding)=round(PolicyProbs(needs_rounding));
+end
 PolicyProbs=gather(reshape(PolicyProbs,[N_a*N_z,N_probs,N_j])); % sparse() requires inputs to be 2-D
 
 %% Use Tan improvement
@@ -32,32 +34,27 @@ StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(gather(jequaloneDistKron)); % use sparse matrix
 
 % Precompute
-II1=(1:1:N_a*N_z)';
 II2=repmat((1:1:N_a*N_z)',1,N_probs); %  Index for this period (a,z), note the N_probs-copies
 
 for jj=1:(N_j-1)
 
     % First, get Gamma
     Gammatranspose=sparse(Policy_aprimez(:,:,jj),II2,PolicyProbs(:,:,jj),N_a*N_z,N_a*N_z); % Note: sparse() will accumulate at repeated indices
-    Gammatranspose_lower=sparse(Policy_aprimez(:,1,jj),II1,PolicyProbs(:,1,jj),N_a*N_z,N_a*N_z);
-    Gammatranspose_upper=sparse(Policy_aprimez(:,2,jj),II1,PolicyProbs(:,2,jj),N_a*N_z,N_a*N_z);
 
     % First step of Tan improvement
     needs_rounding=full(StationaryDist_jj<epsilon | StationaryDist_jj>1-epsilon);
     needs_rounding(StationaryDist_jj==0)=0;
     needs_rounding(StationaryDist_jj==1)=0;
-    StationaryDist_jj(needs_rounding)=round(StationaryDist_jj(needs_rounding));
-    StationaryDist_lower_jj=reshape(Gammatranspose_lower*StationaryDist_jj,[N_a,N_z]);
-    StationaryDist_upper_jj=reshape(Gammatranspose_upper*StationaryDist_jj,[N_a,N_z]);
+    if false
+        StationaryDist_jj(needs_rounding)=round(StationaryDist_jj(needs_rounding));
+    end
     StationaryDist_jj=reshape(Gammatranspose*StationaryDist_jj,[N_a,N_z]);
 
     % Second step of Tan improvement
     pi_z=sparse(gather(pi_z_J(:,:,jj)));
     StationaryDist_jj=StationaryDist_jj*pi_z;
-    StationaryDist_lower_jj=StationaryDist_lower_jj*pi_z;
-    StationaryDist_upper_jj=StationaryDist_upper_jj*pi_z;
 
-    [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,StationaryDist_lower_jj,StationaryDist_upper_jj, N_a1,N_a2,N_z,jj, epsilon,total_zeros_created,jj_at_max_a2);
+    [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,jj, epsilon,total_zeros_created,jj_at_max_a2);
 
     StationaryDist_jj=reshape(StationaryDist_jj,[N_a*N_z,1]);
     assert(all(StationaryDist_jj>=0));

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -86,7 +86,7 @@ else
     temp=reshape(StationaryDist,[N_a1,N_a2,N_z,N_j]);
     [a1,a2,z_c,age_j]=ind2sub(size(temp),find(temp~=0));
     max_a2=max(a2);
-    jj_at_max_a2=age_j(find(a2==max_a2));
+    jj_at_max_a2=min(age_j(find(a2==max_a2)));
     fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
 end
 

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -68,7 +68,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=StationaryDist_jj*pi_z;
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     StationaryDist_jj=reshape(StationaryDist_jj,[N_a*N_z,1]);

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -6,8 +6,14 @@ function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDistK
 if exist('simoptions','var')==0
     simoptions=struct();
     simoptions.optimize_nProbs=0;
-elseif ~isfield(simoptions,'optimize_nProbs')
-    simoptions.optimize_nProbs=0;
+    simoptions.verbosed=0;
+else
+    if ~isfield(simoptions,'verbose')
+        simoptions.verbose=0;
+    end
+    if ~isfield(simoptions,'optimize_nProbs')
+        simoptions.optimize_nProbs=0;
+    end
 end
 
 epsilon=1e-7;
@@ -62,7 +68,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=StationaryDist_jj*pi_z;
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,0,jj, epsilon,total_zeros_created,jj_at_max_a2);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,0,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     StationaryDist_jj=reshape(StationaryDist_jj,[N_a*N_z,1]);
@@ -85,23 +91,35 @@ end
 
 StationaryDist=StationaryDist.*AgeWeights;
 
-if total_zeros_created>0
-    fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
-    if isfinite(jj_at_max_a2)
-        fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
+if isfinite(jj_at_max_a2)
+    if N_a2>0
+        warning("Max ExpAsset index %3d first reached at age %3d \n", N_a2, jj_at_max_a2);
     else
-        if N_a2==0
-            temp=reshape(StationaryDist,[N_a1,N_z,N_j]);
-            [a1,z_c,age_j]=ind2sub(size(temp),find(temp~=0));
-            max_a1=max(a1);
-            jj_at_max_a2=min(age_j(find(a1==max_a1)));
-            fprintf("Max (interpolated) Asset index reached = %3d (of %3d) at age %3d \n", max_a1, N_a1, jj_at_max_a2);
-        else
-            temp=reshape(StationaryDist,[N_a1,N_a2,N_z,N_j]);
-            [a1,a2,z_c,age_j]=ind2sub(size(temp),find(temp~=0));
-            max_a2=max(a2);
-            jj_at_max_a2=min(age_j(find(a2==max_a2)));
-            fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+        warning("Max grid-interpolated asset index %3d first reached at age %3d \n", N_a1, jj_at_max_a2);
+    end
+end
+
+if simoptions.verbose
+    if total_zeros_created>0
+        fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+        if ~isfinite(jj_at_max_a2)
+            max_a=nan;
+            if N_a2==0
+                temp=reshape(StationaryDist,[N_a1,N_z,N_j]);
+                [a1,~,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a1);
+                jj_at_max_a2=min(age_j(a1==max_a));
+            else
+                temp=reshape(StationaryDist,[N_a1,N_a2,N_z,N_j]);
+                [~,a2,~,age_j]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a2);
+                jj_at_max_a2=min(age_j(a2==max_a));
+            end
+            if N_a2>0
+                fprintf("Max ExpAsset index reached: %3d (of %3d) at age %3d \n", max_a, N_a2, jj_at_max_a2);
+            else
+                fprintf("Max grid-interpolated asset index reached: %3d (of %3d) at age %3d \n", max_a, N_a1, jj_at_max_a2);
+            end
         end
     end
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -1,11 +1,28 @@
-function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_probs,N_a,N_z,N_j,pi_z_J,Parameters)
+function StationaryDist=StationaryDist_FHorz_Iteration_nProbs_raw(jequaloneDistKron,AgeWeightParamNames,Policy_aprime,PolicyProbs,N_probs,n_a1,n_a2,N_z,N_j,pi_z_J,Parameters)
 % 'nProbs' refers to N_probs probabilities.
 % Policy_aprime has an additional dimension of length N_probs which is the N_probs points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these N_probs.
 
+epsilon=1e-7;
+total_zeros_created=0;
+jj_at_max_a2=Inf;
+
 % Policy_aprime and PolicyProbs are currently [N_a,N_z,N_probs,N_j]
+N_a1=prod(n_a1);
+N_a2=prod(n_a2);
+if N_a2==0
+    N_a=N_a1;
+elseif N_a1==0
+    N_a=N_a2;
+else
+    N_a=N_a1*N_a2;
+end
 Policy_aprimez=Policy_aprime+N_a*gpuArray(0:1:N_z-1);  % Note: add z' index following the z dimension [Tan improvement, z stays where it is]
 Policy_aprimez=gather(reshape(Policy_aprimez,[N_a*N_z,N_probs,N_j])); % sparse() requires inputs to be 2-D
+needs_rounding=(PolicyProbs<epsilon | PolicyProbs>1-epsilon);
+needs_rounding(PolicyProbs==0)=0;
+needs_rounding(PolicyProbs==1)=0;
+PolicyProbs(needs_rounding)=round(PolicyProbs(needs_rounding));
 PolicyProbs=gather(reshape(PolicyProbs,[N_a*N_z,N_probs,N_j])); % sparse() requires inputs to be 2-D
 
 %% Use Tan improvement
@@ -15,20 +32,35 @@ StationaryDist(:,1)=jequaloneDistKron;
 StationaryDist_jj=sparse(gather(jequaloneDistKron)); % use sparse matrix
 
 % Precompute
+II1=(1:1:N_a*N_z)';
 II2=repmat((1:1:N_a*N_z)',1,N_probs); %  Index for this period (a,z), note the N_probs-copies
 
 for jj=1:(N_j-1)
 
     % First, get Gamma
     Gammatranspose=sparse(Policy_aprimez(:,:,jj),II2,PolicyProbs(:,:,jj),N_a*N_z,N_a*N_z); % Note: sparse() will accumulate at repeated indices
+    Gammatranspose_lower=sparse(Policy_aprimez(:,1,jj),II1,PolicyProbs(:,1,jj),N_a*N_z,N_a*N_z);
+    Gammatranspose_upper=sparse(Policy_aprimez(:,2,jj),II1,PolicyProbs(:,2,jj),N_a*N_z,N_a*N_z);
 
     % First step of Tan improvement
+    needs_rounding=full(StationaryDist_jj<epsilon | StationaryDist_jj>1-epsilon);
+    needs_rounding(StationaryDist_jj==0)=0;
+    needs_rounding(StationaryDist_jj==1)=0;
+    StationaryDist_jj(needs_rounding)=round(StationaryDist_jj(needs_rounding));
+    StationaryDist_lower_jj=reshape(Gammatranspose_lower*StationaryDist_jj,[N_a,N_z]);
+    StationaryDist_upper_jj=reshape(Gammatranspose_upper*StationaryDist_jj,[N_a,N_z]);
     StationaryDist_jj=reshape(Gammatranspose*StationaryDist_jj,[N_a,N_z]);
 
     % Second step of Tan improvement
     pi_z=sparse(gather(pi_z_J(:,:,jj)));
-    StationaryDist_jj=reshape(StationaryDist_jj*pi_z,[N_a*N_z,1]);
+    StationaryDist_jj=StationaryDist_jj*pi_z;
+    StationaryDist_lower_jj=StationaryDist_lower_jj*pi_z;
+    StationaryDist_upper_jj=StationaryDist_upper_jj*pi_z;
 
+    [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,StationaryDist_lower_jj,StationaryDist_upper_jj, N_a1,N_a2,N_z,jj, epsilon,total_zeros_created,jj_at_max_a2);
+
+    StationaryDist_jj=reshape(StationaryDist_jj,[N_a*N_z,1]);
+    assert(all(StationaryDist_jj>=0));
     StationaryDist(:,jj+1)=gpuArray(full(StationaryDist_jj));
 end
 
@@ -46,5 +78,16 @@ if size(AgeWeights,2)==1 % If it seems to be a column vector, then transpose it
 end
 
 StationaryDist=StationaryDist.*AgeWeights;
+
+fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+if isfinite(jj_at_max_a2)
+    fprintf("Max ExpAsset value first observed at age %3d \n", jj_at_max_a2);
+else
+    temp=reshape(StationaryDist,[N_a1,N_a2,N_z,N_j]);
+    [a1,a2,z_c,age_j]=ind2sub(size(temp),find(temp~=0));
+    max_a2=max(a2);
+    jj_at_max_a2=age_j(find(a2==max_a2));
+    fprintf("Max ExpAsset index reached = %3d (of %3d) at age %3d \n", max_a2, N_a2, jj_at_max_a2);
+end
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -20,7 +20,6 @@ epsilon=1e-7;
 total_zeros_created=0;
 jj_at_max_a2=Inf;
 
-% Policy_aprime and PolicyProbs are currently [N_a,N_z,N_probs,N_j]
 N_a1=prod(n_a1);
 N_a2=prod(n_a2);
 if N_a2==0
@@ -30,6 +29,7 @@ elseif N_a1==0
 else
     N_a=N_a1*N_a2;
 end
+% Policy_aprime and PolicyProbs are currently [N_a,N_z,N_probs,N_j]
 Policy_aprimez=Policy_aprime+N_a*gpuArray(0:1:N_z-1);  % Note: add z' index following the z dimension [Tan improvement, z stays where it is]
 Policy_aprimez=gather(reshape(Policy_aprimez,[N_a*N_z,N_probs,N_j])); % sparse() requires inputs to be 2-D
 needs_rounding=(PolicyProbs<epsilon | PolicyProbs>1-epsilon);
@@ -110,7 +110,11 @@ if simoptions.verbose
                 max_a=max(a1);
                 jj_at_max_a2=min(age_j(a1==max_a));
             else
-                temp=reshape(StationaryDist,[N_a1,N_a2,N_z,N_j]);
+                if N_a1>0
+                    temp=reshape(StationaryDist,[N_a1,N_a2,N_z,N_j]);
+                else
+                    temp=reshape(StationaryDist,[1,N_a2,N_z,N_j]);
+                end
                 [~,a2,~,age_j]=ind2sub(size(temp),find(temp~=0));
                 max_a=max(a2);
                 jj_at_max_a2=min(age_j(a2==max_a));

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Iteration_nProbs_raw.m
@@ -68,7 +68,7 @@ for jj=1:(N_j-1)
     StationaryDist_jj=StationaryDist_jj*pi_z;
 
     if simoptions.optimize_nProbs==1
-        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
+        [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,n_a1,n_a2,N_z,jj, epsilon,total_zeros_created,jj_at_max_a2,simoptions);
     end
 
     StationaryDist_jj=reshape(StationaryDist_jj,[N_a*N_z,1]);

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -34,7 +34,6 @@ for z_c=1:N_z
     [rows,~]=find(StationaryDist_row_jj~=0);
     for row=unique(rows')
         % Process agents' ExpAssets row by row (i.e., each N_a1 asset mixture)
-        row_prob_sum=full(sum(StationaryDist_row_jj(row,:),2));
 
         % We have two strategies for dealing with gaps.  The first is
         % to see whether the gap disappears when we look at the whole
@@ -139,6 +138,7 @@ for z_c=1:N_z
         for ll=1:length(group_idx)-1
             all_idx=ea_all_idx(group_idx(ll)+1:group_idx(ll+1));
             vals=all_vals_jj(group_idx(ll)+1:group_idx(ll+1));
+            run_prob_sum=sum(vals);
 
             multiplier=all_idx-all_idx(1)+1;
             assert(allunique(multiplier));
@@ -153,8 +153,8 @@ for z_c=1:N_z
                 zero_candidate(cidx)=1;
                 while nnz(vals)>2
                     % Aggressively try to zero out largest indices
-                    new_vals=linsolve([multiplier;ones(1,length(vals));zero_candidate],[sum(vals.*multiplier); row_prob_sum; 0])';
-                    new_vals=round(new_vals,epsilon_round+abs(fix(log10(row_prob_sum))));
+                    new_vals=linsolve([multiplier;ones(1,length(vals));zero_candidate],[sum(vals.*multiplier); run_prob_sum; 0])';
+                    new_vals=round(new_vals,epsilon_round+abs(fix(log10(run_prob_sum))));
                     if all(new_vals==vals) || any(new_vals<0)
                         zero_candidate(cidx)=0;
                         break
@@ -171,8 +171,8 @@ for z_c=1:N_z
                 zero_candidate(cidx)=1;
                 while nnz(vals)>1
                     % Try to zero out least index
-                    new_vals=linsolve([multiplier;ones(1,length(vals));zero_candidate],[sum(vals.*multiplier); row_prob_sum; 0])';
-                    new_vals=round(new_vals,epsilon_round+abs(fix(log10(row_prob_sum))));
+                    new_vals=linsolve([multiplier;ones(1,length(vals));zero_candidate],[sum(vals.*multiplier); run_prob_sum; 0])';
+                    new_vals=round(new_vals,epsilon_round+abs(fix(log10(run_prob_sum))));
                     if all(new_vals==vals) || any(new_vals<0) || any(isnan(new_vals))
                         break
                     end
@@ -182,9 +182,9 @@ for z_c=1:N_z
                     zero_candidate(cidx)=1;
                 end
             end
-            if ~zero_created
+            if false && ~zero_created
                 % Just re-balance the indices (possibly creating a zero in the middle we cannot move to either end of vals
-                new_vals=linsolve([multiplier;ones(1,length(vals))],[sum(vals.*multiplier); row_prob_sum])';
+                new_vals=linsolve([multiplier;ones(1,length(vals))],[sum(vals.*multiplier); run_prob_sum])';
                 new_vals=round(new_vals,epsilon_round);
                 if any(new_vals<0)
                     break

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -1,8 +1,16 @@
-function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z_input,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2)
+function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1_input,N_a2_input,N_z_input,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2)
 
 epsilon_round=7;
 
 new_zeros_created=zeros(1,N_z_input);
+
+if N_a2_input==0
+    N_a2=N_a1_input;
+    N_a1=1;
+else
+    N_a1=N_a1_input;
+    N_a2=N_a2_input;
+end
 
 if N_z_input==0
     N_z=1;

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -1,0 +1,403 @@
+function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,StationaryDist_lower_jj,StationaryDist_upper_jj, N_a1,N_a2,N_z_input,jj, epsilon,total_zeros_created,jj_at_max_a2)
+
+epsilon_round=7;
+
+age_zeros_created=total_zeros_created;
+
+if N_z_input==0
+    N_z=1;
+else
+    N_z=N_z_input;
+end
+
+for z_c=1:N_z
+    if N_z_input==0
+        StationaryDist_rowz_jj=reshape(StationaryDist_jj,[N_a1,N_a2]);
+    else
+        StationaryDist_rowz_jj=reshape(StationaryDist_jj(:,z_c),[N_a1,N_a2]);
+    end
+    probability_z=full(sum(StationaryDist_rowz_jj,'all'));
+    if probability_z==0 || all(arrayfun(@(r) nnz(StationaryDist_rowz_jj(r,:)), 1:size(StationaryDist_rowz_jj,1))<3)
+        % Sometimes nobody chooses the path less taken
+        continue
+    end
+    if jj<jj_at_max_a2 && any(StationaryDist_rowz_jj(:,N_a2)~=0)
+        jj_at_max_a2=jj;
+    end
+    if N_z_input==0
+        StationaryDist_lowerz_jj=reshape(StationaryDist_lower_jj,[N_a1,N_a2]);
+        StationaryDist_upperz_jj=reshape(StationaryDist_upper_jj,[N_a1,N_a2]);
+    else
+        StationaryDist_lowerz_jj=reshape(StationaryDist_lower_jj(:,z_c),[N_a1,N_a2]);
+        StationaryDist_upperz_jj=reshape(StationaryDist_upper_jj(:,z_c),[N_a1,N_a2]);
+    end
+
+    [rows,~]=find(StationaryDist_rowz_jj~=0);
+    for row=unique(rows')
+        % Process agents' ExpAssets row by row (i.e., each N_a1 asset mixture)
+        row_prob_sum=full(sum(StationaryDist_rowz_jj(row,:),2));
+
+        [~,ea_lower_idx,ea_lower_vals]=find(StationaryDist_lowerz_jj(row,:));
+        if isempty(ea_lower_idx)
+            % Swap and try again; the empty half-distribution will not prevent us from getting the job done
+            ea_upper_idx=ea_lower_idx; % empty!!
+            [~,ea_lower_idx,ea_lower_vals]=find(StationaryDist_upperz_jj(row,:));
+            if length(ea_lower_idx)==2
+                % Below we take care of singletons, which might need to evaporate
+                continue
+            end
+        else
+            [~,ea_upper_idx,ea_upper_vals]=find(StationaryDist_upperz_jj(row,:));
+        end
+        noise_vals=(ea_lower_vals/row_prob_sum)<1e-5;
+        noise_vals(find(noise_vals==0,1,'first'):end)=0;
+        if false && any(noise_vals)
+            temp_cols=ea_lower_idx(noise_vals);
+            ea_lower_idx=ea_lower_idx(~noise_vals);
+            ea_lower_vals=ea_lower_vals(~noise_vals);
+            if N_z_input==0
+                StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=0;
+            else
+                StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c),z_c)=0;
+            end
+        end
+
+        if isempty(ea_upper_idx)
+            if isscalar(ea_lower_idx) && row_prob_sum<epsilon && (ea_lower_idx==1 || ea_lower_idx==N_a2)
+                % Allow this infinitesimal to evaporate from grid
+                total_zeros_created=total_zeros_created+nnz(ea_lower_vals);
+                temp=sparse(row,ea_lower_idx,0,N_a1,N_a2);
+                if N_z_input==0
+                    StationaryDist_jj(sub2ind([N_a1,N_a2],row,ea_lower_idx))=temp(row,ea_lower_idx);
+                else
+                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,ea_lower_idx,z_c),z_c)=temp(row,ea_lower_idx);
+                end
+                continue
+            elseif length(ea_lower_idx)<3
+                continue
+            end
+        else
+            noise_vals=(ea_upper_vals/row_prob_sum)<1e-5;
+            noise_vals(1:find(noise_vals==0,1,'last'))=0;
+            if false && any(noise_vals)
+                temp_cols=ea_upper_idx(noise_vals);
+                ea_upper_idx=ea_upper_idx(~noise_vals);
+                ea_upper_vals=ea_upper_vals(~noise_vals);
+                if N_z_input==0
+                    StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=0;
+                else
+                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c),z_c)=0;
+                end
+            end
+
+            if isempty(ea_lower_idx) || isempty(ea_upper_idx) || ea_upper_idx(end)-ea_lower_idx(1)<2
+                continue
+            end
+        end
+
+        % We have two strategies for dealing with gaps.  The first is
+        % to see whether the gap disappears when we look at the whole
+        % picture.  It can happen that lower/upper columns are
+        % disjoint like this: [2 4] [3 5] which gives 4-in-a-row.
+        % If we see we have [2 3 4 5] we have to reconstruct
+        % lower/upper columns somehow.  In this case, it is possible
+        % for a singleton upper to have a lower index than a lower,
+        % so we take care to fix that.
+
+        % The second strategy is to fill in a single hole if that
+        % allows us to connect lower and upper columns.  In the above
+        % case we get [2 3* 4] [3 4* 5] where * means inserted zero.
+        % This is simpler because lower/upper are already split.
+        [~,ea_allz_idx,allz_vals_jj]=find(StationaryDist_rowz_jj(row,:));
+        p=find(diff(ea_allz_idx)>1); % p columns are start and end of consecutive elements
+        runs=[ea_allz_idx(1),ea_allz_idx(p+1);ea_allz_idx(p),ea_allz_idx(end)];
+
+        if size(runs,2)>1
+            single_gaps=ea_allz_idx(p+1)-ea_allz_idx(p)==2;
+            if any(single_gaps)
+                % A zero logically bubbled in...so make space for it for now
+                s=p(single_gaps);
+                z = zeros(1,length(ea_allz_idx)+length(s));  %initialise a new vector of the appropriate size
+                z(s+(1:length(s))) = ea_allz_idx(s)+1; % set locations in 's' to s+1, which will have the value zero
+                z(z==0) = ea_allz_idx; %insert the original values in ea_allz_idx into the new vector at their new positions.
+                ea_allz_idx=z;
+                z = nan(1,length(allz_vals_jj)+length(s));  %initialise a new vector of the appropriate size
+                z(s+(1:length(s))) = 0; % set value locations in 'p' to zero
+                z(isnan(z)) = allz_vals_jj; %insert the original values in allz_vals_jj into the new vector at their new positions.
+                allz_vals_jj=z;
+                ea_gaps=find(diff(ea_allz_idx)>1);
+                p=find(diff(ea_allz_idx)>1); % p columns are start and end of consecutive elements
+                runs=[ea_allz_idx(1),ea_allz_idx(p+1);ea_allz_idx(p),ea_allz_idx(end)];
+                gap_idx=ea_allz_idx(s)';
+                single_gaps=sum(gap_idx>=runs(1,:) & gap_idx<=runs(2,:),1);
+            else
+                single_gaps=zeros(1,size(runs,2));
+            end
+            for ridx=1:size(runs,2)
+                if runs(2,ridx)-runs(1,ridx)<2
+                    % Remove traces of any short sequences
+                    temp=ea_lower_idx<runs(1,ridx) | ea_lower_idx>runs(2,ridx);
+                    ea_lower_idx=ea_lower_idx(temp);
+                    ea_lower_vals=ea_lower_vals(temp);
+                    temp=ea_upper_idx<runs(1,ridx) | ea_upper_idx>runs(2,ridx);
+                    ea_upper_idx=ea_upper_idx(temp);
+                    ea_upper_vals=ea_upper_vals(temp);
+                else
+                    % Fill in zeros for everything we track
+                    ea_lower_end=find(ea_lower_idx>=runs(1,ridx) & ea_lower_idx<=runs(2,ridx),1,'last');
+                    ea_upper_1=find(ea_upper_idx>=runs(1,ridx) & ea_upper_idx<=runs(2,ridx),1,'first');
+                    if ea_lower_idx(ea_lower_end)~=ea_upper_idx(ea_upper_1) || single_gaps(ridx)
+                        % Merging disjoint/overlapping lower and upper
+                        ea_lower_1=find(ea_lower_idx>=runs(1,ridx),1,'first');
+                        if ea_lower_idx(ea_lower_1)>ea_upper_idx(ea_upper_1)
+                            % add zeros to lower so both start at the same index
+                            new_zeros=ea_lower_idx(ea_lower_1)-ea_upper_idx(ea_upper_1);
+                            ea_lower_vals=[zeros(1,new_zeros),ea_lower_vals];
+                            ea_lower_end=ea_lower_end+new_zeros;
+                            ea_lower_idx=[ea_upper_idx(ea_upper_1)+(0:new_zeros-1),ea_lower_idx];
+                        end
+                        if ea_lower_end>ea_lower_1
+                            % Non-singleton, so maybe insert zeros
+                            new_vals=zeros(1,ea_lower_idx(ea_lower_end)-ea_lower_idx(ea_lower_1)+1); % pick up the new zeros
+                            temp=ea_lower_idx>=runs(1,ridx) & ea_lower_idx<=runs(2,ridx);
+                            new_vals(ea_lower_idx(temp)-ea_lower_idx(ea_lower_1)+1)=ea_lower_vals(temp);
+                            ea_lower_vals=[ea_lower_vals(1:ea_lower_1-1), new_vals, ea_lower_vals(ea_lower_end+1:end)];
+                            ea_lower_idx=[ea_lower_idx(1:ea_lower_1-1), ea_lower_idx(ea_lower_1):ea_lower_idx(ea_lower_end), ea_lower_idx(ea_lower_end+1:end)];
+                        end
+                        ea_upper_end=find(ea_upper_idx<=runs(2,ridx),1,'last');
+                        if ea_upper_end>ea_upper_1
+                            % Non-singleton, so maybe insert zeros
+                            new_vals=zeros(1,ea_upper_idx(ea_upper_end)-ea_upper_idx(ea_upper_1)+1); % pick up the new zeros
+                            temp=ea_upper_idx>=runs(1,ridx) & ea_upper_idx<=runs(2,ridx);
+                            new_vals(ea_upper_idx(temp)-ea_upper_idx(ea_upper_1)+1)=ea_upper_vals(temp);
+                            ea_upper_vals=[ea_upper_vals(1:ea_upper_1-1), new_vals, ea_upper_vals(ea_upper_end+1:end)];
+                            ea_upper_idx=[ea_upper_idx(1:ea_upper_1-1), ea_upper_idx(ea_upper_1):ea_upper_idx(ea_upper_end), ea_upper_idx(ea_upper_end+1:end)];
+                        end
+                    else
+                        continue
+                    end
+                end
+            end
+            runs=runs(:,runs(2,:)-runs(1,:)>1);
+            if isempty(runs)
+                % We have disqualified all merging opportunities
+                continue
+            elseif size(runs,2)==1
+                ea_gaps=[];
+            else
+                ea_gaps=find(diff(ea_allz_idx)>1);
+            end
+        else
+            if ea_lower_idx(end)-ea_lower_idx(1)>=length(ea_lower_idx)
+                % We have no gaps in the big picture, but lower gaps
+                p=find(diff(ea_lower_idx)>1); % p columns are start and end of consecutive elements
+                runs=[ea_lower_idx(1),ea_lower_idx(p+1);ea_lower_idx(p),ea_lower_idx(end)];
+                z = zeros(1,length(ea_lower_idx)+length(p));  %initialise a new vector of the appropriate size
+                z(p+(1:length(p))) = ea_lower_idx(p)+1; % set locations in 'p' to p+1, which will have the value zero
+                z(z==0) = ea_lower_idx; %insert the original values in ea_lower_idx into the new vector at their new positions.
+                ea_lower_idx=z;
+                z = nan(1,length(ea_lower_vals)+length(p));  %initialise a new vector of the appropriate size
+                z(p+(1:length(p))) = 0; % set value locations in 'p' to zero
+                z(isnan(z)) = ea_lower_vals; %insert the original values in ea_lower_vals into the new vector at their new positions.
+                ea_lower_vals=z;
+            end
+            if ea_upper_idx(end)-ea_upper_idx(1)>=length(ea_upper_idx)
+                % We have no gaps in the big picture, but upper gaps
+                p=find(diff(ea_upper_idx)>1); % p columns are start and end of consecutive elements
+                runs=[ea_upper_idx(1),ea_upper_idx(p+1);ea_upper_idx(p),ea_upper_idx(end)];
+                z = zeros(1,length(ea_upper_idx)+length(p));  %initialise a new vector of the appropriate size
+                z(p+(1:length(p))) = ea_upper_idx(p)+1; % set locations in 'p' to p+1, which will have the value zero
+                z(z==0) = ea_upper_idx; %insert the original values in ea_upper_idx into the new vector at their new positions.
+                ea_upper_idx=z;
+                z = nan(1,length(ea_upper_vals)+length(p));  %initialise a new vector of the appropriate size
+                z(p+(1:length(p))) = 0; % set value locations in 'p' to zero
+                z(isnan(z)) = ea_upper_vals; %insert the original values in ea_upper_vals into the new vector at their new positions.
+                ea_upper_vals=z;
+            end
+            ea_gaps=[];
+        end
+
+        [ea_lower_idx,sort_idx]=sort(ea_lower_idx);
+        ea_lower_vals=ea_lower_vals(sort_idx);
+        if isempty(ea_gaps)
+            lower_gaps=ea_gaps;
+        else
+            lower_gaps=find(diff(ea_lower_idx)>1);
+        end
+
+        group_lower_idx=[0,lower_gaps,length(ea_lower_idx)];
+        for ll=1:length(group_lower_idx)-1
+            ea_group_lower_idx=ea_lower_idx(group_lower_idx(ll)+1:group_lower_idx(ll+1));
+            lower_vals=ea_lower_vals(group_lower_idx(ll)+1:group_lower_idx(ll+1));
+
+            multiplier_lower=ea_group_lower_idx-ea_group_lower_idx(1)'+1;
+
+            if isempty(ea_upper_idx)
+                if nnz(lower_vals)>2
+                    % Attempt to consolidate lower into itself
+                    assert(false);
+                    for ii=1:length(lower_vals)-1
+                        if sum(lower_vals(ii:end).*multiplier_lower(ii:end))/multiplier_lower(1)<=row_prob_sum
+                            lower_vals(ii)=sum(lower_vals(ii:end).*multiplier_lower(ii:end))/multiplier_lower(1);
+                            temp=sparse(row,ea_group_lower_idx(1:ii),lower_vals(1:ii),N_a1,N_a2);
+                            temp_cols=ea_group_lower_idx(1):ea_group_lower_idx(end);
+                            if N_z_input
+                                StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
+                            else
+                                StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c),z_c)=temp(row,temp_cols);
+                            end
+                            break
+                        end
+                    end
+                else
+                    continue
+                end
+            end
+
+            % Attempt to consolidate upper and lower
+            [ea_upper_idx,sort_idx]=sort(ea_upper_idx);
+            ea_upper_vals=ea_upper_vals(sort_idx);
+            if isempty(ea_gaps)
+                upper_gaps=ea_gaps;
+            else
+                upper_gaps=find(diff(ea_upper_idx)>1);
+            end
+
+            group_upper_idx=[0,upper_gaps,length(ea_upper_idx)];
+            assert(length(group_lower_idx)==length(group_upper_idx))
+            uu=ll; % we keep these two in sync
+            ea_group_upper_idx=ea_upper_idx(group_upper_idx(uu)+1:group_upper_idx(uu+1));
+            upper_vals=ea_upper_vals(group_upper_idx(uu)+1:group_upper_idx(uu+1));
+
+            multiplier_upper=ea_group_upper_idx-ea_group_lower_idx(1)+1;
+
+            sum_lower=sum(lower_vals.*multiplier_lower);
+            sum_upper=sum(upper_vals.*multiplier_upper);
+            starting_zeros=sum(lower_vals==0)+sum(upper_vals==0);
+
+            if length(unique(multiplier_lower))>1 && (sum_upper+sum_lower)/multiplier_lower(end)<=row_prob_sum
+                % We can fit all the upper values into slots allocated to lower with a basis to work with
+                lower_vals(end)=lower_vals(end)+sum_upper/multiplier_lower(end);
+                % But in so doing, we may have probabilities that sum>1, so fix
+                zero_created=false;
+                if length(lower_vals)>2
+                    next_candidate=length(lower_vals);
+                    zero_candidate=zeros(1,next_candidate);
+                    zero_candidate(next_candidate)=1;
+                    while nnz(lower_vals)>1
+                        % Aggressively try to zero out largest indices
+                        new_vals=linsolve([multiplier_lower;ones(1,length(lower_vals));zero_candidate],[sum(lower_vals.*multiplier_lower); row_prob_sum; 0])';
+                        new_vals=round(new_vals,epsilon_round);
+                        if all(new_vals==lower_vals) || any(new_vals<0)
+                            break
+                        end
+                        lower_vals=new_vals;
+                        zero_created=true;
+                        next_candidate=find(zero_candidate==0,1,'last');
+                        zero_candidate(next_candidate)=1;
+                    end
+                    if zero_created
+                        zero_candidate(next_candidate)=0;
+                    end
+                    next_candidate=1;
+                    zero_candidate(next_candidate)=1;
+                    while nnz(lower_vals)>1
+                        % Try to zero out least index
+                        new_vals=linsolve([multiplier_lower;ones(1,length(lower_vals));zero_candidate],[sum(lower_vals.*multiplier_lower); row_prob_sum; 0])';
+                        new_vals=round(new_vals,epsilon_round);
+                        if all(new_vals==lower_vals) || any(new_vals<0) || any(isnan(new_vals))
+                            break
+                        end
+                        lower_vals=new_vals;
+                        zero_created=true;
+                        next_candidate=find(zero_candidate==0,1,'first');
+                        zero_candidate(next_candidate)=1;
+                    end
+                end
+                if ~zero_created
+                    % Just re-balance the indices (possibly creating a zero in the middle we cannot move to either end of lower_vals
+                    new_vals=linsolve([multiplier_lower;ones(1,length(lower_vals))],[sum(lower_vals.*multiplier_lower); row_prob_sum])';
+                    new_vals=round(new_vals,epsilon_round);
+                    if any(new_vals<0)
+                        break
+                    end
+                    lower_vals=new_vals;
+                end
+                temp=sparse(row,ea_group_lower_idx,lower_vals,N_a1,N_a2);
+                temp_cols=ea_group_lower_idx(1):ea_group_upper_idx(end);
+                if N_z_input
+                    StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
+                else
+                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c),z_c)=temp(row,temp_cols);
+                end
+                total_zeros_created=total_zeros_created+sum(lower_vals==0)+length(upper_vals)-starting_zeros;
+                continue
+            elseif length(unique(multiplier_upper))>1 && sum_lower/multiplier_upper(end-1)+sum(upper_vals)<=row_prob_sum
+                % We can fit all the lower values into slots allocated to upper with a basis to work with
+                upper_vals(end-1)=upper_vals(end-1)+sum_lower/multiplier_upper(end-1);
+                % But in so doing, we may have probabilities that sum>1, so fix
+                zero_created=false;
+                if length(upper_vals)>2
+                    next_candidate=length(upper_vals);
+                    zero_candidate=zeros(1,next_candidate);
+                    zero_candidate(next_candidate)=1;
+                    while nnz(upper_vals)>1
+                        % Aggressively try to zero out largest indices
+                        new_vals=linsolve([multiplier_upper;ones(1,length(upper_vals));zero_candidate],[sum(upper_vals.*multiplier_upper); row_prob_sum; 0])';
+                        new_vals=round(new_vals,epsilon_round);
+                        if all(new_vals==upper_vals) || any(new_vals<0) || any(isnan(new_vals))
+                            break
+                        end
+                        upper_vals=new_vals;
+                        zero_created=true;
+                        next_candidate=find(zero_candidate==0,1,'last');
+                        zero_candidate(next_candidate)=1;
+                    end
+                    if zero_created
+                        zero_candidate(next_candidate)=0;
+                    end
+                    next_candidate=1;
+                    zero_candidate(next_candidate)=1;
+                    while nnz(upper_vals)>1
+                        % Try to zero out least index
+                        new_vals=linsolve([multiplier_upper;ones(1,length(upper_vals));zero_candidate],[sum(upper_vals.*multiplier_upper); row_prob_sum; 0])';
+                        new_vals=round(new_vals,epsilon_round);
+                        if all(new_vals==upper_vals) || any(new_vals<0)
+                            break
+                        end
+                        upper_vals=new_vals;
+                        zero_created=true;
+                        next_candidate=find(zero_candidate==0,1,'first');
+                        zero_candidate(next_candidate)=1;
+                    end
+                end
+                if ~zero_created
+                    % Just re-balance the indices (possibly creating a zero in the middle we cannot move to either end of lower_vals
+                    new_vals=linsolve([multiplier_upper;ones(1,length(upper_vals))],[sum(upper_vals.*multiplier_upper); row_prob_sum])';
+                    new_vals=round(new_vals,epsilon_round);
+                    if any(new_vals<0)
+                        break
+                    end
+                    upper_vals=new_vals;
+                end
+                temp=sparse(row,ea_group_upper_idx,upper_vals,N_a1,N_a2);
+                temp_cols=ea_group_lower_idx(1):ea_group_upper_idx(end);
+                if N_z_input
+                    StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
+                else
+                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c),z_c)=temp(row,temp_cols);
+                end
+                total_zeros_created=total_zeros_created+sum(upper_vals==0)+length(lower_vals)-starting_zeros;
+                continue
+            elseif length(unique(multiplier_upper))>2
+                % Attempt to consolidate upper into itself
+                assert(false);
+            end
+        end
+    end
+end
+
+fprintf("Age %3d: zeros created = %d \n", jj, total_zeros_created-age_zeros_created);
+
+
+end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -1,9 +1,9 @@
-function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1_input,N_a2_input,N_z_input,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2, simoptions)
+function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1_input,N_a2_input,N_z_input,jj, epsilon,total_zeros_created,jj_at_max_a2, simoptions)
 
 epsilon_round=7;
 
-new_zeros_created=zeros(1,N_z_input);
-
+% For grid interpolation, N_a2 arrives as zero.  We simplify the implementation
+% by treating this N_a1x1 grid as an 1xN_a1 grid (with N_a1 spelled N_a2 below).
 if N_a2_input==0
     N_a2=N_a1_input;
     N_a1=1;
@@ -12,13 +12,20 @@ else
     N_a2=N_a2_input;
 end
 
+% Remember whether we want to return [N_a*N_z,1] or [N_a,N_z]
+StationaryDist_jj_size=size(StationaryDist_jj);
+
 if N_z_input==0
     N_z=1;
 else
     N_z=N_z_input;
+    if StationaryDist_jj_size(2)==1 && N_z>1
+        % For our purposes, we need to unmix N_z from N_a
+        StationaryDist_jj=reshape(StationaryDist_jj,[N_a1*N_a2,N_z]);
+    end
 end
 
-assert(N_e==0); % haven't implemented N_e of any kind yet
+new_zeros_created=zeros(1,N_z);
 
 % For large N_z, this loop can be changed to `parfor` for greater CPU parallelism
 for z_c=1:N_z
@@ -147,6 +154,9 @@ if simoptions.verbose>=1
         fprintf("Age %3d: zeros created = %d \n", jj, sum_new_zeros);
     end
 end
+
+% Re-mix N_a and N_z if necessary
+StationaryDist_jj=reshape(StationaryDist_jj,StationaryDist_jj_size);
 
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -1,4 +1,4 @@
-function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,StationaryDist_lower_jj_in,StationaryDist_upper_jj_in, N_a1,N_a2,N_z_input,jj, epsilon,total_zeros_created,jj_at_max_a2)
+function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z_input,jj, epsilon,total_zeros_created,jj_at_max_a2)
  
 epsilon_round=7;
 
@@ -16,55 +16,19 @@ for z_c=1:N_z
     else
         StationaryDist_row_jj=reshape(StationaryDist_jj(:,z_c),[N_a1,N_a2]);
     end
-    probability_z=full(sum(StationaryDist_row_jj,'all'));
-    if probability_z==0 || all(arrayfun(@(r) nnz(StationaryDist_row_jj(r,:)), 1:size(StationaryDist_row_jj,1))<3)
+    row_prob_sum=full(sum(StationaryDist_row_jj,'all'));
+    if row_prob_sum==0 || all(arrayfun(@(r) nnz(StationaryDist_row_jj(r,:)), 1:size(StationaryDist_row_jj,1))<3)
         % Sometimes nobody chooses the path less taken
         continue
     end
     if jj<jj_at_max_a2 && any(StationaryDist_row_jj(:,N_a2)~=0)
         jj_at_max_a2=jj;
     end
-    if N_z_input==0
-        StationaryDist_lower_jj=reshape(StationaryDist_lower_jj_in,[N_a1,N_a2]);
-        StationaryDist_upper_jj=reshape(StationaryDist_upper_jj_in,[N_a1,N_a2]);
-    else
-        StationaryDist_lower_jj=reshape(StationaryDist_lower_jj_in(:,z_c),[N_a1,N_a2]);
-        StationaryDist_upper_jj=reshape(StationaryDist_upper_jj_in(:,z_c),[N_a1,N_a2]);
-    end
 
     [rows,~]=find(StationaryDist_row_jj~=0);
     for row=unique(rows')
         % Process agents' ExpAssets row by row (i.e., each N_a1 asset mixture)
         row_prob_sum=full(sum(StationaryDist_row_jj(row,:),2));
-
-        [~,ea_lower_idx,ea_lower_vals]=find(StationaryDist_lower_jj(row,:));
-        if isempty(ea_lower_idx)
-            % Swap and try again; the empty half-distribution will not prevent us from getting the job done
-            ea_upper_idx=ea_lower_idx; % empty!!
-            [~,ea_lower_idx,ea_lower_vals]=find(StationaryDist_upper_jj(row,:));
-            if length(ea_lower_idx)==2
-                % Below we take care of singletons, which might need to evaporate
-                continue
-            end
-        else
-            [~,ea_upper_idx,ea_upper_vals]=find(StationaryDist_upper_jj(row,:));
-        end
-
-        if isempty(ea_upper_idx)
-            if isscalar(ea_lower_idx) && row_prob_sum<epsilon && (ea_lower_idx==1 || ea_lower_idx==N_a2)
-                % Allow this infinitesimal to evaporate from this otherwise empty row
-                total_zeros_created=total_zeros_created+1;
-                temp=sparse(row,ea_lower_idx,0,N_a1,N_a2);
-                if N_z_input==0
-                    StationaryDist_jj(sub2ind([N_a1,N_a2],row,ea_lower_idx))=temp(row,ea_lower_idx);
-                else
-                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,ea_lower_idx,z_c))=temp(row,ea_lower_idx);
-                end
-                continue
-            elseif length(ea_lower_idx)<3
-                continue
-            end
-        end
 
         % We have two strategies for dealing with gaps.  The first is
         % to see whether the gap disappears when we look at the whole
@@ -99,60 +63,37 @@ for z_c=1:N_z
                 runs=[ea_all_idx(1),ea_all_idx(p+1);ea_all_idx(p),ea_all_idx(end)];
                 gap_idx=ea_all_idx(s)';
                 single_gaps=sum(gap_idx>=runs(1,:) & gap_idx<=runs(2,:),1);
+                all_vals_jj=z;
             else
                 single_gaps=zeros(1,size(runs,2));
             end
             for ridx=1:size(runs,2)
                 if runs(2,ridx)-runs(1,ridx)<2
                     % Remove traces of any short sequences
-                    temp=ea_lower_idx<runs(1,ridx) | ea_lower_idx>runs(2,ridx);
-                    ea_lower_idx=ea_lower_idx(temp);
-                    ea_lower_vals=ea_lower_vals(temp);
-                    temp=ea_upper_idx<runs(1,ridx) | ea_upper_idx>runs(2,ridx);
-                    ea_upper_idx=ea_upper_idx(temp);
-                    ea_upper_vals=ea_upper_vals(temp);
+                    temp=ea_all_idx<runs(1,ridx) | ea_all_idx>runs(2,ridx);
+                    ea_all_idx=ea_all_idx(temp);
+                    all_vals_jj=all_vals_jj(temp);
                 else
                     % Fill in zeros for everything we track
-                    ea_lower_1=find(ea_lower_idx>=runs(1,ridx),1,'first');
-                    ea_lower_end=find(ea_lower_idx>=runs(1,ridx) & ea_lower_idx<=runs(2,ridx),1,'last');
-                    ea_upper_1=find(ea_upper_idx>=runs(1,ridx) & ea_upper_idx<=runs(2,ridx),1,'first');
-                    ea_upper_end=find(ea_upper_idx<=runs(2,ridx),1,'last');
+                    valid_ridx=ea_all_idx>=runs(1,ridx) & ea_all_idx<=runs(2,ridx);
+                    if ~any(valid_ridx)
+                        continue
+                    end
+                    ea_1=find(valid_ridx,1,'first');
+                    ea_end=find(valid_ridx,1,'last');
                     if ~any(single_gaps(ridx))
                         % Check for single gaps intra lower/upper
-                        if any(diff(ea_lower_idx(ea_lower_1:ea_lower_end))==2)
-                            single_gaps(ridx)=true;
-                        end
-                        if any(diff(ea_upper_idx(ea_upper_1:ea_upper_end))==2)
+                        if any(diff(ea_all_idx(ea_1:ea_end))==2)
                             single_gaps(ridx)=true;
                         end
                     end
-                    if ea_lower_idx(ea_lower_end)~=ea_upper_idx(ea_upper_1) || any(single_gaps(ridx))
-                        % Merging disjoint/overlapping lower and upper
-                        if ea_lower_idx(ea_lower_1)>ea_upper_idx(ea_upper_1)
-                            % add zeros to lower so both start at the same index
-                            new_zeros=ea_lower_idx(ea_lower_1)-ea_upper_idx(ea_upper_1);
-                            ea_lower_vals=[zeros(1,new_zeros),ea_lower_vals];
-                            ea_lower_end=ea_lower_end+new_zeros;
-                            ea_lower_idx=[ea_upper_idx(ea_upper_1)+(0:new_zeros-1),ea_lower_idx];
-                        end
-                        if ea_lower_end>ea_lower_1
-                            % Non-singleton, so maybe insert zeros; note ea_lower_idx is continuous, so ea_lower_idx(ea_lower_end)-ea_lower_idx(ea_lower_1)==ea_lower_end-ea_lower_1
-                            new_vals=zeros(1,ea_lower_end-ea_lower_1+1); % pick up the new zeros
-                            temp=ea_lower_idx>=runs(1,ridx) & ea_lower_idx<=runs(2,ridx);
-                            new_vals(ea_lower_idx(temp)-ea_lower_idx(ea_lower_1)+1)=ea_lower_vals(temp);
-                            ea_lower_vals=[ea_lower_vals(1:ea_lower_1-1), new_vals, ea_lower_vals(ea_lower_end+1:end)];
-                            ea_lower_idx=[ea_lower_idx(1:ea_lower_1-1), ea_lower_idx(ea_lower_1):ea_lower_idx(ea_lower_end), ea_lower_idx(ea_lower_end+1:end)];
-                        end
-                        if ea_upper_end>ea_upper_1
-                            % Non-singleton, so maybe insert zeros
-                            new_vals=zeros(1,ea_upper_end-ea_upper_1+1); % pick up the new zeros
-                            temp=ea_upper_idx>=runs(1,ridx) & ea_upper_idx<=runs(2,ridx);
-                            new_vals(ea_upper_idx(temp)-ea_upper_idx(ea_upper_1)+1)=ea_upper_vals(temp);
-                            ea_upper_vals=[ea_upper_vals(1:ea_upper_1-1), new_vals, ea_upper_vals(ea_upper_end+1:end)];
-                            ea_upper_idx=[ea_upper_idx(1:ea_upper_1-1), ea_upper_idx(ea_upper_1):ea_upper_idx(ea_upper_end), ea_upper_idx(ea_upper_end+1:end)];
-                        end
-                    else
-                        continue
+                    if ea_end>ea_1 || any(single_gaps(ridx))
+                        % Non-singleton, so maybe insert zeros; note ea_lower_idx is continuous, so ea_lower_idx(ea_lower_end)-ea_lower_idx(ea_lower_1)==ea_lower_end-ea_lower_1
+                        new_vals=zeros(1,ea_end-ea_1+1); % pick up the new zeros
+                        temp=ea_all_idx>=runs(1,ridx) & ea_all_idx<=runs(2,ridx);
+                        new_vals(ea_all_idx(temp)-ea_all_idx(ea_1)+1)=all_vals_jj(temp);
+                        all_vals_jj=[all_vals_jj(1:ea_1-1), new_vals, all_vals_jj(ea_end+1:end)];
+                        ea_all_idx=[ea_all_idx(1:ea_1-1), ea_all_idx(ea_1):ea_all_idx(ea_end), ea_all_idx(ea_end+1:end)];
                     end
                 end
             end
@@ -164,218 +105,94 @@ for z_c=1:N_z
                 ea_gaps_isempty=size(runs,2)==1;
             end
         else
-            if ea_lower_idx(end)-ea_lower_idx(1)>=length(ea_lower_idx)
+            if ea_all_idx(end)-ea_all_idx(1)>=length(ea_all_idx)
                 % We have no gaps in the big picture, but lower gaps
-                p=find(diff(ea_lower_idx)>1); % p columns are start and end of consecutive elements
-                runs=[ea_lower_idx(1),ea_lower_idx(p+1);ea_lower_idx(p),ea_lower_idx(end)];
-                z = zeros(1,length(ea_lower_idx)+length(p));  %initialise a new vector of the appropriate size
-                z(p+(1:length(p))) = ea_lower_idx(p)+1; % set locations in 'p' to p+1, which will have the value zero
-                z(z==0) = ea_lower_idx; %insert the original values in ea_lower_idx into the new vector at their new positions.
-                ea_lower_idx=z;
-                z = nan(1,length(ea_lower_vals)+length(p));  %initialise a new vector of the appropriate size
+                p=find(diff(ea_all_idx)>1); % p columns are start and end of consecutive elements
+                runs=[ea_all_idx(1),ea_all_idx(p+1);ea_all_idx(p),ea_all_idx(end)];
+                z = zeros(1,length(ea_all_idx)+length(p));  %initialise a new vector of the appropriate size
+                z(p+(1:length(p))) = ea_all_idx(p)+1; % set locations in 'p' to p+1, which will have the value zero
+                z(z==0) = ea_all_idx; %insert the original values in ea_lower_idx into the new vector at their new positions.
+                ea_all_idx=z;
+                z = nan(1,length(all_vals_jj)+length(p));  %initialise a new vector of the appropriate size
                 z(p+(1:length(p))) = 0; % set value locations in 'p' to zero
-                z(isnan(z)) = ea_lower_vals; %insert the original values in ea_lower_vals into the new vector at their new positions.
+                z(isnan(z)) = all_vals_jj; %insert the original values in ea_lower_vals into the new vector at their new positions.
                 ea_lower_vals=z;
-            end
-            if ea_upper_idx(end)-ea_upper_idx(1)>=length(ea_upper_idx)
-                % We have no gaps in the big picture, but upper gaps
-                p=find(diff(ea_upper_idx)>1); % p columns are start and end of consecutive elements
-                runs=[ea_upper_idx(1),ea_upper_idx(p+1);ea_upper_idx(p),ea_upper_idx(end)];
-                z = zeros(1,length(ea_upper_idx)+length(p));  %initialise a new vector of the appropriate size
-                z(p+(1:length(p))) = ea_upper_idx(p)+1; % set locations in 'p' to p+1, which will have the value zero
-                z(z==0) = ea_upper_idx; %insert the original values in ea_upper_idx into the new vector at their new positions.
-                ea_upper_idx=z;
-                z = nan(1,length(ea_upper_vals)+length(p));  %initialise a new vector of the appropriate size
-                z(p+(1:length(p))) = 0; % set value locations in 'p' to zero
-                z(isnan(z)) = ea_upper_vals; %insert the original values in ea_upper_vals into the new vector at their new positions.
-                ea_upper_vals=z;
             end
             ea_gaps_isempty=true;
         end
 
-        [ea_lower_idx,sort_idx]=sort(ea_lower_idx);
-        ea_lower_vals=ea_lower_vals(sort_idx);
+        [ea_all_idx,sort_idx]=sort(ea_all_idx);
+        all_vals_jj=all_vals_jj(sort_idx);
         if ea_gaps_isempty
-            lower_gaps=[];
+            ea_gaps=[];
         else
-            lower_gaps=find(diff(ea_lower_idx)>1);
+            ea_gaps=find(diff(ea_all_idx)>1);
         end
 
-        group_lower_idx=[0,lower_gaps,length(ea_lower_idx)];
-        for ll=1:length(group_lower_idx)-1
-            lower_idx=ea_lower_idx(group_lower_idx(ll)+1:group_lower_idx(ll+1));
-            lower_vals=ea_lower_vals(group_lower_idx(ll)+1:group_lower_idx(ll+1));
+        group_idx=[0,ea_gaps,length(ea_all_idx)];
+        for ll=1:length(group_idx)-1
+            all_idx=ea_all_idx(group_idx(ll)+1:group_idx(ll+1));
+            vals=all_vals_jj(group_idx(ll)+1:group_idx(ll+1));
 
-            multiplier_lower=lower_idx-lower_idx(1)+1;
-            assert(allunique(multiplier_lower));
+            multiplier=all_idx-all_idx(1)+1;
+            assert(allunique(multiplier));
 
-            if isempty(ea_upper_idx)
-                if nnz(lower_vals)>2
-                    % Attempt to consolidate lower into itself
-                    assert(false);
-                    for ii=1:length(lower_vals)-1
-                        if sum(lower_vals(ii:end).*multiplier_lower(ii:end))/multiplier_lower(1)<=row_prob_sum
-                            lower_vals(ii)=sum(lower_vals(ii:end).*multiplier_lower(ii:end))/multiplier_lower(1);
-                            temp=sparse(row,lower_idx(1:ii),lower_vals(1:ii),N_a1,N_a2);
-                            temp_cols=lower_idx(1):lower_idx(end);
-                            if N_z_input==0
-                                StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
-                            else
-                                StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c))=temp(row,temp_cols);
-                            end
-                            break
-                        end
+            % Attempt to consolidate min and max values to the middle
+            starting_zeros=sum(vals==0);
+
+            zero_created=false;
+            if length(vals)>2
+                cidx=length(vals);
+                zero_candidate=zeros(1,cidx);
+                zero_candidate(cidx)=1;
+                while nnz(vals)>2
+                    % Aggressively try to zero out largest indices
+                    new_vals=linsolve([multiplier;ones(1,length(vals));zero_candidate],[sum(vals.*multiplier); row_prob_sum; 0])';
+                    new_vals=round(new_vals,epsilon_round+abs(fix(log10(row_prob_sum))));
+                    if all(new_vals==vals) || any(new_vals<0)
+                        zero_candidate(cidx)=0;
+                        break
                     end
-                else
-                    continue
+                    vals=new_vals;
+                    zero_created=true;
+                    cidx=find(zero_candidate==0,1,'last');
+                    zero_candidate(cidx)=1;
+                end
+                if zero_created
+                    zero_candidate(cidx)=0;
+                end
+                cidx=1;
+                zero_candidate(cidx)=1;
+                while nnz(vals)>1
+                    % Try to zero out least index
+                    new_vals=linsolve([multiplier;ones(1,length(vals));zero_candidate],[sum(vals.*multiplier); row_prob_sum; 0])';
+                    new_vals=round(new_vals,epsilon_round+abs(fix(log10(row_prob_sum))));
+                    if all(new_vals==vals) || any(new_vals<0) || any(isnan(new_vals))
+                        break
+                    end
+                    vals=new_vals;
+                    zero_created=true;
+                    cidx=find(zero_candidate==0,1,'first');
+                    zero_candidate(cidx)=1;
                 end
             end
-
-            % Attempt to consolidate upper and lower
-            [ea_upper_idx,sort_idx]=sort(ea_upper_idx);
-            ea_upper_vals=ea_upper_vals(sort_idx);
-            if ea_gaps_isempty
-                upper_gaps=[];
+            if ~zero_created
+                % Just re-balance the indices (possibly creating a zero in the middle we cannot move to either end of vals
+                new_vals=linsolve([multiplier;ones(1,length(vals))],[sum(vals.*multiplier); row_prob_sum])';
+                new_vals=round(new_vals,epsilon_round);
+                if any(new_vals<0)
+                    break
+                end
+                vals=new_vals;
+            end
+            temp=sparse(row,all_idx,vals,N_a1,N_a2);
+            temp_cols=all_idx(1):all_idx(end);
+            if N_z_input==0
+                StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
             else
-                upper_gaps=find(diff(ea_upper_idx)>1);
+                StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c))=temp(row,temp_cols);
             end
-
-            group_upper_idx=[0,upper_gaps,length(ea_upper_idx)];
-            assert(length(group_lower_idx)==length(group_upper_idx))
-            uu=ll; % we keep these two in sync
-            upper_idx=ea_upper_idx(group_upper_idx(uu)+1:group_upper_idx(uu+1));
-            upper_vals=ea_upper_vals(group_upper_idx(uu)+1:group_upper_idx(uu+1));
-
-            multiplier_upper=upper_idx-lower_idx(1)+1;
-            assert(allunique(multiplier_upper));
-
-            sum_lower=sum(lower_vals.*multiplier_lower);
-            sum_upper=sum(upper_vals.*multiplier_upper);
-            starting_zeros=sum(lower_vals==0)+sum(upper_vals==0);
-
-            if length(multiplier_lower)>1 && (sum_upper+sum_lower)/multiplier_lower(end)<=row_prob_sum
-                % We can fit all the upper values into slots allocated to lower with a basis to work with
-                lower_vals(end)=lower_vals(end)+sum_upper/multiplier_lower(end);
-                % But in so doing, we may have probabilities that sum>1, so fix
-                zero_created=false;
-                if length(lower_vals)>2
-                    next_candidate=length(lower_vals);
-                    zero_candidate=zeros(1,next_candidate);
-                    zero_candidate(next_candidate)=1;
-                    while nnz(lower_vals)>1
-                        % Aggressively try to zero out largest indices
-                        new_vals=linsolve([multiplier_lower;ones(1,length(lower_vals));zero_candidate],[sum(lower_vals.*multiplier_lower); row_prob_sum; 0])';
-                        new_vals=round(new_vals,epsilon_round);
-                        if all(new_vals==lower_vals) || any(new_vals<0)
-                            break
-                        end
-                        lower_vals=new_vals;
-                        zero_created=true;
-                        next_candidate=find(zero_candidate==0,1,'last');
-                        zero_candidate(next_candidate)=1;
-                    end
-                    if zero_created
-                        zero_candidate(next_candidate)=0;
-                    end
-                    next_candidate=1;
-                    zero_candidate(next_candidate)=1;
-                    while nnz(lower_vals)>1
-                        % Try to zero out least index
-                        new_vals=linsolve([multiplier_lower;ones(1,length(lower_vals));zero_candidate],[sum(lower_vals.*multiplier_lower); row_prob_sum; 0])';
-                        new_vals=round(new_vals,epsilon_round);
-                        if all(new_vals==lower_vals) || any(new_vals<0) || any(isnan(new_vals))
-                            break
-                        end
-                        lower_vals=new_vals;
-                        zero_created=true;
-                        next_candidate=find(zero_candidate==0,1,'first');
-                        zero_candidate(next_candidate)=1;
-                    end
-                end
-                if ~zero_created
-                    % Just re-balance the indices (possibly creating a zero in the middle we cannot move to either end of lower_vals
-                    new_vals=linsolve([multiplier_lower;ones(1,length(lower_vals))],[sum(lower_vals.*multiplier_lower); row_prob_sum])';
-                    new_vals=round(new_vals,epsilon_round);
-                    if any(new_vals<0)
-                        break
-                    end
-                    lower_vals=new_vals;
-                end
-                temp=sparse(row,lower_idx,lower_vals,N_a1,N_a2);
-                temp_cols=lower_idx(1):upper_idx(end);
-                if N_z_input==0
-                    StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
-                else
-                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c))=temp(row,temp_cols);
-                end
-                total_zeros_created=total_zeros_created+sum(lower_vals==0)+length(upper_vals)-starting_zeros;
-                continue
-            elseif length(multiplier_upper)>1
-                if sum_lower/multiplier_upper(end-1)+sum(upper_vals)<=row_prob_sum
-                    % We can fit all the lower values into slots allocated to upper(end-1) with a basis to work with...
-                    upper_vals(end-1)=upper_vals(end-1)+sum_lower/multiplier_upper(end-1);
-                elseif sum_lower/multiplier_upper(end)+sum(upper_vals)<=row_prob_sum
-                    % We can fit all the lower values into slots allocated to upper(end) with a basis to work with...
-                    upper_vals(end)=upper_vals(end)+sum_lower/multiplier_upper(end);
-                elseif length(multiplier_upper)>2
-                    % Attempt to consolidate upper into itself
-                    assert(false);
-                end
-                % But in so doing, we may have probabilities that sum>1, so fix
-                zero_created=false;
-                if length(upper_vals)>2
-                    next_candidate=length(upper_vals);
-                    zero_candidate=zeros(1,next_candidate);
-                    zero_candidate(next_candidate)=1;
-                    while nnz(upper_vals)>1
-                        % Aggressively try to zero out largest indices
-                        new_vals=linsolve([multiplier_upper;ones(1,length(upper_vals));zero_candidate],[sum(upper_vals.*multiplier_upper); row_prob_sum; 0])';
-                        new_vals=round(new_vals,epsilon_round);
-                        if all(new_vals==upper_vals) || any(new_vals<0) || any(isnan(new_vals))
-                            break
-                        end
-                        upper_vals=new_vals;
-                        zero_created=true;
-                        next_candidate=find(zero_candidate==0,1,'last');
-                        zero_candidate(next_candidate)=1;
-                    end
-                    if zero_created
-                        zero_candidate(next_candidate)=0;
-                    end
-                    next_candidate=1;
-                    zero_candidate(next_candidate)=1;
-                    while nnz(upper_vals)>1
-                        % Try to zero out least index
-                        new_vals=linsolve([multiplier_upper;ones(1,length(upper_vals));zero_candidate],[sum(upper_vals.*multiplier_upper); row_prob_sum; 0])';
-                        new_vals=round(new_vals,epsilon_round);
-                        if all(new_vals==upper_vals) || any(new_vals<0)
-                            break
-                        end
-                        upper_vals=new_vals;
-                        zero_created=true;
-                        next_candidate=find(zero_candidate==0,1,'first');
-                        zero_candidate(next_candidate)=1;
-                    end
-                end
-                if ~zero_created
-                    % Just re-balance the indices (possibly creating a zero in the middle we cannot move to either end of lower_vals
-                    new_vals=linsolve([multiplier_upper;ones(1,length(upper_vals))],[sum(upper_vals.*multiplier_upper); row_prob_sum])';
-                    new_vals=round(new_vals,epsilon_round);
-                    if any(new_vals<0)
-                        break
-                    end
-                    upper_vals=new_vals;
-                end
-                temp=sparse(row,upper_idx,upper_vals,N_a1,N_a2);
-                temp_cols=lower_idx(1):upper_idx(end);
-                if N_z_input==0
-                    StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
-                else
-                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c))=temp(row,temp_cols);
-                end
-                total_zeros_created=total_zeros_created+sum(upper_vals==0)+length(lower_vals)-starting_zeros;
-                continue
-            end
+            total_zeros_created=total_zeros_created+sum(vals==0)-starting_zeros;
         end
     end
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -1,4 +1,4 @@
-function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1_input,N_a2_input,N_z_input,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2)
+function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1_input,N_a2_input,N_z_input,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2, simoptions)
 
 epsilon_round=7;
 
@@ -205,8 +205,13 @@ if jj<jj_at_max_a2 && any(temp(:,N_a2,:)~=0,'all')
     jj_at_max_a2=jj;
 end
 
-total_zeros_created=total_zeros_created+sum(new_zeros_created);
-fprintf("Age %3d: zeros created = %d \n", jj, sum(new_zeros_created));
+sum_new_zeros=sum(new_zeros_created);
+total_zeros_created=total_zeros_created+sum_new_zeros;
+if simoptions.verbose>=1
+    if sum_new_zeros || simoptions.verbose==2
+        fprintf("Age %3d: zeros created = %d \n", jj, sum_new_zeros);
+    end
+end
 
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -58,7 +58,7 @@ for z_c=1:N_z
                 if N_z_input==0
                     StationaryDist_jj(sub2ind([N_a1,N_a2],row,ea_lower_idx))=temp(row,ea_lower_idx);
                 else
-                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,ea_lower_idx,z_c),z_c)=temp(row,ea_lower_idx);
+                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,ea_lower_idx,z_c))=temp(row,ea_lower_idx);
                 end
                 continue
             elseif length(ea_lower_idx)<3
@@ -218,10 +218,10 @@ for z_c=1:N_z
                             lower_vals(ii)=sum(lower_vals(ii:end).*multiplier_lower(ii:end))/multiplier_lower(1);
                             temp=sparse(row,lower_idx(1:ii),lower_vals(1:ii),N_a1,N_a2);
                             temp_cols=lower_idx(1):lower_idx(end);
-                            if N_z_input
+                            if N_z_input==0
                                 StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
                             else
-                                StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c),z_c)=temp(row,temp_cols);
+                                StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c))=temp(row,temp_cols);
                             end
                             break
                         end
@@ -303,10 +303,10 @@ for z_c=1:N_z
                 end
                 temp=sparse(row,lower_idx,lower_vals,N_a1,N_a2);
                 temp_cols=lower_idx(1):upper_idx(end);
-                if N_z_input
+                if N_z_input==0
                     StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
                 else
-                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c),z_c)=temp(row,temp_cols);
+                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c))=temp(row,temp_cols);
                 end
                 total_zeros_created=total_zeros_created+sum(lower_vals==0)+length(upper_vals)-starting_zeros;
                 continue
@@ -368,10 +368,10 @@ for z_c=1:N_z
                 end
                 temp=sparse(row,upper_idx,upper_vals,N_a1,N_a2);
                 temp_cols=lower_idx(1):upper_idx(end);
-                if N_z_input
+                if N_z_input==0
                     StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
                 else
-                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c),z_c)=temp(row,temp_cols);
+                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c))=temp(row,temp_cols);
                 end
                 total_zeros_created=total_zeros_created+sum(upper_vals==0)+length(lower_vals)-starting_zeros;
                 continue

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -1,5 +1,5 @@
-function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z_input,jj, epsilon,total_zeros_created,jj_at_max_a2)
- 
+function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1,N_a2,N_z_input,N_e,jj, epsilon,total_zeros_created,jj_at_max_a2)
+
 epsilon_round=7;
 
 age_zeros_created=total_zeros_created;
@@ -9,6 +9,8 @@ if N_z_input==0
 else
     N_z=N_z_input;
 end
+
+assert(N_e==0); % haven't implemented N_e of any kind yet
 
 for z_c=1:N_z
     if N_z_input==0

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -35,104 +35,49 @@ for z_c=1:N_z
     for row=unique(rows')
         % Process agents' ExpAssets row by row (i.e., each N_a1 asset mixture)
 
-        % We have two strategies for dealing with gaps.  The first is
-        % to see whether the gap disappears when we look at the whole
-        % picture.  It can happen that lower/upper columns are
-        % disjoint like this: [2 4] [3 5] which gives 4-in-a-row.
-        % If we see we have [2 3 4 5] we have to reconstruct
-        % lower/upper columns somehow.  In this case, it is possible
-        % for a singleton upper to have a lower index than a lower,
-        % so we take care to fix that.
-
-        % The second strategy is to fill in a single hole if that
-        % allows us to connect lower and upper columns.  In the above
-        % case we get [2 3* 4] [3 4* 5] where * means inserted zero.
-        % This is simpler because lower/upper are already split.
+        % Find and join up runs that are reasonably close together
         [~,ea_all_idx,all_vals_jj]=find(StationaryDist_row_jj(row,:));
-        p=find(diff(ea_all_idx)>1); % p columns are start and end of consecutive elements
+        p=find(diff(ea_all_idx)>2); % p columns are start and end of mostly consecutive elements
         runs=[ea_all_idx(1),ea_all_idx(p+1);ea_all_idx(p),ea_all_idx(end)];
 
         if size(runs,2)>1
-            single_gaps=ea_all_idx(p+1)-ea_all_idx(p)==2;
-            if any(single_gaps)
-                % A zero logically bubbled in...so make space for it for now
-                s=p(single_gaps);
-                z = zeros(1,length(ea_all_idx)+length(s));  %initialise a new vector of the appropriate size
-                z(s+(1:length(s))) = ea_all_idx(s)+1; % set locations in 's' to s+1, which will have the value zero
-                z(z==0) = ea_all_idx; %insert the original values in ea_all_idx into the new vector at their new positions.
-                ea_all_idx=z;
-                z = nan(1,length(all_vals_jj)+length(s));  %initialise a new vector of the appropriate size
-                z(s+(1:length(s))) = 0; % set value locations in 'p' to zero
-                z(isnan(z)) = all_vals_jj; %insert the original values in all_vals_jj into the new vector at their new positions.
-                p=find(diff(ea_all_idx)>1); % p columns are start and end of consecutive elements
-                runs=[ea_all_idx(1),ea_all_idx(p+1);ea_all_idx(p),ea_all_idx(end)];
-                gap_idx=ea_all_idx(s)';
-                single_gaps=sum(gap_idx>=runs(1,:) & gap_idx<=runs(2,:),1);
-                all_vals_jj=z;
-            else
-                single_gaps=zeros(1,size(runs,2));
-            end
+            ea_1=1;
             for ridx=1:size(runs,2)
                 if runs(2,ridx)-runs(1,ridx)<2
                     % Remove traces of any short sequences
                     temp=ea_all_idx<runs(1,ridx) | ea_all_idx>runs(2,ridx);
                     ea_all_idx=ea_all_idx(temp);
                     all_vals_jj=all_vals_jj(temp);
-                else
-                    % Fill in zeros for everything we track
-                    valid_ridx=ea_all_idx>=runs(1,ridx) & ea_all_idx<=runs(2,ridx);
-                    if ~any(valid_ridx)
-                        continue
-                    end
-                    ea_1=find(valid_ridx,1,'first');
-                    ea_end=find(valid_ridx,1,'last');
-                    if ~any(single_gaps(ridx))
-                        % Check for single gaps intra lower/upper
-                        if any(diff(ea_all_idx(ea_1:ea_end))==2)
-                            single_gaps(ridx)=true;
-                        end
-                    end
-                    if ea_end>ea_1 || any(single_gaps(ridx))
-                        % Non-singleton, so maybe insert zeros; note ea_lower_idx is continuous, so ea_lower_idx(ea_lower_end)-ea_lower_idx(ea_lower_1)==ea_lower_end-ea_lower_1
-                        new_vals=zeros(1,ea_end-ea_1+1); % pick up the new zeros
-                        temp=ea_all_idx>=runs(1,ridx) & ea_all_idx<=runs(2,ridx);
-                        new_vals(ea_all_idx(temp)-ea_all_idx(ea_1)+1)=all_vals_jj(temp);
-                        all_vals_jj=[all_vals_jj(1:ea_1-1), new_vals, all_vals_jj(ea_end+1:end)];
-                        ea_all_idx=[ea_all_idx(1:ea_1-1), ea_all_idx(ea_1):ea_all_idx(ea_end), ea_all_idx(ea_end+1:end)];
-                    end
+                    % ea_1 doesn't move
+                    continue
                 end
+                % Fill in zeros for everything we track
+                valid_ridx=ea_all_idx>=runs(1,ridx) & ea_all_idx<=runs(2,ridx);
+                if sum(valid_ridx)==runs(2,ridx)-runs(1,ridx)+1
+                    % We have a full run with no gaps to fill
+                    ea_1=ea_1+runs(2,ridx)-runs(1,ridx)+1;
+                    continue
+                end
+                ea_end_plus1=ea_1+length(all_vals_jj(valid_ridx));
+                new_idx=runs(1,ridx):runs(2,ridx);
+                new_ridx=ismember(new_idx, ea_all_idx(valid_ridx));
+                new_vals=zeros(1,length(new_idx));
+                new_vals(new_ridx)=all_vals_jj(valid_ridx);
+                all_vals_jj=[all_vals_jj(1:ea_1-1), new_vals, all_vals_jj(ea_end_plus1:end)];
+                ea_all_idx=[ea_all_idx(1:ea_1-1), new_idx, ea_all_idx(ea_end_plus1:end)];
+                ea_1=ea_1+length(new_idx);
             end
+            % Remove runs ignored above (but used to cut down idx and vals)
             runs=runs(:,runs(2,:)-runs(1,:)>1);
             if isempty(runs)
                 % We have disqualified all merging opportunities
                 continue
-            else
-                ea_gaps_isempty=size(runs,2)==1;
             end
-        else
-            if ea_all_idx(end)-ea_all_idx(1)>=length(ea_all_idx)
-                % We have no gaps in the big picture, but lower gaps
-                p=find(diff(ea_all_idx)>1); % p columns are start and end of consecutive elements
-                runs=[ea_all_idx(1),ea_all_idx(p+1);ea_all_idx(p),ea_all_idx(end)];
-                z = zeros(1,length(ea_all_idx)+length(p));  %initialise a new vector of the appropriate size
-                z(p+(1:length(p))) = ea_all_idx(p)+1; % set locations in 'p' to p+1, which will have the value zero
-                z(z==0) = ea_all_idx; %insert the original values in ea_lower_idx into the new vector at their new positions.
-                ea_all_idx=z;
-                z = nan(1,length(all_vals_jj)+length(p));  %initialise a new vector of the appropriate size
-                z(p+(1:length(p))) = 0; % set value locations in 'p' to zero
-                z(isnan(z)) = all_vals_jj; %insert the original values in ea_lower_vals into the new vector at their new positions.
-                ea_lower_vals=z;
-            end
-            ea_gaps_isempty=true;
         end
 
         [ea_all_idx,sort_idx]=sort(ea_all_idx);
         all_vals_jj=all_vals_jj(sort_idx);
-        if ea_gaps_isempty
-            ea_gaps=[];
-        else
-            ea_gaps=find(diff(ea_all_idx)>1);
-        end
+        ea_gaps=find(diff(ea_all_idx)>1);
 
         group_idx=[0,ea_gaps,length(ea_all_idx)];
         for ll=1:length(group_idx)-1
@@ -177,19 +122,9 @@ for z_c=1:N_z
                         break
                     end
                     vals=new_vals;
-                    zero_created=true;
                     cidx=find(zero_candidate==0,1,'first');
                     zero_candidate(cidx)=1;
                 end
-            end
-            if false && ~zero_created
-                % Just re-balance the indices (possibly creating a zero in the middle we cannot move to either end of vals
-                new_vals=linsolve([multiplier;ones(1,length(vals))],[sum(vals.*multiplier); run_prob_sum])';
-                new_vals=round(new_vals,epsilon_round);
-                if any(new_vals<0)
-                    break
-                end
-                vals=new_vals;
             end
             temp=sparse(row,all_idx,vals,N_a1,N_a2);
             temp_cols=all_idx(1):all_idx(end);

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -1,5 +1,5 @@
-function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,StationaryDist_lower_jj,StationaryDist_upper_jj, N_a1,N_a2,N_z_input,jj, epsilon,total_zeros_created,jj_at_max_a2)
-
+function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj,StationaryDist_lower_jj_in,StationaryDist_upper_jj_in, N_a1,N_a2,N_z_input,jj, epsilon,total_zeros_created,jj_at_max_a2)
+ 
 epsilon_round=7;
 
 age_zeros_created=total_zeros_created;
@@ -12,60 +12,48 @@ end
 
 for z_c=1:N_z
     if N_z_input==0
-        StationaryDist_rowz_jj=reshape(StationaryDist_jj,[N_a1,N_a2]);
+        StationaryDist_row_jj=reshape(StationaryDist_jj,[N_a1,N_a2]);
     else
-        StationaryDist_rowz_jj=reshape(StationaryDist_jj(:,z_c),[N_a1,N_a2]);
+        StationaryDist_row_jj=reshape(StationaryDist_jj(:,z_c),[N_a1,N_a2]);
     end
-    probability_z=full(sum(StationaryDist_rowz_jj,'all'));
-    if probability_z==0 || all(arrayfun(@(r) nnz(StationaryDist_rowz_jj(r,:)), 1:size(StationaryDist_rowz_jj,1))<3)
+    probability_z=full(sum(StationaryDist_row_jj,'all'));
+    if probability_z==0 || all(arrayfun(@(r) nnz(StationaryDist_row_jj(r,:)), 1:size(StationaryDist_row_jj,1))<3)
         % Sometimes nobody chooses the path less taken
         continue
     end
-    if jj<jj_at_max_a2 && any(StationaryDist_rowz_jj(:,N_a2)~=0)
+    if jj<jj_at_max_a2 && any(StationaryDist_row_jj(:,N_a2)~=0)
         jj_at_max_a2=jj;
     end
     if N_z_input==0
-        StationaryDist_lowerz_jj=reshape(StationaryDist_lower_jj,[N_a1,N_a2]);
-        StationaryDist_upperz_jj=reshape(StationaryDist_upper_jj,[N_a1,N_a2]);
+        StationaryDist_lower_jj=reshape(StationaryDist_lower_jj_in,[N_a1,N_a2]);
+        StationaryDist_upper_jj=reshape(StationaryDist_upper_jj_in,[N_a1,N_a2]);
     else
-        StationaryDist_lowerz_jj=reshape(StationaryDist_lower_jj(:,z_c),[N_a1,N_a2]);
-        StationaryDist_upperz_jj=reshape(StationaryDist_upper_jj(:,z_c),[N_a1,N_a2]);
+        StationaryDist_lower_jj=reshape(StationaryDist_lower_jj_in(:,z_c),[N_a1,N_a2]);
+        StationaryDist_upper_jj=reshape(StationaryDist_upper_jj_in(:,z_c),[N_a1,N_a2]);
     end
 
-    [rows,~]=find(StationaryDist_rowz_jj~=0);
+    [rows,~]=find(StationaryDist_row_jj~=0);
     for row=unique(rows')
         % Process agents' ExpAssets row by row (i.e., each N_a1 asset mixture)
-        row_prob_sum=full(sum(StationaryDist_rowz_jj(row,:),2));
+        row_prob_sum=full(sum(StationaryDist_row_jj(row,:),2));
 
-        [~,ea_lower_idx,ea_lower_vals]=find(StationaryDist_lowerz_jj(row,:));
+        [~,ea_lower_idx,ea_lower_vals]=find(StationaryDist_lower_jj(row,:));
         if isempty(ea_lower_idx)
             % Swap and try again; the empty half-distribution will not prevent us from getting the job done
             ea_upper_idx=ea_lower_idx; % empty!!
-            [~,ea_lower_idx,ea_lower_vals]=find(StationaryDist_upperz_jj(row,:));
+            [~,ea_lower_idx,ea_lower_vals]=find(StationaryDist_upper_jj(row,:));
             if length(ea_lower_idx)==2
                 % Below we take care of singletons, which might need to evaporate
                 continue
             end
         else
-            [~,ea_upper_idx,ea_upper_vals]=find(StationaryDist_upperz_jj(row,:));
-        end
-        noise_vals=(ea_lower_vals/row_prob_sum)<1e-5;
-        noise_vals(find(noise_vals==0,1,'first'):end)=0;
-        if false && any(noise_vals)
-            temp_cols=ea_lower_idx(noise_vals);
-            ea_lower_idx=ea_lower_idx(~noise_vals);
-            ea_lower_vals=ea_lower_vals(~noise_vals);
-            if N_z_input==0
-                StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=0;
-            else
-                StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c),z_c)=0;
-            end
+            [~,ea_upper_idx,ea_upper_vals]=find(StationaryDist_upper_jj(row,:));
         end
 
         if isempty(ea_upper_idx)
             if isscalar(ea_lower_idx) && row_prob_sum<epsilon && (ea_lower_idx==1 || ea_lower_idx==N_a2)
-                % Allow this infinitesimal to evaporate from grid
-                total_zeros_created=total_zeros_created+nnz(ea_lower_vals);
+                % Allow this infinitesimal to evaporate from this otherwise empty row
+                total_zeros_created=total_zeros_created+1;
                 temp=sparse(row,ea_lower_idx,0,N_a1,N_a2);
                 if N_z_input==0
                     StationaryDist_jj(sub2ind([N_a1,N_a2],row,ea_lower_idx))=temp(row,ea_lower_idx);
@@ -74,23 +62,6 @@ for z_c=1:N_z
                 end
                 continue
             elseif length(ea_lower_idx)<3
-                continue
-            end
-        else
-            noise_vals=(ea_upper_vals/row_prob_sum)<1e-5;
-            noise_vals(1:find(noise_vals==0,1,'last'))=0;
-            if false && any(noise_vals)
-                temp_cols=ea_upper_idx(noise_vals);
-                ea_upper_idx=ea_upper_idx(~noise_vals);
-                ea_upper_vals=ea_upper_vals(~noise_vals);
-                if N_z_input==0
-                    StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=0;
-                else
-                    StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c),z_c)=0;
-                end
-            end
-
-            if isempty(ea_lower_idx) || isempty(ea_upper_idx) || ea_upper_idx(end)-ea_lower_idx(1)<2
                 continue
             end
         end
@@ -108,27 +79,25 @@ for z_c=1:N_z
         % allows us to connect lower and upper columns.  In the above
         % case we get [2 3* 4] [3 4* 5] where * means inserted zero.
         % This is simpler because lower/upper are already split.
-        [~,ea_allz_idx,allz_vals_jj]=find(StationaryDist_rowz_jj(row,:));
-        p=find(diff(ea_allz_idx)>1); % p columns are start and end of consecutive elements
-        runs=[ea_allz_idx(1),ea_allz_idx(p+1);ea_allz_idx(p),ea_allz_idx(end)];
+        [~,ea_all_idx,all_vals_jj]=find(StationaryDist_row_jj(row,:));
+        p=find(diff(ea_all_idx)>1); % p columns are start and end of consecutive elements
+        runs=[ea_all_idx(1),ea_all_idx(p+1);ea_all_idx(p),ea_all_idx(end)];
 
         if size(runs,2)>1
-            single_gaps=ea_allz_idx(p+1)-ea_allz_idx(p)==2;
+            single_gaps=ea_all_idx(p+1)-ea_all_idx(p)==2;
             if any(single_gaps)
                 % A zero logically bubbled in...so make space for it for now
                 s=p(single_gaps);
-                z = zeros(1,length(ea_allz_idx)+length(s));  %initialise a new vector of the appropriate size
-                z(s+(1:length(s))) = ea_allz_idx(s)+1; % set locations in 's' to s+1, which will have the value zero
-                z(z==0) = ea_allz_idx; %insert the original values in ea_allz_idx into the new vector at their new positions.
-                ea_allz_idx=z;
-                z = nan(1,length(allz_vals_jj)+length(s));  %initialise a new vector of the appropriate size
+                z = zeros(1,length(ea_all_idx)+length(s));  %initialise a new vector of the appropriate size
+                z(s+(1:length(s))) = ea_all_idx(s)+1; % set locations in 's' to s+1, which will have the value zero
+                z(z==0) = ea_all_idx; %insert the original values in ea_all_idx into the new vector at their new positions.
+                ea_all_idx=z;
+                z = nan(1,length(all_vals_jj)+length(s));  %initialise a new vector of the appropriate size
                 z(s+(1:length(s))) = 0; % set value locations in 'p' to zero
-                z(isnan(z)) = allz_vals_jj; %insert the original values in allz_vals_jj into the new vector at their new positions.
-                allz_vals_jj=z;
-                ea_gaps=find(diff(ea_allz_idx)>1);
-                p=find(diff(ea_allz_idx)>1); % p columns are start and end of consecutive elements
-                runs=[ea_allz_idx(1),ea_allz_idx(p+1);ea_allz_idx(p),ea_allz_idx(end)];
-                gap_idx=ea_allz_idx(s)';
+                z(isnan(z)) = all_vals_jj; %insert the original values in all_vals_jj into the new vector at their new positions.
+                p=find(diff(ea_all_idx)>1); % p columns are start and end of consecutive elements
+                runs=[ea_all_idx(1),ea_all_idx(p+1);ea_all_idx(p),ea_all_idx(end)];
+                gap_idx=ea_all_idx(s)';
                 single_gaps=sum(gap_idx>=runs(1,:) & gap_idx<=runs(2,:),1);
             else
                 single_gaps=zeros(1,size(runs,2));
@@ -144,11 +113,21 @@ for z_c=1:N_z
                     ea_upper_vals=ea_upper_vals(temp);
                 else
                     % Fill in zeros for everything we track
+                    ea_lower_1=find(ea_lower_idx>=runs(1,ridx),1,'first');
                     ea_lower_end=find(ea_lower_idx>=runs(1,ridx) & ea_lower_idx<=runs(2,ridx),1,'last');
                     ea_upper_1=find(ea_upper_idx>=runs(1,ridx) & ea_upper_idx<=runs(2,ridx),1,'first');
-                    if ea_lower_idx(ea_lower_end)~=ea_upper_idx(ea_upper_1) || single_gaps(ridx)
+                    ea_upper_end=find(ea_upper_idx<=runs(2,ridx),1,'last');
+                    if ~any(single_gaps(ridx))
+                        % Check for single gaps intra lower/upper
+                        if any(diff(ea_lower_idx(ea_lower_1:ea_lower_end))==2)
+                            single_gaps(ridx)=true;
+                        end
+                        if any(diff(ea_upper_idx(ea_upper_1:ea_upper_end))==2)
+                            single_gaps(ridx)=true;
+                        end
+                    end
+                    if ea_lower_idx(ea_lower_end)~=ea_upper_idx(ea_upper_1) || any(single_gaps(ridx))
                         % Merging disjoint/overlapping lower and upper
-                        ea_lower_1=find(ea_lower_idx>=runs(1,ridx),1,'first');
                         if ea_lower_idx(ea_lower_1)>ea_upper_idx(ea_upper_1)
                             % add zeros to lower so both start at the same index
                             new_zeros=ea_lower_idx(ea_lower_1)-ea_upper_idx(ea_upper_1);
@@ -157,17 +136,16 @@ for z_c=1:N_z
                             ea_lower_idx=[ea_upper_idx(ea_upper_1)+(0:new_zeros-1),ea_lower_idx];
                         end
                         if ea_lower_end>ea_lower_1
-                            % Non-singleton, so maybe insert zeros
-                            new_vals=zeros(1,ea_lower_idx(ea_lower_end)-ea_lower_idx(ea_lower_1)+1); % pick up the new zeros
+                            % Non-singleton, so maybe insert zeros; note ea_lower_idx is continuous, so ea_lower_idx(ea_lower_end)-ea_lower_idx(ea_lower_1)==ea_lower_end-ea_lower_1
+                            new_vals=zeros(1,ea_lower_end-ea_lower_1+1); % pick up the new zeros
                             temp=ea_lower_idx>=runs(1,ridx) & ea_lower_idx<=runs(2,ridx);
                             new_vals(ea_lower_idx(temp)-ea_lower_idx(ea_lower_1)+1)=ea_lower_vals(temp);
                             ea_lower_vals=[ea_lower_vals(1:ea_lower_1-1), new_vals, ea_lower_vals(ea_lower_end+1:end)];
                             ea_lower_idx=[ea_lower_idx(1:ea_lower_1-1), ea_lower_idx(ea_lower_1):ea_lower_idx(ea_lower_end), ea_lower_idx(ea_lower_end+1:end)];
                         end
-                        ea_upper_end=find(ea_upper_idx<=runs(2,ridx),1,'last');
                         if ea_upper_end>ea_upper_1
                             % Non-singleton, so maybe insert zeros
-                            new_vals=zeros(1,ea_upper_idx(ea_upper_end)-ea_upper_idx(ea_upper_1)+1); % pick up the new zeros
+                            new_vals=zeros(1,ea_upper_end-ea_upper_1+1); % pick up the new zeros
                             temp=ea_upper_idx>=runs(1,ridx) & ea_upper_idx<=runs(2,ridx);
                             new_vals(ea_upper_idx(temp)-ea_upper_idx(ea_upper_1)+1)=ea_upper_vals(temp);
                             ea_upper_vals=[ea_upper_vals(1:ea_upper_1-1), new_vals, ea_upper_vals(ea_upper_end+1:end)];
@@ -182,10 +160,8 @@ for z_c=1:N_z
             if isempty(runs)
                 % We have disqualified all merging opportunities
                 continue
-            elseif size(runs,2)==1
-                ea_gaps=[];
             else
-                ea_gaps=find(diff(ea_allz_idx)>1);
+                ea_gaps_isempty=size(runs,2)==1;
             end
         else
             if ea_lower_idx(end)-ea_lower_idx(1)>=length(ea_lower_idx)
@@ -214,23 +190,24 @@ for z_c=1:N_z
                 z(isnan(z)) = ea_upper_vals; %insert the original values in ea_upper_vals into the new vector at their new positions.
                 ea_upper_vals=z;
             end
-            ea_gaps=[];
+            ea_gaps_isempty=true;
         end
 
         [ea_lower_idx,sort_idx]=sort(ea_lower_idx);
         ea_lower_vals=ea_lower_vals(sort_idx);
-        if isempty(ea_gaps)
-            lower_gaps=ea_gaps;
+        if ea_gaps_isempty
+            lower_gaps=[];
         else
             lower_gaps=find(diff(ea_lower_idx)>1);
         end
 
         group_lower_idx=[0,lower_gaps,length(ea_lower_idx)];
         for ll=1:length(group_lower_idx)-1
-            ea_group_lower_idx=ea_lower_idx(group_lower_idx(ll)+1:group_lower_idx(ll+1));
+            lower_idx=ea_lower_idx(group_lower_idx(ll)+1:group_lower_idx(ll+1));
             lower_vals=ea_lower_vals(group_lower_idx(ll)+1:group_lower_idx(ll+1));
 
-            multiplier_lower=ea_group_lower_idx-ea_group_lower_idx(1)'+1;
+            multiplier_lower=lower_idx-lower_idx(1)+1;
+            assert(allunique(multiplier_lower));
 
             if isempty(ea_upper_idx)
                 if nnz(lower_vals)>2
@@ -239,8 +216,8 @@ for z_c=1:N_z
                     for ii=1:length(lower_vals)-1
                         if sum(lower_vals(ii:end).*multiplier_lower(ii:end))/multiplier_lower(1)<=row_prob_sum
                             lower_vals(ii)=sum(lower_vals(ii:end).*multiplier_lower(ii:end))/multiplier_lower(1);
-                            temp=sparse(row,ea_group_lower_idx(1:ii),lower_vals(1:ii),N_a1,N_a2);
-                            temp_cols=ea_group_lower_idx(1):ea_group_lower_idx(end);
+                            temp=sparse(row,lower_idx(1:ii),lower_vals(1:ii),N_a1,N_a2);
+                            temp_cols=lower_idx(1):lower_idx(end);
                             if N_z_input
                                 StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
                             else
@@ -257,8 +234,8 @@ for z_c=1:N_z
             % Attempt to consolidate upper and lower
             [ea_upper_idx,sort_idx]=sort(ea_upper_idx);
             ea_upper_vals=ea_upper_vals(sort_idx);
-            if isempty(ea_gaps)
-                upper_gaps=ea_gaps;
+            if ea_gaps_isempty
+                upper_gaps=[];
             else
                 upper_gaps=find(diff(ea_upper_idx)>1);
             end
@@ -266,16 +243,17 @@ for z_c=1:N_z
             group_upper_idx=[0,upper_gaps,length(ea_upper_idx)];
             assert(length(group_lower_idx)==length(group_upper_idx))
             uu=ll; % we keep these two in sync
-            ea_group_upper_idx=ea_upper_idx(group_upper_idx(uu)+1:group_upper_idx(uu+1));
+            upper_idx=ea_upper_idx(group_upper_idx(uu)+1:group_upper_idx(uu+1));
             upper_vals=ea_upper_vals(group_upper_idx(uu)+1:group_upper_idx(uu+1));
 
-            multiplier_upper=ea_group_upper_idx-ea_group_lower_idx(1)+1;
+            multiplier_upper=upper_idx-lower_idx(1)+1;
+            assert(allunique(multiplier_upper));
 
             sum_lower=sum(lower_vals.*multiplier_lower);
             sum_upper=sum(upper_vals.*multiplier_upper);
             starting_zeros=sum(lower_vals==0)+sum(upper_vals==0);
 
-            if length(unique(multiplier_lower))>1 && (sum_upper+sum_lower)/multiplier_lower(end)<=row_prob_sum
+            if length(multiplier_lower)>1 && (sum_upper+sum_lower)/multiplier_lower(end)<=row_prob_sum
                 % We can fit all the upper values into slots allocated to lower with a basis to work with
                 lower_vals(end)=lower_vals(end)+sum_upper/multiplier_lower(end);
                 % But in so doing, we may have probabilities that sum>1, so fix
@@ -323,8 +301,8 @@ for z_c=1:N_z
                     end
                     lower_vals=new_vals;
                 end
-                temp=sparse(row,ea_group_lower_idx,lower_vals,N_a1,N_a2);
-                temp_cols=ea_group_lower_idx(1):ea_group_upper_idx(end);
+                temp=sparse(row,lower_idx,lower_vals,N_a1,N_a2);
+                temp_cols=lower_idx(1):upper_idx(end);
                 if N_z_input
                     StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
                 else
@@ -332,9 +310,17 @@ for z_c=1:N_z
                 end
                 total_zeros_created=total_zeros_created+sum(lower_vals==0)+length(upper_vals)-starting_zeros;
                 continue
-            elseif length(unique(multiplier_upper))>1 && sum_lower/multiplier_upper(end-1)+sum(upper_vals)<=row_prob_sum
-                % We can fit all the lower values into slots allocated to upper with a basis to work with
-                upper_vals(end-1)=upper_vals(end-1)+sum_lower/multiplier_upper(end-1);
+            elseif length(multiplier_upper)>1
+                if sum_lower/multiplier_upper(end-1)+sum(upper_vals)<=row_prob_sum
+                    % We can fit all the lower values into slots allocated to upper(end-1) with a basis to work with...
+                    upper_vals(end-1)=upper_vals(end-1)+sum_lower/multiplier_upper(end-1);
+                elseif sum_lower/multiplier_upper(end)+sum(upper_vals)<=row_prob_sum
+                    % We can fit all the lower values into slots allocated to upper(end) with a basis to work with...
+                    upper_vals(end)=upper_vals(end)+sum_lower/multiplier_upper(end);
+                elseif length(multiplier_upper)>2
+                    % Attempt to consolidate upper into itself
+                    assert(false);
+                end
                 % But in so doing, we may have probabilities that sum>1, so fix
                 zero_created=false;
                 if length(upper_vals)>2
@@ -380,8 +366,8 @@ for z_c=1:N_z
                     end
                     upper_vals=new_vals;
                 end
-                temp=sparse(row,ea_group_upper_idx,upper_vals,N_a1,N_a2);
-                temp_cols=ea_group_lower_idx(1):ea_group_upper_idx(end);
+                temp=sparse(row,upper_idx,upper_vals,N_a1,N_a2);
+                temp_cols=lower_idx(1):upper_idx(end);
                 if N_z_input
                     StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
                 else
@@ -389,9 +375,6 @@ for z_c=1:N_z
                 end
                 total_zeros_created=total_zeros_created+sum(upper_vals==0)+length(lower_vals)-starting_zeros;
                 continue
-            elseif length(unique(multiplier_upper))>2
-                % Attempt to consolidate upper into itself
-                assert(false);
             end
         end
     end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -2,7 +2,7 @@ function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHo
 
 epsilon_round=7;
 
-age_zeros_created=total_zeros_created;
+new_zeros_created=zeros(1,N_z_input);
 
 if N_z_input==0
     N_z=1;
@@ -12,19 +12,15 @@ end
 
 assert(N_e==0); % haven't implemented N_e of any kind yet
 
+% For large N_z, this loop can be changed to `parfor` for greater CPU parallelism
 for z_c=1:N_z
-    if N_z_input==0
-        StationaryDist_row_jj=reshape(StationaryDist_jj,[N_a1,N_a2]);
-    else
-        StationaryDist_row_jj=reshape(StationaryDist_jj(:,z_c),[N_a1,N_a2]);
-    end
+    % When N_z=1, the index z_c is only every 1, which does nothing
+    StationaryDist_row_jj=reshape(StationaryDist_jj(:,z_c),[N_a1,N_a2]);
+
     row_prob_sum=full(sum(StationaryDist_row_jj,'all'));
     if row_prob_sum==0 || all(arrayfun(@(r) nnz(StationaryDist_row_jj(r,:)), 1:size(StationaryDist_row_jj,1))<3)
         % Sometimes nobody chooses the path less taken
         continue
-    end
-    if jj<jj_at_max_a2 && any(StationaryDist_row_jj(:,N_a2)~=0)
-        jj_at_max_a2=jj;
     end
 
     [rows,~]=find(StationaryDist_row_jj~=0);
@@ -189,17 +185,20 @@ for z_c=1:N_z
             end
             temp=sparse(row,all_idx,vals,N_a1,N_a2);
             temp_cols=all_idx(1):all_idx(end);
-            if N_z_input==0
-                StationaryDist_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
-            else
-                StationaryDist_jj(sub2ind([N_a1,N_a2,N_z],row,temp_cols,z_c))=temp(row,temp_cols);
-            end
-            total_zeros_created=total_zeros_created+sum(vals==0)-starting_zeros;
+            StationaryDist_row_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
+            new_zeros_created(z_c)=new_zeros_created(z_c)+sum(vals==0)-starting_zeros;
         end
     end
+    StationaryDist_jj(:,z_c)=reshape(StationaryDist_row_jj,[N_a1*N_a2,1]);
 end
 
-fprintf("Age %3d: zeros created = %d \n", jj, total_zeros_created-age_zeros_created);
+temp=reshape(full(StationaryDist_jj),[N_a1,N_a2,N_z]);
+if jj<jj_at_max_a2 && any(temp(:,N_a2,:)~=0,'all')
+    jj_at_max_a2=jj;
+end
+
+total_zeros_created=total_zeros_created+sum(new_zeros_created);
+fprintf("Age %3d: zeros created = %d \n", jj, sum(new_zeros_created));
 
 
 end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -88,54 +88,65 @@ for z_c=1:N_z
 
         group_idx=[0,ea_gaps,length(ea_all_idx)];
         for ll=1:length(group_idx)-1
-            all_idx=ea_all_idx(group_idx(ll)+1:group_idx(ll+1));
             vals=all_vals_jj(group_idx(ll)+1:group_idx(ll+1));
+            if length(vals)<3
+                continue
+            end
+            all_idx=ea_all_idx(group_idx(ll)+1:group_idx(ll+1));
             run_prob_sum=sum(vals);
 
             multiplier=all_idx-all_idx(1)+1;
             assert(allunique(multiplier));
 
             % Attempt to consolidate min and max values to the middle
+            % Don't take credit for zeros we created to make runs longer
             starting_zeros=sum(vals==0);
 
             zero_created=false;
-            if length(vals)>2
-                cidx=length(vals);
-                zero_candidate=zeros(1,cidx);
-                zero_candidate(cidx)=1;
-                while nnz(vals)>2
-                    % Aggressively try to zero out largest indices
-                    new_vals=linsolve([multiplier;ones(1,length(vals));zero_candidate],[sum(vals.*multiplier); run_prob_sum; 0])';
-                    new_vals=round(new_vals,epsilon_round+abs(fix(log10(run_prob_sum))));
-                    if all(new_vals==vals) || any(new_vals<0)
-                        zero_candidate(cidx)=0;
-                        break
-                    end
-                    vals=new_vals;
-                    zero_created=true;
-                    cidx=find(zero_candidate==0,1,'last');
-                    zero_candidate(cidx)=1;
-                end
-                if zero_created
+            cidx=length(vals);
+            zero_candidate=zeros(1,cidx);
+            nonzeros=true(1,cidx);
+            zero_candidate(cidx)=1;
+            while nnz(vals)>1
+                % Aggressively try to zero out largest indices
+                SystemOfEquations=[multiplier(nonzeros);ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
+                GoalValues=[sum(vals(nonzeros).*multiplier(nonzeros)); run_prob_sum; 0];
+                new_vals=linsolve(SystemOfEquations,GoalValues);
+                res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                new_vals=round(new_vals,epsilon_round)';
+                if res_vec_mag/norm(new_vals)>1e-5 || all(new_vals==vals(nonzeros)) || any(new_vals<0)
                     zero_candidate(cidx)=0;
+                    break
                 end
-                cidx=1;
+                vals=paddata(new_vals,length(vals));
+                nonzeros(cidx)=false;
+                zero_created=true;
+                cidx=cidx-1;
                 zero_candidate(cidx)=1;
-                while nnz(vals)>1
-                    % Try to zero out least index
-                    new_vals=linsolve([multiplier;ones(1,length(vals));zero_candidate],[sum(vals.*multiplier); run_prob_sum; 0])';
-                    new_vals=round(new_vals,epsilon_round+abs(fix(log10(run_prob_sum))));
-                    if all(new_vals==vals) || any(new_vals<0) || any(isnan(new_vals))
-                        break
-                    end
-                    vals=new_vals;
-                    cidx=find(zero_candidate==0,1,'first');
-                    zero_candidate(cidx)=1;
+            end
+            if zero_created
+                zero_candidate(cidx)=0;
+            end
+            cidx=1;
+            zero_candidate(cidx)=1;
+            while nnz(vals)>1
+                % Try to zero out least index
+                SystemOfEquations=[multiplier(nonzeros);ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
+                GoalValues=[sum(vals(nonzeros).*multiplier(nonzeros)); run_prob_sum; 0];
+                new_vals=linsolve(SystemOfEquations,GoalValues);
+                res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                new_vals=round(new_vals,epsilon_round)';
+                if res_vec_mag/norm(new_vals)>1e-5 || all(new_vals==vals(nonzeros)) || any(new_vals<0)
+                    break
                 end
+                vals=paddata([zeros(1,cidx-1), new_vals],length(vals));
+                nonzeros(cidx)=false;
+                cidx=cidx+1;
+                zero_candidate(cidx)=1;
             end
             temp=sparse(row,all_idx,vals,N_a1,N_a2);
             temp_cols=all_idx(1):all_idx(end);
-            StationaryDist_row_jj(sub2ind([N_a1,N_a2],row,temp_cols))=temp(row,temp_cols);
+            StationaryDist_row_jj(row,temp_cols)=temp(row,temp_cols);
             new_zeros_created(z_c)=new_zeros_created(z_c)+sum(vals==0)-starting_zeros;
         end
     end

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -17,6 +17,9 @@ else
     a2_grid_T=1:N_a2;
 end
 
+% Gather so we can round; it will be placed back into gpuArray by caller
+StationaryDist_jj=gather(StationaryDist_jj);
+
 % Remember whether we want to return [N_a*N_z,1] or [N_a,N_z]
 StationaryDist_jj_size=size(StationaryDist_jj);
 

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -8,7 +8,7 @@ if n_a2==0
     N_a1=1;
     n_a2=n_a1;
 else
-    N_a1=prod(n_a1);
+    N_a1=max(prod(n_a1),1);
 end
 N_a2=prod(n_a2);
 if isfield(simoptions, 'a_grid')

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -66,98 +66,48 @@ for z_c=1:N_z
             % Attempt to consolidate min and max values to the middle
             % Don't take credit for zeros we created to make runs longer
             starting_zeros=sum(vals==0);
-
-            zero_created=false;
             cidx=length(this_run);
-            zero_candidate=zeros(1,cidx);
-            nonzeros=true(1,cidx);
 
-            if cidx>3
-                % Just once, try to zero out both max and min in one shot
-                if any(a2_grid_T(this_run)==0)
-                    SystemOfEquations=[this_run;ones(1,cidx);[1,zeros(1,cidx-1)];[zeros(1,cidx-1),1]];
-                    GoalValues=[sum(vals.*this_run); run_prob_sum; 0; 0];
-                    new_vals=linsolve(SystemOfEquations,GoalValues);
-                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
-                else
-                    SystemOfEquations=[a2_grid_T(this_run);ones(1,cidx);[1,zeros(1,cidx-1)];[zeros(1,cidx-1),1]];
-                    GoalValues=[sum(vals.*a2_grid_T(this_run)); run_prob_sum; 0; 0];
-                    new_vals=linsolve(SystemOfEquations,GoalValues);
-                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
-                end
-                new_vals=round(new_vals,epsilon_round)';
-                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>epsilon || all(abs(new_vals-vals)<epsilon) || any(new_vals<0)
-                    % zero_candidate(cidx)=0;
-                else
-                    vals=new_vals;
-                    if cidx<5
-                        % Early out if we collapsed 4 values into 2
-                        temp=sparse(row,this_run,vals,N_a1,N_a2);
-                        StationaryDist_row_jj(row,this_run)=temp(row,this_run);
-                        new_zeros_created(z_c)=new_zeros_created(z_c)+sum(vals==0)-starting_zeros;
-                        continue
-                    end
-                    zero_created=true;
-                    nonzeros(1)=false; nonzeros(cidx)=false;
-                    zero_candidate(1)=1; zero_candidate(cidx)=1;
-                    cidx=cidx-1;
-                end
+            % See if we can collapse this system down to two or three basis elements
+            % gridvals and the sums are indexed into `this_run`, not values of `this_run`
+            gridvals=vals.*a2_grid_T(this_run);
+            lower_sums=cumsum(gridvals,'forward');
+            lower_sums=[vals(1)*(a2_grid_T(this_run(1))~=0),lower_sums(2:end)./a2_grid_T(this_run(2:end))];
+            lower_sums(isinf(lower_sums))=lower_sums(circshift(isinf(lower_sums),-1));
+            upper_sums=cumsum(gridvals,'reverse');
+            upper_sums=[upper_sums(1:end-1)./a2_grid_T(this_run(1:end-1)),vals(end)*(a2_grid_T(this_run(end))~=0)];
+            upper_sums(isinf(upper_sums))=upper_sums(circshift(isinf(upper_sums),1)); % grids should have only a single zero value
+            % Where lower_sums(1:end-1)+upper_sums(2:end)<=run_prob_sum we have room to redistribute probabilities
+            valid_crossover=run_prob_sum-(lower_sums(1:end-1)+upper_sums(2:end))>=0;
+            lower_idx=find(valid_crossover,1,'first');
+            if isempty(lower_idx)
+                % Maybe we need a span of 3...it happens
+                valid_crossover=run_prob_sum-(lower_sums(1:end-2)+upper_sums(3:end))>=0;
+                lower_idx=find(valid_crossover,1,'first');
+                assert(~isempty(lower_idx));
+                upper_idx=lower_idx+2;
+            else
+                upper_idx=lower_idx+1;
             end
-            zero_candidate(cidx)=1;
-            while nnz(vals)>1
-                % Try to zero out largest indices, perhaps squeezing zero from middle
-                if any(a2_grid_T(this_run(nonzeros))==0)
-                    SystemOfEquations=[this_run(nonzeros);ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
-                    GoalValues=[sum(vals(nonzeros).*this_run(nonzeros)); run_prob_sum; 0];
-                    new_vals=linsolve(SystemOfEquations,GoalValues);
-                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
-                else
-                    SystemOfEquations=[a2_grid_T(this_run(nonzeros));ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
-                    GoalValues=[sum(vals(nonzeros).*a2_grid_T(this_run(nonzeros))); run_prob_sum; 0];
-                    new_vals=linsolve(SystemOfEquations,GoalValues);
-                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
-                end
-                new_vals=round(new_vals,epsilon_round)';
-                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>epsilon || all(abs(new_vals-vals(nonzeros))<epsilon) || any(new_vals<0)
-                    zero_candidate(cidx)=0;
-                    break
-                end
-                vals(nonzeros)=new_vals;
-                nonzeros(cidx)=false;
-                zero_created=true;
-                cidx=cidx-1;
-                zero_candidate(cidx)=1;
+            SystemOfEquations=[a2_grid_T(this_run(lower_idx:upper_idx));ones(1,upper_idx-lower_idx+1)];
+            GoalValues=[sum(gridvals); run_prob_sum];
+            new_vals=linsolve(SystemOfEquations,GoalValues);
+            if any(new_vals<0)
+                % Maybe we need a span of 3...it happens
+                lower_idx=lower_idx-(new_vals(2)<0);
+                upper_idx=upper_idx+(new_vals(1)<0);
+                SystemOfEquations=[a2_grid_T(this_run(lower_idx:upper_idx));ones(1,upper_idx-lower_idx+1)];
+                new_vals=linsolve(SystemOfEquations,GoalValues);
+                assert(all(new_vals>=0));
             end
-            if zero_created
-                zero_candidate(cidx)=0;
+            res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+            new_vals=round(new_vals,epsilon_round)';
+            if res_vec_mag==0 || (~isnan(res_vec_mag) && res_vec_mag/norm(new_vals)<=epsilon)
+                % Put this valid redistribution into the Stationary Dist, finishing this run
+                temp=sparse(row,this_run(lower_idx:upper_idx),new_vals,N_a1,N_a2);
+                StationaryDist_row_jj(row,this_run)=temp(row,this_run);
+                new_zeros_created(z_c)=new_zeros_created(z_c)+cidx-2-starting_zeros;
             end
-            cidx=find(zero_candidate==0,1,'first');
-            zero_candidate(cidx)=1;
-            while nnz(vals)>1
-                % Try to zero out least index, perhaps squeezing zero from middle
-                if any(a2_grid_T(this_run(nonzeros))==0)
-                    SystemOfEquations=[this_run(nonzeros);ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
-                    GoalValues=[sum(vals(nonzeros).*this_run(nonzeros)); run_prob_sum; 0];
-                    new_vals=linsolve(SystemOfEquations,GoalValues);
-                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
-                else
-                    SystemOfEquations=[a2_grid_T(this_run(nonzeros));ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
-                    GoalValues=[sum(vals(nonzeros).*a2_grid_T(this_run(nonzeros))); run_prob_sum; 0];
-                    new_vals=linsolve(SystemOfEquations,GoalValues);
-                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
-                end
-                new_vals=round(new_vals,epsilon_round)';
-                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>epsilon || all(abs(new_vals-vals(nonzeros))<epsilon) || any(new_vals<0)
-                    break
-                end
-                vals(nonzeros)=new_vals;
-                nonzeros(cidx)=false;
-                cidx=cidx+1;
-                zero_candidate(cidx)=1;
-            end
-            temp=sparse(row,this_run,vals,N_a1,N_a2);
-            StationaryDist_row_jj(row,this_run)=temp(row,this_run);
-            new_zeros_created(z_c)=new_zeros_created(z_c)+sum(vals==0)-starting_zeros;
         end
     end
     StationaryDist_jj(:,z_c)=reshape(StationaryDist_row_jj,[N_a1*N_a2,1]);

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -1,6 +1,6 @@
 function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, n_a1,n_a2,N_z_input,jj, epsilon,total_zeros_created,jj_at_max_a2, simoptions)
 
-epsilon_round=7;
+epsilon_round=10;
 
 % For grid interpolation, N_a2 arrives as zero.  We simplify the implementation
 % by treating this N_a1x1 grid as an 1xN_a1 grid (with N_a1 spelled N_a2 below).
@@ -11,7 +11,11 @@ else
     N_a1=prod(n_a1);
 end
 N_a2=prod(n_a2);
-a2_grid_T=gather(double(simoptions.a_grid(sum(n_a1)+1:end)))';
+if isfield(simoptions, 'a_grid')
+    a2_grid_T=gather(double(simoptions.a_grid(sum(n_a1)+1:end)))';
+else
+    a2_grid_T=1:N_a2;
+end
 
 % Remember whether we want to return [N_a*N_z,1] or [N_a,N_z]
 StationaryDist_jj_size=size(StationaryDist_jj);
@@ -82,7 +86,7 @@ for z_c=1:N_z
                     res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
                 end
                 new_vals=round(new_vals,epsilon_round)';
-                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>1e-5 || all(abs(new_vals-vals)<1e-6) || any(new_vals<0)
+                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>epsilon || all(abs(new_vals-vals)<epsilon) || any(new_vals<0)
                     % zero_candidate(cidx)=0;
                 else
                     vals=new_vals;
@@ -114,7 +118,7 @@ for z_c=1:N_z
                     res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
                 end
                 new_vals=round(new_vals,epsilon_round)';
-                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>1e-5 || all(abs(new_vals-vals(nonzeros))<1e-6) || any(new_vals<0)
+                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>epsilon || all(abs(new_vals-vals(nonzeros))<epsilon) || any(new_vals<0)
                     zero_candidate(cidx)=0;
                     break
                 end
@@ -143,7 +147,7 @@ for z_c=1:N_z
                     res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
                 end
                 new_vals=round(new_vals,epsilon_round)';
-                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>1e-5 || all(abs(new_vals-vals(nonzeros))<1e-6) || any(new_vals<0)
+                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>epsilon || all(abs(new_vals-vals(nonzeros))<epsilon) || any(new_vals<0)
                     break
                 end
                 vals(nonzeros)=new_vals;

--- a/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/FHorz/nProbs/StationaryDist_FHorz_Optimize_nProbs_raw.m
@@ -1,16 +1,17 @@
-function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, N_a1_input,N_a2_input,N_z_input,jj, epsilon,total_zeros_created,jj_at_max_a2, simoptions)
+function [StationaryDist_jj,total_zeros_created,jj_at_max_a2]=StationaryDist_FHorz_Optimize_nProbs_raw(StationaryDist_jj, n_a1,n_a2,N_z_input,jj, epsilon,total_zeros_created,jj_at_max_a2, simoptions)
 
 epsilon_round=7;
 
 % For grid interpolation, N_a2 arrives as zero.  We simplify the implementation
 % by treating this N_a1x1 grid as an 1xN_a1 grid (with N_a1 spelled N_a2 below).
-if N_a2_input==0
-    N_a2=N_a1_input;
+if n_a2==0
     N_a1=1;
+    n_a2=n_a1;
 else
-    N_a1=N_a1_input;
-    N_a2=N_a2_input;
+    N_a1=prod(n_a1);
 end
+N_a2=prod(n_a2);
+a2_grid_T=gather(double(simoptions.a_grid(sum(n_a1)+1:end)))';
 
 % Remember whether we want to return [N_a*N_z,1] or [N_a,N_z]
 StationaryDist_jj_size=size(StationaryDist_jj);
@@ -30,7 +31,7 @@ new_zeros_created=zeros(1,N_z);
 % For large N_z, this loop can be changed to `parfor` for greater CPU parallelism
 for z_c=1:N_z
     % When N_z=1, the index z_c is only every 1, which does nothing
-    StationaryDist_row_jj=reshape(StationaryDist_jj(:,z_c),[N_a1,N_a2]);
+    StationaryDist_row_jj=round(reshape(StationaryDist_jj(:,z_c),[N_a1,N_a2]),epsilon_round);
 
     row_prob_sum=full(sum(StationaryDist_row_jj,'all'));
     if row_prob_sum==0 || all(arrayfun(@(r) nnz(StationaryDist_row_jj(r,:)), 1:size(StationaryDist_row_jj,1))<3)
@@ -44,81 +45,80 @@ for z_c=1:N_z
 
         % Find and join up runs that are reasonably close together
         [~,ea_all_idx,all_vals_jj]=find(StationaryDist_row_jj(row,:));
-        p=find(diff(ea_all_idx)>2); % p columns are start and end of mostly consecutive elements
+        p=find(diff(ea_all_idx)>3); % p columns are start and end of mostly consecutive elements
         runs=[ea_all_idx(1),ea_all_idx(p+1);ea_all_idx(p),ea_all_idx(end)];
 
-        if size(runs,2)>1
-            ea_1=1;
-            for ridx=1:size(runs,2)
-                if runs(2,ridx)-runs(1,ridx)<2
-                    % Remove traces of any short sequences
-                    temp=ea_all_idx<runs(1,ridx) | ea_all_idx>runs(2,ridx);
-                    ea_all_idx=ea_all_idx(temp);
-                    all_vals_jj=all_vals_jj(temp);
-                    % ea_1 doesn't move
-                    continue
-                end
-                % Fill in zeros for everything we track
-                valid_ridx=ea_all_idx>=runs(1,ridx) & ea_all_idx<=runs(2,ridx);
-                if sum(valid_ridx)==runs(2,ridx)-runs(1,ridx)+1
-                    % We have a full run with no gaps to fill
-                    ea_1=ea_1+runs(2,ridx)-runs(1,ridx)+1;
-                    continue
-                end
-                ea_end_plus1=ea_1+length(all_vals_jj(valid_ridx));
-                new_idx=runs(1,ridx):runs(2,ridx);
-                new_ridx=ismember(new_idx, ea_all_idx(valid_ridx));
-                new_vals=zeros(1,length(new_idx));
-                new_vals(new_ridx)=all_vals_jj(valid_ridx);
-                all_vals_jj=[all_vals_jj(1:ea_1-1), new_vals, all_vals_jj(ea_end_plus1:end)];
-                ea_all_idx=[ea_all_idx(1:ea_1-1), new_idx, ea_all_idx(ea_end_plus1:end)];
-                ea_1=ea_1+length(new_idx);
-            end
-            % Remove runs ignored above (but used to cut down idx and vals)
-            runs=runs(:,runs(2,:)-runs(1,:)>1);
-            if isempty(runs)
-                % We have disqualified all merging opportunities
+        for ridx=1:size(runs,2)
+            if runs(2,ridx)-runs(1,ridx)<2
+                % Don't bother with short runs
                 continue
             end
-        end
-
-        [ea_all_idx,sort_idx]=sort(ea_all_idx);
-        all_vals_jj=all_vals_jj(sort_idx);
-        ea_gaps=find(diff(ea_all_idx)>1);
-
-        group_idx=[0,ea_gaps,length(ea_all_idx)];
-        for ll=1:length(group_idx)-1
-            vals=all_vals_jj(group_idx(ll)+1:group_idx(ll+1));
-            if length(vals)<3
-                continue
-            end
-            all_idx=ea_all_idx(group_idx(ll)+1:group_idx(ll+1));
+            this_run=runs(1,ridx):runs(2,ridx);
+            vals=zeros(1,length(this_run));
+            ea_this_run=ea_all_idx(ismember(ea_all_idx,this_run))-this_run(1)+1;
+            vals(ea_this_run)=all_vals_jj(ismember(ea_all_idx,this_run));
             run_prob_sum=sum(vals);
-
-            multiplier=all_idx-all_idx(1)+1;
-            assert(allunique(multiplier));
 
             % Attempt to consolidate min and max values to the middle
             % Don't take credit for zeros we created to make runs longer
             starting_zeros=sum(vals==0);
 
             zero_created=false;
-            cidx=length(vals);
+            cidx=length(this_run);
             zero_candidate=zeros(1,cidx);
             nonzeros=true(1,cidx);
+
+            if cidx>3
+                % Just once, try to zero out both max and min in one shot
+                if any(a2_grid_T(this_run)==0)
+                    SystemOfEquations=[this_run;ones(1,cidx);[1,zeros(1,cidx-1)];[zeros(1,cidx-1),1]];
+                    GoalValues=[sum(vals.*this_run); run_prob_sum; 0; 0];
+                    new_vals=linsolve(SystemOfEquations,GoalValues);
+                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                else
+                    SystemOfEquations=[a2_grid_T(this_run);ones(1,cidx);[1,zeros(1,cidx-1)];[zeros(1,cidx-1),1]];
+                    GoalValues=[sum(vals.*a2_grid_T(this_run)); run_prob_sum; 0; 0];
+                    new_vals=linsolve(SystemOfEquations,GoalValues);
+                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                end
+                new_vals=round(new_vals,epsilon_round)';
+                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>1e-5 || all(abs(new_vals-vals)<1e-6) || any(new_vals<0)
+                    % zero_candidate(cidx)=0;
+                else
+                    vals=new_vals;
+                    if cidx<5
+                        % Early out if we collapsed 4 values into 2
+                        temp=sparse(row,this_run,vals,N_a1,N_a2);
+                        StationaryDist_row_jj(row,this_run)=temp(row,this_run);
+                        new_zeros_created(z_c)=new_zeros_created(z_c)+sum(vals==0)-starting_zeros;
+                        continue
+                    end
+                    zero_created=true;
+                    nonzeros(1)=false; nonzeros(cidx)=false;
+                    zero_candidate(1)=1; zero_candidate(cidx)=1;
+                    cidx=cidx-1;
+                end
+            end
             zero_candidate(cidx)=1;
             while nnz(vals)>1
-                % Aggressively try to zero out largest indices
-                SystemOfEquations=[multiplier(nonzeros);ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
-                GoalValues=[sum(vals(nonzeros).*multiplier(nonzeros)); run_prob_sum; 0];
-                new_vals=linsolve(SystemOfEquations,GoalValues);
-                res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                % Try to zero out largest indices, perhaps squeezing zero from middle
+                if any(a2_grid_T(this_run(nonzeros))==0)
+                    SystemOfEquations=[this_run(nonzeros);ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
+                    GoalValues=[sum(vals(nonzeros).*this_run(nonzeros)); run_prob_sum; 0];
+                    new_vals=linsolve(SystemOfEquations,GoalValues);
+                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                else
+                    SystemOfEquations=[a2_grid_T(this_run(nonzeros));ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
+                    GoalValues=[sum(vals(nonzeros).*a2_grid_T(this_run(nonzeros))); run_prob_sum; 0];
+                    new_vals=linsolve(SystemOfEquations,GoalValues);
+                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                end
                 new_vals=round(new_vals,epsilon_round)';
-                if res_vec_mag/norm(new_vals)>1e-5 || all(new_vals==vals(nonzeros)) || any(new_vals<0)
+                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>1e-5 || all(abs(new_vals-vals(nonzeros))<1e-6) || any(new_vals<0)
                     zero_candidate(cidx)=0;
                     break
                 end
-                vals=paddata(new_vals,length(vals));
+                vals(nonzeros)=new_vals;
                 nonzeros(cidx)=false;
                 zero_created=true;
                 cidx=cidx-1;
@@ -127,26 +127,32 @@ for z_c=1:N_z
             if zero_created
                 zero_candidate(cidx)=0;
             end
-            cidx=1;
+            cidx=find(zero_candidate==0,1,'first');
             zero_candidate(cidx)=1;
             while nnz(vals)>1
-                % Try to zero out least index
-                SystemOfEquations=[multiplier(nonzeros);ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
-                GoalValues=[sum(vals(nonzeros).*multiplier(nonzeros)); run_prob_sum; 0];
-                new_vals=linsolve(SystemOfEquations,GoalValues);
-                res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                % Try to zero out least index, perhaps squeezing zero from middle
+                if any(a2_grid_T(this_run(nonzeros))==0)
+                    SystemOfEquations=[this_run(nonzeros);ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
+                    GoalValues=[sum(vals(nonzeros).*this_run(nonzeros)); run_prob_sum; 0];
+                    new_vals=linsolve(SystemOfEquations,GoalValues);
+                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                else
+                    SystemOfEquations=[a2_grid_T(this_run(nonzeros));ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
+                    GoalValues=[sum(vals(nonzeros).*a2_grid_T(this_run(nonzeros))); run_prob_sum; 0];
+                    new_vals=linsolve(SystemOfEquations,GoalValues);
+                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                end
                 new_vals=round(new_vals,epsilon_round)';
-                if res_vec_mag/norm(new_vals)>1e-5 || all(new_vals==vals(nonzeros)) || any(new_vals<0)
+                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>1e-5 || all(abs(new_vals-vals(nonzeros))<1e-6) || any(new_vals<0)
                     break
                 end
-                vals=paddata([zeros(1,cidx-1), new_vals],length(vals));
+                vals(nonzeros)=new_vals;
                 nonzeros(cidx)=false;
                 cidx=cidx+1;
                 zero_candidate(cidx)=1;
             end
-            temp=sparse(row,all_idx,vals,N_a1,N_a2);
-            temp_cols=all_idx(1):all_idx(end);
-            StationaryDist_row_jj(row,temp_cols)=temp(row,temp_cols);
+            temp=sparse(row,this_run,vals,N_a1,N_a2);
+            StationaryDist_row_jj(row,this_run)=temp(row,this_run);
             new_zeros_created(z_c)=new_zeros_created(z_c)+sum(vals==0)-starting_zeros;
         end
     end
@@ -160,7 +166,7 @@ end
 
 sum_new_zeros=sum(new_zeros_created);
 total_zeros_created=total_zeros_created+sum_new_zeros;
-if simoptions.verbose>=1
+if simoptions.verbose==2
     if sum_new_zeros || simoptions.verbose==2
         fprintf("Age %3d: zeros created = %d \n", jj, sum_new_zeros);
     end

--- a/StationaryDist/InfHorz/ExpAsset/StationaryDist_InfHorz_ExpAsset.m
+++ b/StationaryDist/InfHorz/ExpAsset/StationaryDist_InfHorz_ExpAsset.m
@@ -101,9 +101,9 @@ end
 %%
 % Note: N_z=0 is a different code
 if N_e>0
-    StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_e_raw(StationaryDistKron,Policy_aprime,PolicyProbs,2,N_a,N_z,N_e,pi_z,pi_e,simoptions); % zero is n_d, because we already converted Policy to only contain aprime
+    StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_e_raw(StationaryDistKron,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,N_e,pi_z,pi_e,simoptions); % zero is n_d, because we already converted Policy to only contain aprime
 else % no e
-    StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_raw(StationaryDistKron,Policy_aprime,PolicyProbs,2,N_a,N_z,pi_z,simoptions); % zero is n_d, because we already converted Policy to only contain aprime
+    StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_raw(StationaryDistKron,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,pi_z,simoptions); % zero is n_d, because we already converted Policy to only contain aprime
 end
 
 if simoptions.parallel==2

--- a/StationaryDist/InfHorz/GridInterpLayer/StationaryDist_InfHorz_GI_e_raw.m
+++ b/StationaryDist/InfHorz/GridInterpLayer/StationaryDist_InfHorz_GI_e_raw.m
@@ -36,6 +36,6 @@ L2index(L2flag==3)=simoptions.ngridinterp+2; % force all weight to upper grid po
 PolicyProbs(:,:,2)=shiftdim((L2index-1)/(simoptions.ngridinterp+1),1); % probability of upper grid point
 PolicyProbs(:,:,1)=1-PolicyProbs(:,:,2); % probability of lower grid point
 
-StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_e_raw(StationaryDist,Policy_aprime,PolicyProbs,2,N_a,N_z,N_e,pi_z,pi_e,simoptions);
+StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_e_raw(StationaryDist,Policy_aprime,PolicyProbs,2,n_a,0,N_z,N_e,pi_z,pi_e,simoptions);
 
 end

--- a/StationaryDist/InfHorz/GridInterpLayer/StationaryDist_InfHorz_GI_noz_e_raw.m
+++ b/StationaryDist/InfHorz/GridInterpLayer/StationaryDist_InfHorz_GI_noz_e_raw.m
@@ -36,6 +36,6 @@ L2index(L2flag==3)=simoptions.ngridinterp+2; % force all weight to upper grid po
 PolicyProbs(:,:,2)=shiftdim((L2index-1)/(simoptions.ngridinterp+1),1); % probability of upper grid point
 PolicyProbs(:,:,1)=1-PolicyProbs(:,:,2); % probability of lower grid point
 
-StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_noz_e_raw(StationaryDist,Policy_aprime,PolicyProbs,2,N_a,N_e,pi_e,simoptions);
+StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_noz_e_raw(StationaryDist,Policy_aprime,PolicyProbs,2,n_a,0,N_e,pi_e,simoptions);
 
 end

--- a/StationaryDist/InfHorz/GridInterpLayer/StationaryDist_InfHorz_GI_noz_raw.m
+++ b/StationaryDist/InfHorz/GridInterpLayer/StationaryDist_InfHorz_GI_noz_raw.m
@@ -36,6 +36,6 @@ L2index(L2flag==3)=simoptions.ngridinterp+2; % force all weight to upper grid po
 PolicyProbs(:,2)=shiftdim((L2index-1)/(simoptions.ngridinterp+1),1); % probability of upper grid point
 PolicyProbs(:,1)=1-PolicyProbs(:,2); % probability of lower grid point
 
-StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_noz_raw(StationaryDist,Policy_aprime,PolicyProbs,2,N_a,simoptions);
+StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_noz_raw(StationaryDist,Policy_aprime,PolicyProbs,2,n_a,0,simoptions);
 
 end

--- a/StationaryDist/InfHorz/GridInterpLayer/StationaryDist_InfHorz_GI_raw.m
+++ b/StationaryDist/InfHorz/GridInterpLayer/StationaryDist_InfHorz_GI_raw.m
@@ -36,6 +36,6 @@ L2index(L2flag==3)=simoptions.ngridinterp+2; % force all weight to upper grid po
 PolicyProbs(:,:,2)=shiftdim((L2index-1)/(simoptions.ngridinterp+1),1); % probability of upper grid point
 PolicyProbs(:,:,1)=1-PolicyProbs(:,:,2); % probability of lower grid point
 
-StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_raw(StationaryDist,Policy_aprime,PolicyProbs,2,N_a,N_z,pi_z,simoptions);
+StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_raw(StationaryDist,Policy_aprime,PolicyProbs,2,n_a,0,N_z,pi_z,simoptions);
 
 end

--- a/StationaryDist/InfHorz/InheritAsset/StationaryDist_InfHorz_InheritAsset.m
+++ b/StationaryDist/InfHorz/InheritAsset/StationaryDist_InfHorz_InheritAsset.m
@@ -89,7 +89,7 @@ end
 
 %%
 % Policy depends on zprime
-StationaryDist=StationaryDist_InfHorz_Iteration_zprime_nProbs_raw(StationaryDistKron,Policy_aprime,PolicyProbs,2,N_a,N_z,pi_z,simoptions); % zero is n_d, because we already converted Policy to only contain aprime
+StationaryDist=StationaryDist_InfHorz_Iteration_zprime_nProbs_raw(StationaryDistKron,Policy_aprime,PolicyProbs,2,n_a1,n_a2,N_z,pi_z,simoptions); % zero is n_d, because we already converted Policy to only contain aprime
 
 StationaryDist=gpuArray(StationaryDist); % move output to gpu
 

--- a/StationaryDist/InfHorz/nProbs/StationaryDist_InfHorz_Iteration_nProbs_raw.m
+++ b/StationaryDist/InfHorz/nProbs/StationaryDist_InfHorz_Iteration_nProbs_raw.m
@@ -1,7 +1,23 @@
-function StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_raw(StationaryDist,Policy_aprime,PolicyProbs,N_probs,N_a,N_z,pi_z,simoptions)
+function StationaryDist=StationaryDist_InfHorz_Iteration_nProbs_raw(StationaryDist,Policy_aprime,PolicyProbs,N_probs,n_a1,n_a2,N_z,pi_z,simoptions)
 % 'nProbs' refers to N_probs probabilities.
 % Policy_aprime has an additional dimension of length N_probs which is the N_probs points (and contains only the aprime indexes, no d indexes as would usually be the case).
 % PolicyProbs are the corresponding probabilities of each of these N_probs.
+
+epsilon=1e-7;
+total_zeros_created=0;
+counter_at_max_a2=Inf;
+
+% For grid interpolation, N_a2 arrives as zero.  We simplify the implementation
+% by treating this N_a1x1 grid as an 1xN_a1 grid (with N_a1 spelled N_a2 below).
+N_a1=prod(n_a1);
+N_a2=prod(n_a2);
+if N_a2==0
+    N_a=N_a1;
+elseif N_a1==0
+    N_a=N_a2;
+else
+    N_a=N_a1*N_a2;
+end
 
 % Policy_aprime and PolicyProbs are currently [N_a,N_z,N_probs]
 Policy_aprimez=Policy_aprime+N_a*gpuArray(0:1:N_z-1);  % Note: add z' index following the z dimension [Tan improvement, z stays where it is]
@@ -31,6 +47,10 @@ while currdist>simoptions.tolerance && counter<simoptions.maxit
     % Second step of Tan improvement
     StationaryDist=reshape(StationaryDist*pi_z,[N_a*N_z,1]);
 
+    if simoptions.optimize_nProbs==1
+        [StationaryDist,total_zeros_created,counter_at_max_a2]=StationaryDist_InfHorz_Optimize_nProbs_raw(StationaryDist,n_a1,n_a2,N_z, counter,epsilon,total_zeros_created,counter_at_max_a2,simoptions);
+    end
+
     if rem(counter,simoptions.multiiter)==0
         StationaryDistOld=StationaryDist;
     elseif rem(counter,simoptions.multiiter)==10
@@ -49,5 +69,42 @@ end
 
 % Convert back to full matrix for output
 StationaryDist=gpuArray(full(StationaryDist));
+
+
+if isfinite(counter_at_max_a2)
+    if N_a2>0
+        warning("Max ExpAsset index %3d first reached at counter %3d \n", N_a2, counter_at_max_a2);
+    else
+        warning("Max grid-interpolated asset index %3d first reached at counter %3d \n", N_a1, counter_at_max_a2);
+    end
+end
+
+if simoptions.verbose
+    if total_zeros_created>0
+        fprintf("With epsilon = %.2e, total zeros created = %d \n", epsilon, total_zeros_created);
+        if ~isfinite(counter_at_max_a2)
+            max_a=nan;
+            if N_a2==0
+                temp=reshape(StationaryDist,[N_a1,N_z]);
+                [a1,~]=ind2sub(size(temp),find(temp~=0));
+                max_a=max(a1);
+            else
+                if N_a1>0
+                    temp=reshape(full(StationaryDist),[N_a1,N_a2,N_z]);
+                    [~,a2,~]=ind2sub(size(temp),find(temp~=0));
+                else
+                    temp=reshape(StationaryDist,[1,N_a2,N_z]);
+                    [~,a2,~]=ind2sub(size(temp),find(temp~=0));
+                end
+                max_a=max(a2);
+            end
+            if N_a2>0
+                fprintf("Max InfHorz ExpAsset index reached: %3d (of %3d); counter %d \n", max_a, N_a2, counter);
+            else
+                fprintf("Max InfHorz grid-interpolated asset index reached: %3d (of %3d); counter %3d \n", max_a, N_a1, counter);
+            end
+        end
+    end
+end
 
 end

--- a/StationaryDist/InfHorz/nProbs/StationaryDist_InfHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/InfHorz/nProbs/StationaryDist_InfHorz_Optimize_nProbs_raw.m
@@ -1,0 +1,183 @@
+function [StationaryDist,total_zeros_created,counter_at_max_a2]=StationaryDist_InfHorz_Optimize_nProbs_raw(StationaryDist, n_a1,n_a2,N_z_input, counter,epsilon,total_zeros_created,counter_at_max_a2, simoptions)
+
+epsilon_round=10;
+
+% For grid interpolation, N_a2 arrives as zero.  We simplify the implementation
+% by treating this N_a1x1 grid as an 1xN_a1 grid (with N_a1 spelled N_a2 below).
+if n_a2==0
+    N_a1=1;
+    n_a2=n_a1;
+else
+    N_a1=max(prod(n_a1),1);
+end
+N_a2=prod(n_a2);
+if isfield(simoptions, 'a_grid')
+    a2_grid_T=gather(double(simoptions.a_grid(sum(n_a1)+1:end)))';
+else
+    a2_grid_T=1:N_a2;
+end
+
+% Remember whether we want to return [N_a*N_z,1] or [N_a,N_z]
+StationaryDist_size=size(StationaryDist);
+
+if N_z_input==0
+    N_z=1;
+else
+    N_z=N_z_input;
+    if StationaryDist_size(2)==1 && N_z>1
+        % For our purposes, we need to unmix N_z from N_a
+        StationaryDist=reshape(StationaryDist,[N_a1*N_a2,N_z]);
+    end
+end
+
+new_zeros_created=zeros(1,N_z);
+
+% For large N_z, this loop can be changed to `parfor` for greater CPU parallelism
+for z_c=1:N_z
+    % When N_z=1, the index z_c is only every 1, which does nothing
+    StationaryDist_row=round(reshape(StationaryDist(:,z_c),[N_a1,N_a2]),epsilon_round);
+
+    row_prob_sum=full(sum(StationaryDist_row,'all'));
+    if row_prob_sum==0 || all(arrayfun(@(r) nnz(StationaryDist_row(r,:)), 1:size(StationaryDist_row,1))<3)
+        % Sometimes nobody chooses the path less taken
+        continue
+    end
+
+    [rows,~]=find(StationaryDist_row~=0);
+    for row=unique(rows')
+        % Process agents' ExpAssets row by row (i.e., each N_a1 asset mixture)
+
+        % Find and join up runs that are reasonably close together
+        [~,ea_all_idx,all_vals]=find(StationaryDist_row(row,:));
+        p=find(diff(ea_all_idx)>3); % p columns are start and end of mostly consecutive elements
+        runs=[ea_all_idx(1),ea_all_idx(p+1);ea_all_idx(p),ea_all_idx(end)];
+
+        for ridx=1:size(runs,2)
+            if runs(2,ridx)-runs(1,ridx)<2
+                % Don't bother with short runs
+                continue
+            end
+            this_run=runs(1,ridx):runs(2,ridx);
+            vals=zeros(1,length(this_run));
+            ea_this_run=ea_all_idx(ismember(ea_all_idx,this_run))-this_run(1)+1;
+            vals(ea_this_run)=all_vals(ismember(ea_all_idx,this_run));
+            run_prob_sum=sum(vals);
+
+            % Attempt to consolidate min and max values to the middle
+            % Don't take credit for zeros we created to make runs longer
+            starting_zeros=sum(vals==0);
+
+            zero_created=false;
+            cidx=length(this_run);
+            zero_candidate=zeros(1,cidx);
+            nonzeros=true(1,cidx);
+
+            if cidx>3
+                % Just once, try to zero out both max and min in one shot
+                if any(a2_grid_T(this_run)==0)
+                    SystemOfEquations=[this_run;ones(1,cidx);[1,zeros(1,cidx-1)];[zeros(1,cidx-1),1]];
+                    GoalValues=[sum(vals.*this_run); run_prob_sum; 0; 0];
+                    new_vals=linsolve(SystemOfEquations,GoalValues);
+                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                else
+                    SystemOfEquations=[a2_grid_T(this_run);ones(1,cidx);[1,zeros(1,cidx-1)];[zeros(1,cidx-1),1]];
+                    GoalValues=[sum(vals.*a2_grid_T(this_run)); run_prob_sum; 0; 0];
+                    new_vals=linsolve(SystemOfEquations,GoalValues);
+                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                end
+                new_vals=round(new_vals,epsilon_round)';
+                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>epsilon || all(abs(new_vals-vals)<epsilon) || any(new_vals<0)
+                    % zero_candidate(cidx)=0;
+                else
+                    vals=new_vals;
+                    if cidx<5
+                        % Early out if we collapsed 4 values into 2
+                        temp=sparse(row,this_run,vals,N_a1,N_a2);
+                        StationaryDist_row(row,this_run)=temp(row,this_run);
+                        new_zeros_created(z_c)=new_zeros_created(z_c)+sum(vals==0)-starting_zeros;
+                        continue
+                    end
+                    zero_created=true;
+                    nonzeros(1)=false; nonzeros(cidx)=false;
+                    zero_candidate(1)=1; zero_candidate(cidx)=1;
+                    cidx=cidx-1;
+                end
+            end
+            zero_candidate(cidx)=1;
+            while nnz(vals)>1
+                % Try to zero out largest indices, perhaps squeezing zero from middle
+                if any(a2_grid_T(this_run(nonzeros))==0)
+                    SystemOfEquations=[this_run(nonzeros);ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
+                    GoalValues=[sum(vals(nonzeros).*this_run(nonzeros)); run_prob_sum; 0];
+                    new_vals=linsolve(SystemOfEquations,GoalValues);
+                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                else
+                    SystemOfEquations=[a2_grid_T(this_run(nonzeros));ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
+                    GoalValues=[sum(vals(nonzeros).*a2_grid_T(this_run(nonzeros))); run_prob_sum; 0];
+                    new_vals=linsolve(SystemOfEquations,GoalValues);
+                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                end
+                new_vals=round(new_vals,epsilon_round)';
+                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>epsilon || all(abs(new_vals-vals(nonzeros))<epsilon) || any(new_vals<0)
+                    zero_candidate(cidx)=0;
+                    break
+                end
+                vals(nonzeros)=new_vals;
+                nonzeros(cidx)=false;
+                zero_created=true;
+                cidx=cidx-1;
+                zero_candidate(cidx)=1;
+            end
+            if zero_created
+                zero_candidate(cidx)=0;
+            end
+            cidx=find(zero_candidate==0,1,'first');
+            zero_candidate(cidx)=1;
+            while nnz(vals)>1
+                % Try to zero out least index, perhaps squeezing zero from middle
+                if any(a2_grid_T(this_run(nonzeros))==0)
+                    SystemOfEquations=[this_run(nonzeros);ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
+                    GoalValues=[sum(vals(nonzeros).*this_run(nonzeros)); run_prob_sum; 0];
+                    new_vals=linsolve(SystemOfEquations,GoalValues);
+                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                else
+                    SystemOfEquations=[a2_grid_T(this_run(nonzeros));ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
+                    GoalValues=[sum(vals(nonzeros).*a2_grid_T(this_run(nonzeros))); run_prob_sum; 0];
+                    new_vals=linsolve(SystemOfEquations,GoalValues);
+                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+                end
+                new_vals=round(new_vals,epsilon_round)';
+                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>epsilon || all(abs(new_vals-vals(nonzeros))<epsilon) || any(new_vals<0)
+                    break
+                end
+                vals(nonzeros)=new_vals;
+                nonzeros(cidx)=false;
+                cidx=cidx+1;
+                zero_candidate(cidx)=1;
+            end
+            temp=sparse(row,this_run,vals,N_a1,N_a2);
+            StationaryDist_row(row,this_run)=temp(row,this_run);
+            new_zeros_created(z_c)=new_zeros_created(z_c)+sum(vals==0)-starting_zeros;
+        end
+    end
+    StationaryDist(:,z_c)=reshape(StationaryDist_row,[N_a1*N_a2,1]);
+end
+
+temp=reshape(full(StationaryDist),[N_a1,N_a2,N_z]);
+if ~isfinite(counter_at_max_a2) && any(temp(:,N_a2,:)~=0,'all')
+    counter_at_max_a2=counter;
+end
+
+sum_new_zeros=sum(new_zeros_created);
+total_zeros_created=total_zeros_created+sum_new_zeros;
+if simoptions.verbose==2
+    if sum_new_zeros || simoptions.verbose==2
+        fprintf("Counter %3d: zeros created = %d \n", counter, sum_new_zeros);
+    end
+end
+
+% Re-mix N_a and N_z if necessary
+StationaryDist=reshape(StationaryDist,StationaryDist_size);
+
+
+end

--- a/StationaryDist/InfHorz/nProbs/StationaryDist_InfHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/InfHorz/nProbs/StationaryDist_InfHorz_Optimize_nProbs_raw.m
@@ -66,98 +66,48 @@ for z_c=1:N_z
             % Attempt to consolidate min and max values to the middle
             % Don't take credit for zeros we created to make runs longer
             starting_zeros=sum(vals==0);
-
-            zero_created=false;
             cidx=length(this_run);
-            zero_candidate=zeros(1,cidx);
-            nonzeros=true(1,cidx);
 
-            if cidx>3
-                % Just once, try to zero out both max and min in one shot
-                if any(a2_grid_T(this_run)==0)
-                    SystemOfEquations=[this_run;ones(1,cidx);[1,zeros(1,cidx-1)];[zeros(1,cidx-1),1]];
-                    GoalValues=[sum(vals.*this_run); run_prob_sum; 0; 0];
-                    new_vals=linsolve(SystemOfEquations,GoalValues);
-                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
-                else
-                    SystemOfEquations=[a2_grid_T(this_run);ones(1,cidx);[1,zeros(1,cidx-1)];[zeros(1,cidx-1),1]];
-                    GoalValues=[sum(vals.*a2_grid_T(this_run)); run_prob_sum; 0; 0];
-                    new_vals=linsolve(SystemOfEquations,GoalValues);
-                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
-                end
-                new_vals=round(new_vals,epsilon_round)';
-                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>epsilon || all(abs(new_vals-vals)<epsilon) || any(new_vals<0)
-                    % zero_candidate(cidx)=0;
-                else
-                    vals=new_vals;
-                    if cidx<5
-                        % Early out if we collapsed 4 values into 2
-                        temp=sparse(row,this_run,vals,N_a1,N_a2);
-                        StationaryDist_row(row,this_run)=temp(row,this_run);
-                        new_zeros_created(z_c)=new_zeros_created(z_c)+sum(vals==0)-starting_zeros;
-                        continue
-                    end
-                    zero_created=true;
-                    nonzeros(1)=false; nonzeros(cidx)=false;
-                    zero_candidate(1)=1; zero_candidate(cidx)=1;
-                    cidx=cidx-1;
-                end
+            % See if we can collapse this system down to two or three basis elements
+            % gridvals and the sums are indexed into `this_run`, not values of `this_run`
+            gridvals=vals.*a2_grid_T(this_run);
+            lower_sums=cumsum(gridvals,'forward');
+            lower_sums=[vals(1)*(a2_grid_T(this_run(1))~=0),lower_sums(2:end)./a2_grid_T(this_run(2:end))];
+            lower_sums(isinf(lower_sums))=lower_sums(circshift(isinf(lower_sums),-1));
+            upper_sums=cumsum(gridvals,'reverse');
+            upper_sums=[upper_sums(1:end-1)./a2_grid_T(this_run(1:end-1)),vals(end)*(a2_grid_T(this_run(end))~=0)];
+            upper_sums(isinf(upper_sums))=upper_sums(circshift(isinf(upper_sums),1)); % grids should have only a single zero value
+            % Where lower_sums(1:end-1)+upper_sums(2:end)<=run_prob_sum we have room to redistribute probabilities
+            valid_crossover=run_prob_sum-(lower_sums(1:end-1)+upper_sums(2:end))>=0;
+            lower_idx=find(valid_crossover,1,'first');
+            if isempty(lower_idx)
+                % Maybe we need a span of 3...it happens
+                valid_crossover=run_prob_sum-(lower_sums(1:end-2)+upper_sums(3:end))>=0;
+                lower_idx=find(valid_crossover,1,'first');
+                assert(~isempty(lower_idx));
+                upper_idx=lower_idx+2;
+            else
+                upper_idx=lower_idx+1;
             end
-            zero_candidate(cidx)=1;
-            while nnz(vals)>1
-                % Try to zero out largest indices, perhaps squeezing zero from middle
-                if any(a2_grid_T(this_run(nonzeros))==0)
-                    SystemOfEquations=[this_run(nonzeros);ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
-                    GoalValues=[sum(vals(nonzeros).*this_run(nonzeros)); run_prob_sum; 0];
-                    new_vals=linsolve(SystemOfEquations,GoalValues);
-                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
-                else
-                    SystemOfEquations=[a2_grid_T(this_run(nonzeros));ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
-                    GoalValues=[sum(vals(nonzeros).*a2_grid_T(this_run(nonzeros))); run_prob_sum; 0];
-                    new_vals=linsolve(SystemOfEquations,GoalValues);
-                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
-                end
-                new_vals=round(new_vals,epsilon_round)';
-                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>epsilon || all(abs(new_vals-vals(nonzeros))<epsilon) || any(new_vals<0)
-                    zero_candidate(cidx)=0;
-                    break
-                end
-                vals(nonzeros)=new_vals;
-                nonzeros(cidx)=false;
-                zero_created=true;
-                cidx=cidx-1;
-                zero_candidate(cidx)=1;
+            SystemOfEquations=[a2_grid_T(this_run(lower_idx:upper_idx));ones(1,upper_idx-lower_idx+1)];
+            GoalValues=[sum(gridvals); run_prob_sum];
+            new_vals=linsolve(SystemOfEquations,GoalValues);
+            if any(new_vals<0)
+                % Maybe we need a span of 3...it happens
+                lower_idx=lower_idx-(new_vals(2)<0);
+                upper_idx=upper_idx+(new_vals(1)<0);
+                SystemOfEquations=[a2_grid_T(this_run(lower_idx:upper_idx));ones(1,upper_idx-lower_idx+1)];
+                new_vals=linsolve(SystemOfEquations,GoalValues);
+                assert(all(new_vals>=0));
             end
-            if zero_created
-                zero_candidate(cidx)=0;
+            res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
+            new_vals=round(new_vals,epsilon_round)';
+            if res_vec_mag==0 || (~isnan(res_vec_mag) && res_vec_mag/norm(new_vals)<=epsilon)
+                % Put this valid redistribution into the Stationary Dist, finishing this run
+                temp=sparse(row,this_run(lower_idx:upper_idx),new_vals,N_a1,N_a2);
+                StationaryDist_row(row,this_run)=temp(row,this_run);
+                new_zeros_created(z_c)=new_zeros_created(z_c)+cidx-2-starting_zeros;
             end
-            cidx=find(zero_candidate==0,1,'first');
-            zero_candidate(cidx)=1;
-            while nnz(vals)>1
-                % Try to zero out least index, perhaps squeezing zero from middle
-                if any(a2_grid_T(this_run(nonzeros))==0)
-                    SystemOfEquations=[this_run(nonzeros);ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
-                    GoalValues=[sum(vals(nonzeros).*this_run(nonzeros)); run_prob_sum; 0];
-                    new_vals=linsolve(SystemOfEquations,GoalValues);
-                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
-                else
-                    SystemOfEquations=[a2_grid_T(this_run(nonzeros));ones(1,nnz(nonzeros));zero_candidate(nonzeros)];
-                    GoalValues=[sum(vals(nonzeros).*a2_grid_T(this_run(nonzeros))); run_prob_sum; 0];
-                    new_vals=linsolve(SystemOfEquations,GoalValues);
-                    res_vec_mag = norm(GoalValues-SystemOfEquations*new_vals);
-                end
-                new_vals=round(new_vals,epsilon_round)';
-                if isnan(res_vec_mag) || res_vec_mag/norm(new_vals)>epsilon || all(abs(new_vals-vals(nonzeros))<epsilon) || any(new_vals<0)
-                    break
-                end
-                vals(nonzeros)=new_vals;
-                nonzeros(cidx)=false;
-                cidx=cidx+1;
-                zero_candidate(cidx)=1;
-            end
-            temp=sparse(row,this_run,vals,N_a1,N_a2);
-            StationaryDist_row(row,this_run)=temp(row,this_run);
-            new_zeros_created(z_c)=new_zeros_created(z_c)+sum(vals==0)-starting_zeros;
         end
     end
     StationaryDist(:,z_c)=reshape(StationaryDist_row,[N_a1*N_a2,1]);

--- a/StationaryDist/InfHorz/nProbs/StationaryDist_InfHorz_Optimize_nProbs_raw.m
+++ b/StationaryDist/InfHorz/nProbs/StationaryDist_InfHorz_Optimize_nProbs_raw.m
@@ -17,6 +17,9 @@ else
     a2_grid_T=1:N_a2;
 end
 
+% Gather so we can round; it will be placed back into gpuArray by caller
+StationaryDist=gather(StationaryDist);
+
 % Remember whether we want to return [N_a*N_z,1] or [N_a,N_z]
 StationaryDist_size=size(StationaryDist);
 

--- a/ValueFnIter/FHorz/DivideConquerGridInterpLayer/ValueFnIter_FHorz_DC1_GI1_noz_e_raw.m
+++ b/ValueFnIter/FHorz/DivideConquerGridInterpLayer/ValueFnIter_FHorz_DC1_GI1_noz_e_raw.m
@@ -68,7 +68,7 @@ if ~isfield(vfoptions,'V_Jplus1')
                 % aprime possibilities are n_d-by-maxgap(ii)+1-by-1-by-n_e
                 ReturnMatrix_ii=CreateReturnFnMatrix_Disc_DC1(ReturnFn, n_d, n_e, d_gridvals, a_grid(aprimeindexes), a_grid(level1ii(ii)+1:level1ii(ii+1)-1), e_gridvals_J(:,:,N_j), ReturnFnParamsVec,3);
                 [~,maxindex]=max(ReturnMatrix_ii,[],2);
-                midpoints_jj(:,1,curraindex,:)=shiftdim(maxindex+(loweredge-1),1);
+                midpoints_jj(:,1,curraindex,:)=shiftdim(maxindex+(loweredge-1),0);
             else
                 loweredge=maxindex1(:,1,ii,:);
                 midpoints_jj(:,1,curraindex,:)=repelem(loweredge,1,1,length(curraindex),1);


### PR DESCRIPTION
These changes implement an optimization of the nProbs calculations.  The recognize when we can fold lower and upper rows that come from the Gammatransform into just one or the other.  And related optimizations that can defer or prevent nProbs from escaping the ExpAsset grid.  This allows for smaller ExpAsset grids, more accurate calculations, or both.

This differs greatly from PR #114, which papered over the problem by merely deleting probabilities that seemed ripe for deletion.  That approach was both bad accounting, and relied too heavily on addressing the problem long after it was fixable.  This approach  can stop probabilities from needlessly occupying state space while preserving the mathematical truth they intend to represent.

I believe this could be a prototype for an "adaptive grid" approach.  Users could allocate regular assets to the nProbs grids and let the optimization do the magic, while permitting all the complicated things one can do with full-fledged assets.  Floating point numbers have far more representational capacity than creating sub-grids of 10 or 100 points, potentially increasing both the accuracy of the results and reducing the curse of dimensionality.